### PR TITLE
If macro

### DIFF
--- a/Functions/IfFunction.cs
+++ b/Functions/IfFunction.cs
@@ -20,57 +20,36 @@
  *
  */
 
-using System;
+using System.Collections.Generic;
+using System.Linq;
 using MetaphysicsIndustries.Solus.Expressions;
+using MetaphysicsIndustries.Solus.Macros;
 
 namespace MetaphysicsIndustries.Solus.Functions
 {
-    public class IfFunction : Function
+    public class IfFunction : Macro
     {
         public static readonly IfFunction Value = new IfFunction();
 
         protected IfFunction()
-            : base("If")
         {
-            Types.Clear();
-            Types.Add(typeof(Expression));
-            Types.Add(typeof(Expression));
-            Types.Add(typeof(Expression));
+            Name = "if";
+            NumArguments = 3;
         }
 
-        public override Literal Call(SolusEnvironment env, params Expression[] args)
+        public override Expression InternalCall(IEnumerable<Expression> args, SolusEnvironment env)
         {
-            CheckArguments(args);
-
-            float value = args[0].Eval(env).Value;
+            var args2 = args.ToArray();
+            float value = args2[0].Eval(env).Value;
 
             if (value == 0 || float.IsNaN(value) || float.IsInfinity(value))
             {
-                return args[2].Eval(env);
+                return args2[2].Eval(env);
             }
             else
             {
-                return args[1].Eval(env);
+                return args2[1].Eval(env);
             }
-        }
-
-        protected override Literal InternalCall(SolusEnvironment env, Literal[] args)
-        {
-            throw new NotSupportedException();
-            //float value = args[0].Value;
-            //if (value == 0 || float.IsNaN(value) || float.IsInfinity(value))
-            //{
-            //    return args[2];
-            //}
-            //else
-            //{
-            //    return args[1];
-            //}
-        }
-
-        public override string DisplayName
-        {
-            get { return "if"; }
         }
     }
 }

