### PR TITLE
Vector/matrix eval

### DIFF
--- a/Expressions/MatrixExpression.cs
+++ b/Expressions/MatrixExpression.cs
@@ -612,7 +612,11 @@ namespace MetaphysicsIndustries.Solus.Expressions
 
         public override IMathObject Eval(SolusEnvironment env)
         {
-            return new Number(0);
+            var values = new IMathObject[RowCount, ColumnCount];
+            for (int r = 0; r < RowCount; r++)
+                for (int c = 0; c < ColumnCount; c++)
+                    values[r, c] = this[r, c].Eval(env);
+            return new Matrix(values);
         }
 
         public override Expression Clone()

--- a/Expressions/VectorExpression.cs
+++ b/Expressions/VectorExpression.cs
@@ -101,7 +101,10 @@ namespace MetaphysicsIndustries.Solus.Expressions
 
         public override IMathObject Eval(SolusEnvironment env)
         {
-            return new Number(0);
+            var values = new IMathObject[Length];
+            for (int i = 0; i < Length; i++)
+                values[i] = this[i].Eval(env);
+            return new Vector(values);
         }
 
         public override Expression Clone()

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/MatrixExpressionT/EvalTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/MatrixExpressionT/EvalTest.cs
@@ -105,7 +105,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.MatrixExpressionT
                 new Literal(3),
                 new VariableAccess("a"));
             var env = new SolusEnvironment();