--- a/Functions/IfMacro.cs
+++ b/Functions/IfMacro.cs
@@ -27,11 +27,11 @@ using MetaphysicsIndustries.Solus.Macros;
 
 namespace MetaphysicsIndustries.Solus.Functions
 {
-    public class IfFunction : Macro
+    public class IfMacro : Macro
     {
-        public static readonly IfFunction Value = new IfFunction();
+        public static readonly IfMacro Value = new IfMacro();
 
-        protected IfFunction()
+        protected IfMacro()
         {
             Name = "if";
             NumArguments = 3;

--- a/Macros/IfMacro.cs
+++ b/Macros/IfMacro.cs
@@ -23,9 +23,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using MetaphysicsIndustries.Solus.Expressions;
-using MetaphysicsIndustries.Solus.Macros;
 
-namespace MetaphysicsIndustries.Solus.Functions
+namespace MetaphysicsIndustries.Solus.Macros
 {
     public class IfMacro : Macro
     {

--- a/MetaphysicsIndustries.Solus.Test/MacrosT/IfMacroT/IfMacroTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/MacrosT/IfMacroT/IfMacroTest.cs
@@ -1,0 +1,187 @@
+using System;
+using MetaphysicsIndustries.Solus.Expressions;
+using MetaphysicsIndustries.Solus.Macros;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.MacrosT.IfMacroT
+{
+    public class IfMacroTest
+    {
+        [Test]
+        public void HasDefaultValues()
+        {
+            // given
+            var result = IfMacro.Value;
+            // expect
+            Assert.AreEqual("if", result.Name);
+            Assert.AreEqual(3, result.NumArguments);
+            Assert.False(result.HasVariableNumArgs);
+        }
+
+        class MockExpression : Expression
+        {
+            public MockExpression(Func<SolusEnvironment, Literal> evalf)
+            {
+                EvalF = evalf;
+            }
+
+            public Func<SolusEnvironment, Literal> EvalF;
+            public override Literal Eval(SolusEnvironment env)
+            {
+                if (EvalF != null) return EvalF(env);
+                throw new System.NotImplementedException();
+            }
+
+            public override Expression Clone() =>
+                throw new NotImplementedException();
+
+            public override void AcceptVisitor(IExpressionVisitor visitor) =>
+                throw new NotImplementedException();
+        }
+
+        [Test]
+        public void TrueConditionEvaluatesSecondArgButNotThirdArg()
+        {
+            // given
+            bool thenEvaled = false;
+            bool elseEvaled = false;
+            var thenArg = new MockExpression(_ =>
+            {
+                thenEvaled = true;
+                return new Literal(0);
+            });
+            var elseArg = new MockExpression(_ =>
+            {
+                elseEvaled = true;
+                return new Literal(0);
+            });
+            var condition = new Literal(1);
+            var args = new Expression[] {condition, thenArg, elseArg};
+            // when
+            var result = IfMacro.Value.Call(args, null);
+            // then
+            Assert.IsInstanceOf<Literal>(result);
+            var literal = (Literal) result;
+            Assert.AreEqual(0, literal.Value);
+            // and
+            Assert.True(thenEvaled);
+            Assert.False(elseEvaled);
+        }
+
+        [Test]
+        public void FalseConditionEvaluatesThirdArgButNotSecondArg()
+        {
+            // given
+            bool thenEvaled = false;
+            bool elseEvaled = false;
+            var thenArg = new MockExpression(_ =>
+            {
+                thenEvaled = true;
+                return new Literal(0);
+            });
+            var elseArg = new MockExpression(_ =>
+            {
+                elseEvaled = true;
+                return new Literal(0);
+            });
+            var condition = new Literal(0);
+            var args = new Expression[] {condition, thenArg, elseArg};
+            // when
+            var result = IfMacro.Value.Call(args, null);
+            // then
+            Assert.IsInstanceOf<Literal>(result);
+            var literal = (Literal) result;
+            Assert.AreEqual(0, literal.Value);
+            // and
+            Assert.False(thenEvaled);
+            Assert.True(elseEvaled);
+        }
+
+        [Test]
+        public void NanConditionEvaluatesThirdArgButNotSecondArg()
+        {
+            // given
+            bool thenEvaled = false;
+            bool elseEvaled = false;
+            var thenArg = new MockExpression(_ =>
+            {
+                thenEvaled = true;
+                return new Literal(0);
+            });
+            var elseArg = new MockExpression(_ =>
+            {
+                elseEvaled = true;
+                return new Literal(0);
+            });
+            var condition = new Literal(float.NaN);
+            var args = new Expression[] {condition, thenArg, elseArg};
+            // when
+            var result = IfMacro.Value.Call(args, null);
+            // then
+            Assert.IsInstanceOf<Literal>(result);
+            var literal = (Literal) result;
+            Assert.AreEqual(0, literal.Value);
+            // and
+            Assert.False(thenEvaled);
+            Assert.True(elseEvaled);
+        }
+
+        [Test]
+        public void PositiveInfinityConditionEvaluatesThirdArgButNotSecondArg()
+        {
+            // given
+            bool thenEvaled = false;
+            bool elseEvaled = false;
+            var thenArg = new MockExpression(_ =>
+            {
+                thenEvaled = true;
+                return new Literal(0);
+            });
+            var elseArg = new MockExpression(_ =>
+            {
+                elseEvaled = true;
+                return new Literal(0);
+            });
+            var condition = new Literal(float.PositiveInfinity);
+            var args = new Expression[] {condition, thenArg, elseArg};
+            // when
+            var result = IfMacro.Value.Call(args, null);
+            // then
+            Assert.IsInstanceOf<Literal>(result);
+            var literal = (Literal) result;
+            Assert.AreEqual(0, literal.Value);
+            // and
+            Assert.False(thenEvaled);
+            Assert.True(elseEvaled);
+        }
+
+        [Test]
+        public void NegativeInfinityConditionEvaluatesThirdArgButNotSecondArg()
+        {
+            // given
+            bool thenEvaled = false;
+            bool elseEvaled = false;
+            var thenArg = new MockExpression(_ =>
+            {
+                thenEvaled = true;
+                return new Literal(0);
+            });
+            var elseArg = new MockExpression(_ =>
+            {
+                elseEvaled = true;
+                return new Literal(0);
+            });
+            var condition = new Literal(float.NegativeInfinity);
+            var args = new Expression[] {condition, thenArg, elseArg};
+            // when
+            var result = IfMacro.Value.Call(args, null);
+            // then
+            Assert.IsInstanceOf<Literal>(result);
+            var literal = (Literal) result;
+            Assert.AreEqual(0, literal.Value);
+            // and
+            Assert.False(thenEvaled);
+            Assert.True(elseEvaled);
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/MetaphysicsIndustries.Solus.Test.csproj
+++ b/MetaphysicsIndustries.Solus.Test/MetaphysicsIndustries.Solus.Test.csproj
@@ -31,6 +31,7 @@
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
+    <Compile Include="MacrosT\IfMacroT\IfMacroTest.cs" />
     <Compile Include="SolusParserTest.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/MetaphysicsIndustries.Solus.Test/SolusParserTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/SolusParserTest.cs
@@ -421,16 +421,9 @@ namespace MetaphysicsIndustries.Solus.Test
 
             var expr = parser.GetExpression("if(1, 2, 3)", cleanup: false);
 
-            Assert.IsInstanceOf(typeof(FunctionCall), expr);
-            var fcall = (FunctionCall)expr;
-            Assert.IsInstanceOf(typeof(IfMacro), fcall.Function);
-            Assert.AreEqual(3, fcall.Arguments.Count);
-            Assert.IsInstanceOf(typeof(Literal), fcall.Arguments[0]);
-            Assert.IsInstanceOf(typeof(Literal), fcall.Arguments[1]);
-            Assert.IsInstanceOf(typeof(Literal), fcall.Arguments[2]);
-            Assert.AreEqual(1, (fcall.Arguments[0] as Literal).Value);
-            Assert.AreEqual(2, (fcall.Arguments[1] as Literal).Value);
-            Assert.AreEqual(3, (fcall.Arguments[2] as Literal).Value);
+            Assert.IsInstanceOf(typeof(Literal), expr);
+            var literal = (Literal) expr;
+            Assert.AreEqual(2, literal.Value);
         }
 
         public class CustomAsdfFunction : Function

--- a/MetaphysicsIndustries.Solus.Test/SolusParserTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/SolusParserTest.cs
@@ -423,7 +423,7 @@ namespace MetaphysicsIndustries.Solus.Test
 
             Assert.IsInstanceOf(typeof(FunctionCall), expr);
             var fcall = (FunctionCall)expr;
-            Assert.IsInstanceOf(typeof(IfFunction), fcall.Function);
+            Assert.IsInstanceOf(typeof(IfMacro), fcall.Function);
             Assert.AreEqual(3, fcall.Arguments.Count);
             Assert.IsInstanceOf(typeof(Literal), fcall.Arguments[0]);
             Assert.IsInstanceOf(typeof(Literal), fcall.Arguments[1]);

--- a/MetaphysicsIndustries.Solus.csproj
+++ b/MetaphysicsIndustries.Solus.csproj
@@ -97,7 +97,6 @@
     <Compile Include="Functions\Function.cs" />
     <Compile Include="Functions\GreaterThanComparisonOperation.cs" />
     <Compile Include="Functions\GreaterThanOrEqualComparisonOperation.cs" />
-    <Compile Include="Functions\IfMacro.cs" />
     <Compile Include="Functions\LessThanComparisonOperation.cs" />
     <Compile Include="Functions\LessThanOrEqualComparisonOperation.cs" />
     <Compile Include="Functions\Log10Function.cs" />
@@ -126,6 +125,7 @@
     <Compile Include="Macros\DeleteMacro.cs" />
     <Compile Include="Macros\DeriveMacro.cs" />
     <Compile Include="Macros\FeedbackMacro.cs" />
+    <Compile Include="Macros\IfMacro.cs" />
     <Compile Include="Macros\Macro.cs" />
     <Compile Include="Macros\RandMacro.cs" />
     <Compile Include="Macros\SqrtMacro.cs" />

--- a/MetaphysicsIndustries.Solus.csproj
+++ b/MetaphysicsIndustries.Solus.csproj
@@ -97,7 +97,7 @@
     <Compile Include="Functions\Function.cs" />
     <Compile Include="Functions\GreaterThanComparisonOperation.cs" />
     <Compile Include="Functions\GreaterThanOrEqualComparisonOperation.cs" />
-    <Compile Include="Functions\IfFunction.cs" />
+    <Compile Include="Functions\IfMacro.cs" />
     <Compile Include="Functions\LessThanComparisonOperation.cs" />
     <Compile Include="Functions\LessThanOrEqualComparisonOperation.cs" />
     <Compile Include="Functions\Log10Function.cs" />

--- a/SolusEnvironment.cs
+++ b/SolusEnvironment.cs
@@ -57,7 +57,6 @@ namespace MetaphysicsIndustries.Solus
                     UnitStepFunction.Value,
                     Arctangent2Function.Value,
                     LogarithmFunction.Value,
-                    IfFunction.Value,
                     DistFunction.Value,
                     DistSqFunction.Value,
                 };
@@ -76,6 +75,7 @@ namespace MetaphysicsIndustries.Solus
                     SubstMacro.Value,
                     AssignMacro.Value,
                     DeleteMacro.Value,
+                    IfFunction.Value,
                 };
 
                 foreach (var macro in macros)

--- a/SolusEnvironment.cs
+++ b/SolusEnvironment.cs
@@ -75,7 +75,7 @@ namespace MetaphysicsIndustries.Solus
                     SubstMacro.Value,
                     AssignMacro.Value,
                     DeleteMacro.Value,
-                    IfFunction.Value,
+                    IfMacro.Value,
                 };
 
                 foreach (var macro in macros)

--- a/todo.txt
+++ b/todo.txt
@@ -1,3 +1,4 @@
 unify the namespace
     so that `vars` and `delete` and friends all work consistently and
     predictably
+don't evaluate macros while parsing


### PR DESCRIPTION
This PR changes the `IfFunction` function into the `IfMacro` macro. This ensures that only the right arguments get evaluated, without overriding and duplicating otherwise normal `Function` code.

This PR also includes full tests for the class.

Fixes #1 