-            env.Variables["a"] = new Literal(5);
+            env.SetVariable("a", new Literal(5));
             // when
             var result = expr.Eval(env);
             // then

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/MatrixExpressionT/EvalTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/MatrixExpressionT/EvalTest.cs
@@ -1,0 +1,155 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2021 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Exceptions;
+using MetaphysicsIndustries.Solus.Expressions;
+using MetaphysicsIndustries.Solus.Values;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.MatrixExpressionT
+{
+    [TestFixture]
+    public class EvalTest
+    {
+        [Test]
+        public void LiteralsYieldMatrix()
+        {
+            // given
+            var expr = new MatrixExpression(2, 2,
+                new Literal(1),
+                new Literal(2),
+                new Literal(3),
+                new Literal(4));
+            // when
+            var result = expr.Eval(null);
+            // then
+            Assert.IsInstanceOf<Matrix>(result);
+            var matrix = (Matrix) result;
+            Assert.AreEqual(2, matrix.RowCount);
+            Assert.AreEqual(2, matrix.ColumnCount);
+            Assert.AreEqual(1.ToNumber(), matrix[0, 0]);
+            Assert.AreEqual(2.ToNumber(), matrix[0, 1]);
+            Assert.AreEqual(3.ToNumber(), matrix[1, 0]);
+            Assert.AreEqual(4.ToNumber(), matrix[1, 1]);
+        }
+
+        [Test]
+        public void LiteralsYieldMatrix2()
+        {
+            // given
+            var expr = new MatrixExpression(2, 3,
+                new Literal(1),
+                new Literal(2),
+                new Literal(3),
+                new Literal(4),
+                new Literal(5),
+                new Literal(6));
+            // when
+            var result = expr.Eval(null);
+            // then
+            Assert.IsInstanceOf<Matrix>(result);
+            var matrix = (Matrix) result;
+            Assert.AreEqual(2, matrix.RowCount);
+            Assert.AreEqual(3, matrix.ColumnCount);
+            Assert.AreEqual(1.ToNumber(), matrix[0, 0]);
+            Assert.AreEqual(2.ToNumber(), matrix[0, 1]);
+            Assert.AreEqual(3.ToNumber(), matrix[0, 2]);
+            Assert.AreEqual(4.ToNumber(), matrix[1, 0]);
+            Assert.AreEqual(5.ToNumber(), matrix[1, 1]);
+            Assert.AreEqual(6.ToNumber(), matrix[1, 2]);
+        }
+
+        [Test]
+        public void UndefinedVariablesInExpressionCauseException()
+        {
+            // given
+            var expr = new MatrixExpression(2, 2,
+                new Literal(1),
+                new Literal(2),
+                new Literal(3),
+                new VariableAccess("a"));
+            var env = new SolusEnvironment();
+            // expect
+            var exc = Assert.Throws<NameException>(() => expr.Eval(env));
+            // and
+            Assert.AreEqual("Variable not found in variable table: a",
+                exc.Message);
+        }
+
+        [Test]
+        public void DefinedVariablesInExpressionYieldValue()
+        {
+            // given
+            var expr = new MatrixExpression(2, 2,
+                new Literal(1),
+                new Literal(2),
+                new Literal(3),
+                new VariableAccess("a"));
+            var env = new SolusEnvironment();
+            env.Variables["a"] = new Literal(5);
+            // when
+            var result = expr.Eval(env);
+            // then
+            Assert.IsInstanceOf<Matrix>(result);
+            var matrix = (Matrix) result;
+            Assert.AreEqual(2, matrix.RowCount);
+            Assert.AreEqual(2, matrix.ColumnCount);
+            Assert.AreEqual(1.ToNumber(), matrix[0, 0]);
+            Assert.AreEqual(2.ToNumber(), matrix[0, 1]);
+            Assert.AreEqual(3.ToNumber(), matrix[1, 0]);
+            Assert.AreEqual(5.ToNumber(), matrix[1, 1]);
+        }
+
+        [Test]
+        public void NestedExpressionsYieldNestedValues()
+        {
+            // given
+            var expr = new MatrixExpression(2, 2,
+                new Literal(1),
+                new Literal(2),
+                new Literal(3),
+                new MatrixExpression(2, 2,
+                    new Literal(4),
+                    new Literal(5),
+                    new Literal(6),
+                    new Literal(7)));
+            // when
+            var result = expr.Eval(null);
+            // then
+            Assert.IsInstanceOf<Matrix>(result);
+            var matrix = (Matrix) result;
+            Assert.AreEqual(2, matrix.RowCount);
+            Assert.AreEqual(2, matrix.ColumnCount);
+            Assert.AreEqual(1.ToNumber(), matrix[0, 0]);
+            Assert.AreEqual(2.ToNumber(), matrix[0, 1]);
+            Assert.AreEqual(3.ToNumber(), matrix[1, 0]);
+            Assert.IsInstanceOf<Matrix>(matrix[1, 1]);
+            var matrix2 = (Matrix) matrix[1, 1];
+            Assert.AreEqual(2, matrix2.RowCount);
+            Assert.AreEqual(2, matrix2.ColumnCount);
+            Assert.AreEqual(4.ToNumber(), matrix2[0, 0]);
+            Assert.AreEqual(5.ToNumber(), matrix2[0, 1]);
+            Assert.AreEqual(6.ToNumber(), matrix2[1, 0]);
+            Assert.AreEqual(7.ToNumber(), matrix2[1, 1]);
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/VectorExpressionT/EvalTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/VectorExpressionT/EvalTest.cs
@@ -74,7 +74,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.VectorExpressionT
                 new Literal(2),
                 new VariableAccess("a"));
             var env = new SolusEnvironment();
-            env.Variables["a"] = new Literal(5);
+            env.SetVariable("a", new Literal(5));
             // when
             var result = expr.Eval(env);
             // then

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/VectorExpressionT/EvalTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/VectorExpressionT/EvalTest.cs
@@ -1,0 +1,116 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2021 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Exceptions;
+using MetaphysicsIndustries.Solus.Expressions;
+using MetaphysicsIndustries.Solus.Values;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.VectorExpressionT
+{
+    [TestFixture]
+    public class EvalTest
+    {
+        [Test]
+        public void LiteralsYieldVector()
+        {
+            // given
+            var expr = new VectorExpression(3,
+                new Literal(1),
+                new Literal(2),
+                new Literal(3));
+            // when
+            var result = expr.Eval(null);
+            // then
+            Assert.IsInstanceOf<Vector>(result);
+            var vector = (Vector) result;
+            Assert.AreEqual(3, vector.Length);
+            Assert.AreEqual(1.ToNumber(), vector[0]);
+            Assert.AreEqual(2.ToNumber(), vector[1]);
+            Assert.AreEqual(3.ToNumber(), vector[2]);
+        }
+
+        [Test]
+        public void UndefinedVariablesInExpressionCauseException()
+        {
+            // given
+            var expr = new VectorExpression(3,
+                new Literal(1),
+                new Literal(2),
+                new VariableAccess("a"));
+            var env = new SolusEnvironment();
+            // expect
+            var exc = Assert.Throws<NameException>(() => expr.Eval(env));
+            // and
+            Assert.AreEqual("Variable not found in variable table: a",
+                exc.Message);
+        }
+
+        [Test]
+        public void DefinedVariablesInExpressionYieldValue()
+        {
+            // given
+            var expr = new VectorExpression(3,
+                new Literal(1),
+                new Literal(2),
+                new VariableAccess("a"));
+            var env = new SolusEnvironment();
+            env.Variables["a"] = new Literal(5);
+            // when
+            var result = expr.Eval(env);
+            // then
+            Assert.IsInstanceOf<Vector>(result);
+            var vector = (Vector) result;
+            Assert.AreEqual(3, vector.Length);
+            Assert.AreEqual(1.ToNumber(), vector[0]);
+            Assert.AreEqual(2.ToNumber(), vector[1]);
+            Assert.AreEqual(5.ToNumber(), vector[2]);
+        }
+
+        [Test]
+        public void NestedExpressionsYieldNestedValues()
+        {
+            // given
+            var expr = new VectorExpression(3,
+                new Literal(1),
+                new Literal(2),
+                new VectorExpression(3,
+                    new Literal(3),
+                    new Literal(4),
+                    new Literal(5)));
+            // when
+            var result = expr.Eval(null);
+            // then
+            Assert.IsInstanceOf<Vector>(result);
+            var vector = (Vector) result;
+            Assert.AreEqual(3, vector.Length);
+            Assert.AreEqual(1.ToNumber(), vector[0]);
+            Assert.AreEqual(2.ToNumber(), vector[1]);
+            Assert.IsInstanceOf<Vector>(vector[2]);
+            var vector2 = (Vector) vector[2];
+            Assert.AreEqual(3, vector2.Length);
+            Assert.AreEqual(3.ToNumber(), vector2[0]);
+            Assert.AreEqual(4.ToNumber(), vector2[1]);
+            Assert.AreEqual(5.ToNumber(), vector2[2]);
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/MetaphysicsIndustries.Solus.Test.csproj
+++ b/MetaphysicsIndustries.Solus.Test/MetaphysicsIndustries.Solus.Test.csproj
@@ -40,6 +40,7 @@
     <Compile Include="ExpressionsT\ComponentAccessT\AccessComponentTest.cs" />
     <Compile Include="ExpressionsT\ComponentAccessT\ComponentAccessTest.cs" />
     <Compile Include="ExpressionsT\ComponentAccessT\PreliminaryEvalTest.cs" />
+    <Compile Include="ExpressionsT\MatrixExpressionT\EvalTest.cs" />
     <Compile Include="FunctionsT\AssociativeCommutativeOperationT\CheckArgumentsTest.cs" />
     <Compile Include="FunctionsT\FunctionT\CheckArgumentsTest.cs" />
     <Compile Include="FunctionsT\FunctionT\FunctionTest.cs" />
@@ -71,6 +72,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="ExpressionsT\VectorExpressionT" />
   </ItemGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/MetaphysicsIndustries.Solus.Test/MetaphysicsIndustries.Solus.Test.csproj
+++ b/MetaphysicsIndustries.Solus.Test/MetaphysicsIndustries.Solus.Test.csproj
@@ -41,6 +41,7 @@
     <Compile Include="ExpressionsT\ComponentAccessT\ComponentAccessTest.cs" />
     <Compile Include="ExpressionsT\ComponentAccessT\PreliminaryEvalTest.cs" />
     <Compile Include="ExpressionsT\MatrixExpressionT\EvalTest.cs" />
+    <Compile Include="ExpressionsT\VectorExpressionT\EvalTest.cs" />
     <Compile Include="FunctionsT\AssociativeCommutativeOperationT\CheckArgumentsTest.cs" />
     <Compile Include="FunctionsT\FunctionT\CheckArgumentsTest.cs" />
     <Compile Include="FunctionsT\FunctionT\FunctionTest.cs" />
@@ -72,9 +73,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="ExpressionsT\VectorExpressionT" />
   </ItemGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>


### PR DESCRIPTION
This PR adds proper `Eval` methods to `VectorExpression` and `MatrixExpression`. Previously, they just returned `0`. Now they reduced down to `Vector` and `Matrix` values, respectively.