### PR TITLE
Interrogation unknown

### DIFF
--- a/Compiler/ILCompiler.cs
+++ b/Compiler/ILCompiler.cs
@@ -169,7 +169,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
         public IEnumerable<Instruction> ConvertToInstructions(
             Literal expr, VariableToArgumentNumberMapper varmap)
         {
-            if (expr.Value.IsScalar(null))
+            if (expr.Value.IsIsScalar(null))
                 return new []
                 {
                     Instruction.LoadConstant(expr.Value.ToFloat())

--- a/Expressions/ColorExpression.cs
+++ b/Expressions/ColorExpression.cs
@@ -108,13 +108,13 @@ namespace MetaphysicsIndustries.Solus.Expressions
         public override IMathObject Result { get; } = new ResultC();
         private class ResultC : IMathObject
         {
-            public bool IsScalar(SolusEnvironment env) => true;
-            public bool IsVector(SolusEnvironment env) => false;
-            public bool IsMatrix(SolusEnvironment env) => false;
-            public int GetTensorRank(SolusEnvironment env) => 0;
-            public bool IsString(SolusEnvironment env) => false;
+            public bool? IsScalar(SolusEnvironment env) => true;
+            public bool? IsVector(SolusEnvironment env) => false;
+            public bool? IsMatrix(SolusEnvironment env) => false;
+            public int? GetTensorRank(SolusEnvironment env) => 0;
+            public bool? IsString(SolusEnvironment env) => false;
 
-            public int GetDimension(SolusEnvironment env, int index)
+            public int? GetDimension(SolusEnvironment env, int index)
             {
                 throw new IndexOutOfRangeException(
                     "Color expressions do not have dimensions");
@@ -126,7 +126,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
                     "Color expressions do not have dimensions");
             }
 
-            public int GetVectorLength(SolusEnvironment env)
+            public int? GetVectorLength(SolusEnvironment env)
             {
                 throw new InvalidOperationException(
                     "Color expressions do not have a length");

--- a/Expressions/ColorExpression.cs
+++ b/Expressions/ColorExpression.cs
@@ -113,25 +113,9 @@ namespace MetaphysicsIndustries.Solus.Expressions
             public bool? IsMatrix(SolusEnvironment env) => false;
             public int? GetTensorRank(SolusEnvironment env) => 0;
             public bool? IsString(SolusEnvironment env) => false;
-
-            public int? GetDimension(SolusEnvironment env, int index)
-            {
-                throw new IndexOutOfRangeException(
-                    "Color expressions do not have dimensions");
-            }
-
-            public int[] GetDimensions(SolusEnvironment env)
-            {
-                throw new IndexOutOfRangeException(
-                    "Color expressions do not have dimensions");
-            }
-
-            public int? GetVectorLength(SolusEnvironment env)
-            {
-                throw new InvalidOperationException(
-                    "Color expressions do not have a length");
-            }
-
+            public int? GetDimension(SolusEnvironment env, int index) => null;
+            public int[] GetDimensions(SolusEnvironment env) => null;
+            public int? GetVectorLength(SolusEnvironment env) => null;
             public bool IsConcrete => false;
         }
     }

--- a/Expressions/ColorExpression.cs
+++ b/Expressions/ColorExpression.cs
@@ -105,18 +105,6 @@ namespace MetaphysicsIndustries.Solus.Expressions
             throw new NotImplementedException();
         }
 
-        public override IMathObject Result { get; } = new ResultC();
-        private class ResultC : IMathObject
-        {
-            public bool? IsScalar(SolusEnvironment env) => true;
-            public bool? IsVector(SolusEnvironment env) => false;
-            public bool? IsMatrix(SolusEnvironment env) => false;
-            public int? GetTensorRank(SolusEnvironment env) => 0;
-            public bool? IsString(SolusEnvironment env) => false;
-            public int? GetDimension(SolusEnvironment env, int index) => null;
-            public int[] GetDimensions(SolusEnvironment env) => null;
-            public int? GetVectorLength(SolusEnvironment env) => null;
-            public bool IsConcrete => false;
-        }
+        public override IMathObject Result => ScalarMathObject.Value;
     }
 }

--- a/Expressions/ComponentAccess.cs
+++ b/Expressions/ComponentAccess.cs
@@ -263,62 +263,14 @@ namespace MetaphysicsIndustries.Solus.Expressions
             // indexes.
             public ResultC(ComponentAccess ca) => _ca = ca;
             private readonly ComponentAccess _ca;
-            public bool? IsScalar(SolusEnvironment env)
-            {
-                var evaledIndexes = _ca.GetEvaledIndexes(env);
-                var expr = AccessComponent(_ca.Expr, evaledIndexes, env);
-                return expr.Result.IsScalar(env);
-            }
-
-            public bool? IsVector(SolusEnvironment env)
-            {
-                var evaledIndexes = _ca.GetEvaledIndexes(env);
-                var expr = AccessComponent(_ca.Expr, evaledIndexes, env);
-                return expr.Result.IsVector(env);
-            }
-
-            public bool? IsMatrix(SolusEnvironment env)
-            {
-                var evaledIndexes = _ca.GetEvaledIndexes(env);
-                var expr = AccessComponent(_ca.Expr, evaledIndexes, env);
-                return expr.Result.IsMatrix(env);
-            }
-
-            public int? GetTensorRank(SolusEnvironment env)
-            {
-                var evaledIndexes = _ca.GetEvaledIndexes(env);
-                var expr = AccessComponent(_ca.Expr, evaledIndexes, env);
-                return expr.Result.GetTensorRank(env);
-            }
-
-            public bool? IsString(SolusEnvironment env)
-            {
-                var evaledIndexes = _ca.GetEvaledIndexes(env);
-                var expr = AccessComponent(_ca.Expr, evaledIndexes, env);
-                return expr.Result.IsString(env);
-            }
-
-            public int? GetDimension(SolusEnvironment env, int index)
-            {
-                var evaledIndexes = _ca.GetEvaledIndexes(env);
-                var expr = AccessComponent(_ca.Expr, evaledIndexes, env);
-                return expr.Result.GetDimension(env, index);
-            }
-
-            public int[] GetDimensions(SolusEnvironment env)
-            {
-                var evaledIndexes = _ca.GetEvaledIndexes(env);
-                var expr = AccessComponent(_ca.Expr, evaledIndexes, env);
-                return expr.Result.GetDimensions(env);
-            }
-
-            public int? GetVectorLength(SolusEnvironment env)
-            {
-                var evaledIndexes = _ca.GetEvaledIndexes(env);
-                var expr = AccessComponent(_ca.Expr, evaledIndexes, env);
-                return expr.Result.GetVectorLength(env);
-            }
-
+            public bool? IsScalar(SolusEnvironment env) => null;
+            public bool? IsVector(SolusEnvironment env) => null;
+            public bool? IsMatrix(SolusEnvironment env) => null;
+            public int? GetTensorRank(SolusEnvironment env) => null;
+            public bool? IsString(SolusEnvironment env) => null;
+            public int? GetDimension(SolusEnvironment env, int index) => null;
+            public int[] GetDimensions(SolusEnvironment env) => null;
+            public int? GetVectorLength(SolusEnvironment env) => null;
             public bool IsConcrete => false;
         }
 

--- a/Expressions/ComponentAccess.cs
+++ b/Expressions/ComponentAccess.cs
@@ -133,15 +133,12 @@ namespace MetaphysicsIndustries.Solus.Expressions
             IMathObject[] indexes, SolusEnvironment env)
         {
             int? length = null;
-            if (expr.IsIsVector(env)) length = expr.ToVector().Length;
-            else if (expr.IsIsString(env)) length = expr.ToStringValue().Length;
-            int? exprRowCount = null;
-            int? exprColumnCount = null;
-            if (expr.GetTensorRank(env) > 1)
-            {
-                exprRowCount = expr.GetDimension(env, 0);
-                exprColumnCount = expr.GetDimension(env, 1);
-            }
+            if (expr.IsIsVector(env))
+                length = expr.ToVector().Length;
+            else if (expr.IsIsString(env))
+                length = expr.ToStringValue().Length;
+            var exprRowCount = expr.GetDimension(env, 0);
+            var exprColumnCount = expr.GetDimension(env, 1);
             CheckIndexes(indexes, expr.IsScalar(env), expr.IsVector(env),
                 expr.IsMatrix(env), expr.GetTensorRank(env),
                 expr.IsString(env), length,

--- a/Expressions/ComponentAccess.cs
+++ b/Expressions/ComponentAccess.cs
@@ -72,7 +72,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
             }
             else
             {
-                if ((exprIsScalar.HasValue && exprIsScalar.Value) || 
+                if ((exprIsScalar.HasValue && exprIsScalar.Value) ||
                     exprTensorRank < 1)
                     throw new OperandException(
                         "Scalars do not have components");
@@ -236,7 +236,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
         public override void AcceptVisitor(IExpressionVisitor visitor)
         {
             visitor.Visit(this);
-            
+
             Expr.AcceptVisitor(visitor);
             foreach (var index in Indexes)
                 index.AcceptVisitor(visitor);

--- a/Expressions/ComponentAccess.cs
+++ b/Expressions/ComponentAccess.cs
@@ -260,6 +260,10 @@ namespace MetaphysicsIndustries.Solus.Expressions
 
         private class ResultC : IMathObject
         {
+            // TODO: really, we can only interrogate the component if the
+            // object is known to have components all of a particular type,
+            // e.g. 3-vector in R^3. otherwise, we have to evaluate the
+            // indexes.
             public ResultC(ComponentAccess ca) => _ca = ca;
             private readonly ComponentAccess _ca;
             public bool? IsScalar(SolusEnvironment env)

--- a/Expressions/ComponentAccess.cs
+++ b/Expressions/ComponentAccess.cs
@@ -59,11 +59,11 @@ namespace MetaphysicsIndustries.Solus.Expressions
         }
 
         private static void CheckIndexes(IMathObject[] indexes,
-            bool exprIsScalar, bool exprIsVector, bool exprIsMatrix,
-            int exprTensorRank, bool exprIsString, int? exprLength,
+            bool? exprIsScalar, bool? exprIsVector, bool? exprIsMatrix,
+            int? exprTensorRank, bool? exprIsString, int? exprLength,
             int? exprRowCount, int? exprColumnCount)
         {
-            if (exprIsString)
+            if (exprIsString.HasValue && exprIsString.Value)
             {
                 if (1 != indexes.Length)
                     throw new IndexException(
@@ -72,7 +72,8 @@ namespace MetaphysicsIndustries.Solus.Expressions
             }
             else
             {
-                if (exprIsScalar || exprTensorRank < 1)
+                if ((exprIsScalar.HasValue && exprIsScalar.Value) || 
+                    exprTensorRank < 1)
                     throw new OperandException(
                         "Scalars do not have components");
                 if (exprTensorRank != indexes.Length)
@@ -83,7 +84,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
 
             // TODO: maybe pass the env, and then we don't have to eval the
             // indexes before-hand?
-            if (indexes.Any(i => !i.IsScalar(null)))
+            if (indexes.Any(i => !i.IsIsScalar(null)))
                 throw new IndexException(
                     "Indexes must be scalar");
             if (indexes.Any(i => i.ToNumber().Value < 0))
@@ -91,7 +92,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
                     "Indexes must not be negative");
 
             var index0 = (int) indexes[0].ToNumber().Value;
-            if (exprIsVector)
+            if (exprIsVector.HasValue && exprIsVector.Value)
             {
                 if (index0 >= exprLength.Value)
                     throw new IndexException(
@@ -99,7 +100,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
                 return;
             }
 
-            if (exprIsString)
+            if (exprIsString.HasValue && exprIsString.Value)
             {
                 // TODO: check index for string
                 // if (!exprLength.HasValue)
@@ -112,7 +113,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
             }
 
             var index1 = (int) indexes[1].ToNumber().Value;
-            if (exprIsMatrix)
+            if (exprIsMatrix.HasValue && exprIsMatrix.Value)
             {
                 if (index0 >= exprRowCount)
                     throw new IndexException(
@@ -132,14 +133,14 @@ namespace MetaphysicsIndustries.Solus.Expressions
             IMathObject[] indexes, SolusEnvironment env)
         {
             int? length = null;
-            if (expr.IsVector(env)) length = expr.ToVector().Length;
-            else if (expr.IsString(env)) length = expr.ToStringValue().Length;
+            if (expr.IsIsVector(env)) length = expr.ToVector().Length;
+            else if (expr.IsIsString(env)) length = expr.ToStringValue().Length;
             int? exprRowCount = null;
             int? exprColumnCount = null;
             if (expr.GetTensorRank(env) > 1)
             {
-                exprRowCount = new int?(expr.GetDimension(env, 0));
-                exprColumnCount = new int?(expr.GetDimension(env, 1));
+                exprRowCount = expr.GetDimension(env, 0);
+                exprColumnCount = expr.GetDimension(env, 1);
             }
             CheckIndexes(indexes, expr.IsScalar(env), expr.IsVector(env),
                 expr.IsMatrix(env), expr.GetTensorRank(env),
@@ -147,20 +148,20 @@ namespace MetaphysicsIndustries.Solus.Expressions
                 exprRowCount, exprColumnCount);
 
             var index0 = (int) indexes[0].ToNumber().Value;
-            if (expr.IsVector(env))
+            if (expr.IsIsVector(env))
             {
                 var v = expr.ToVector();
                 return v[index0];
             }
 
-            if (expr.IsString(env))
+            if (expr.IsIsString(env))
             {
                 var sv = expr.ToStringValue();
                 return sv.Value[index0].ToStringValue();
             }
 
             var index1 = (int) indexes[1].ToNumber().Value;
-            if (expr.IsMatrix(env))
+            if (expr.IsIsMatrix(env))
             {
                 var m = expr.ToMatrix();
                 return m[index0, index1];
@@ -175,13 +176,13 @@ namespace MetaphysicsIndustries.Solus.Expressions
             IMathObject[] indexes, SolusEnvironment env)
         {
             int? length = null;
-            if (expr.Result.IsVector(env))
+            if (expr.Result.IsIsVector(env))
                 length = expr.Result.GetVectorLength(env);
 
-            int exprTensorRank = expr.Result.GetTensorRank(env);
+            int? exprTensorRank = expr.Result.GetTensorRank(env);
             int? exprRowCount = null;
             int? exprColumnCount = null;
-            if (exprTensorRank == 2)
+            if (exprTensorRank.HasValue && exprTensorRank.Value == 2)
             {
                 exprRowCount = expr.Result.GetDimension(env, 0);
                 exprColumnCount = expr.Result.GetDimension(env, 1);
@@ -261,42 +262,42 @@ namespace MetaphysicsIndustries.Solus.Expressions
         {
             public ResultC(ComponentAccess ca) => _ca = ca;
             private readonly ComponentAccess _ca;
-            public bool IsScalar(SolusEnvironment env)
+            public bool? IsScalar(SolusEnvironment env)
             {
                 var evaledIndexes = _ca.GetEvaledIndexes(env);
                 var expr = AccessComponent(_ca.Expr, evaledIndexes, env);
                 return expr.Result.IsScalar(env);
             }
 
-            public bool IsVector(SolusEnvironment env)
+            public bool? IsVector(SolusEnvironment env)
             {
                 var evaledIndexes = _ca.GetEvaledIndexes(env);
                 var expr = AccessComponent(_ca.Expr, evaledIndexes, env);
                 return expr.Result.IsVector(env);
             }
 
-            public bool IsMatrix(SolusEnvironment env)
+            public bool? IsMatrix(SolusEnvironment env)
             {
                 var evaledIndexes = _ca.GetEvaledIndexes(env);
                 var expr = AccessComponent(_ca.Expr, evaledIndexes, env);
                 return expr.Result.IsMatrix(env);
             }
 
-            public int GetTensorRank(SolusEnvironment env)
+            public int? GetTensorRank(SolusEnvironment env)
             {
                 var evaledIndexes = _ca.GetEvaledIndexes(env);
                 var expr = AccessComponent(_ca.Expr, evaledIndexes, env);
                 return expr.Result.GetTensorRank(env);
             }
 
-            public bool IsString(SolusEnvironment env)
+            public bool? IsString(SolusEnvironment env)
             {
                 var evaledIndexes = _ca.GetEvaledIndexes(env);
                 var expr = AccessComponent(_ca.Expr, evaledIndexes, env);
                 return expr.Result.IsString(env);
             }
 
-            public int GetDimension(SolusEnvironment env, int index)
+            public int? GetDimension(SolusEnvironment env, int index)
             {
                 var evaledIndexes = _ca.GetEvaledIndexes(env);
                 var expr = AccessComponent(_ca.Expr, evaledIndexes, env);
@@ -310,7 +311,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
                 return expr.Result.GetDimensions(env);
             }
 
-            public int GetVectorLength(SolusEnvironment env)
+            public int? GetVectorLength(SolusEnvironment env)
             {
                 var evaledIndexes = _ca.GetEvaledIndexes(env);
                 var expr = AccessComponent(_ca.Expr, evaledIndexes, env);

--- a/Expressions/FunctionCall.cs
+++ b/Expressions/FunctionCall.cs
@@ -121,6 +121,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
 
         public virtual List<Expression> Arguments
         {
+            // TODO: make this immutable
             get
             {
                 return _arguments;
@@ -217,6 +218,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
         }
 
         public override IMathObject Result =>
+            // TODO: don't use linq
             Function.GetResult(Arguments.Select(a => a.Result));
     }
 }

--- a/Expressions/FunctionCall.cs
+++ b/Expressions/FunctionCall.cs
@@ -229,7 +229,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
                 int i;
                 for (i = 0; i < Arguments.Count; i++)
                     _argumentResultCache[i] = Arguments[i].Result;
-                Function.GetResult(_argumentResultCache);
+                return Function.GetResult(_argumentResultCache);
             }
         }
     }

--- a/Expressions/FunctionCall.cs
+++ b/Expressions/FunctionCall.cs
@@ -217,8 +217,20 @@ namespace MetaphysicsIndustries.Solus.Expressions
             }
         }
 
-        public override IMathObject Result =>
-            // TODO: don't use linq
-            Function.GetResult(Arguments.Select(a => a.Result));
+        private IMathObject[] _argumentResultCache;
+
+        public override IMathObject Result
+        {
+            get
+            {
+                if (_argumentResultCache == null ||
+                    _argumentResultCache.Length < Arguments.Count)
+                    _argumentResultCache = new IMathObject[Arguments.Count];
+                int i;
+                for (i = 0; i < Arguments.Count; i++)
+                    _argumentResultCache[i] = Arguments[i].Result;
+                Function.GetResult(_argumentResultCache);
+            }
+        }
     }
 }

--- a/Expressions/MatrixExpression.cs
+++ b/Expressions/MatrixExpression.cs
@@ -760,13 +760,13 @@ namespace MetaphysicsIndustries.Solus.Expressions
         {
             public ResultC(MatrixExpression me) => _me = me;
             private readonly MatrixExpression _me;
-            public bool IsScalar(SolusEnvironment env) => false;
-            public bool IsVector(SolusEnvironment env) => false;
-            public bool IsMatrix(SolusEnvironment env) => true;
-            public int GetTensorRank(SolusEnvironment env) => _me.TensorRank;
-            public bool IsString(SolusEnvironment env) => false;
+            public bool? IsScalar(SolusEnvironment env) => false;
+            public bool? IsVector(SolusEnvironment env) => false;
+            public bool? IsMatrix(SolusEnvironment env) => true;
+            public int? GetTensorRank(SolusEnvironment env) => _me.TensorRank;
+            public bool? IsString(SolusEnvironment env) => false;
 
-            public int GetDimension(SolusEnvironment env, int index)
+            public int? GetDimension(SolusEnvironment env, int index)
             {
                 if (index == 0) return _me.RowCount;
                 if (index == 1) return _me.ColumnCount;
@@ -783,7 +783,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
                 return __GetDimensions;
             }
 
-            public int GetVectorLength(SolusEnvironment env)
+            public int? GetVectorLength(SolusEnvironment env)
             {
                 throw new InvalidOperationException(
                     "A matrix is not a vector");

--- a/Expressions/MatrixExpression.cs
+++ b/Expressions/MatrixExpression.cs
@@ -770,8 +770,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
             {
                 if (index == 0) return _me.RowCount;
                 if (index == 1) return _me.ColumnCount;
-                throw new IndexOutOfRangeException(
-                    "The index must be zero or one for a matrix");
+                return null;
             }
 
             private int[] __GetDimensions;
@@ -783,11 +782,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
                 return __GetDimensions;
             }
 
-            public int? GetVectorLength(SolusEnvironment env)
-            {
-                throw new InvalidOperationException(
-                    "A matrix is not a vector");
-            }
+            public int? GetVectorLength(SolusEnvironment env) => null;
 
             public bool IsConcrete => false;
         }

--- a/Expressions/RandomExpression.cs
+++ b/Expressions/RandomExpression.cs
@@ -50,13 +50,13 @@ namespace MetaphysicsIndustries.Solus.Expressions
 
         private class ResultC : IMathObject
         {
-            public bool IsScalar(SolusEnvironment env) => true;
-            public bool IsVector(SolusEnvironment env) => false;
-            public bool IsMatrix(SolusEnvironment env) => false;
-            public int GetTensorRank(SolusEnvironment env) => 0;
-            public bool IsString(SolusEnvironment env) => false;
+            public bool? IsScalar(SolusEnvironment env) => true;
+            public bool? IsVector(SolusEnvironment env) => false;
+            public bool? IsMatrix(SolusEnvironment env) => false;
+            public int? GetTensorRank(SolusEnvironment env) => 0;
+            public bool? IsString(SolusEnvironment env) => false;
 
-            public int GetDimension(SolusEnvironment env, int index)
+            public int? GetDimension(SolusEnvironment env, int index)
             {
                 throw new IndexOutOfRangeException(
                     "Random expressions do not have dimensions");
@@ -68,7 +68,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
                     "Random expressions do not have dimensions");
             }
 
-            public int GetVectorLength(SolusEnvironment env)
+            public int? GetVectorLength(SolusEnvironment env)
             {
                 throw new InvalidOperationException(
                     "Random expressions do not have a length");

--- a/Expressions/RandomExpression.cs
+++ b/Expressions/RandomExpression.cs
@@ -55,25 +55,9 @@ namespace MetaphysicsIndustries.Solus.Expressions
             public bool? IsMatrix(SolusEnvironment env) => false;
             public int? GetTensorRank(SolusEnvironment env) => 0;
             public bool? IsString(SolusEnvironment env) => false;
-
-            public int? GetDimension(SolusEnvironment env, int index)
-            {
-                throw new IndexOutOfRangeException(
-                    "Random expressions do not have dimensions");
-            }
-
-            public int[] GetDimensions(SolusEnvironment env)
-            {
-                throw new IndexOutOfRangeException(
-                    "Random expressions do not have dimensions");
-            }
-
-            public int? GetVectorLength(SolusEnvironment env)
-            {
-                throw new InvalidOperationException(
-                    "Random expressions do not have a length");
-            }
-
+            public int? GetDimension(SolusEnvironment env, int index) => null;
+            public int[] GetDimensions(SolusEnvironment env) => null;
+            public int? GetVectorLength(SolusEnvironment env) => null;
             public bool IsConcrete => false;
         }
     }

--- a/Expressions/VariableAccess.cs
+++ b/Expressions/VariableAccess.cs
@@ -102,66 +102,58 @@ namespace MetaphysicsIndustries.Solus.Expressions
             public ResultC(VariableAccess va) => _va = va;
             private readonly VariableAccess _va;
 
-            private void Check(SolusEnvironment env)
-            {
-                if (!env.ContainsVariable(_va.VariableName))
-                    throw new NameException(
-                        $"Variable not found in the environment: " +
-                        _va.VariableName);
-            }
-
             public bool? IsScalar(SolusEnvironment env)
             {
-                Check(env);
+                if (!env.ContainsVariable(_va.VariableName)) return null;
                 var varexpr = env.GetVariable(_va.VariableName);
                 return varexpr.Result.IsScalar(env);
             }
 
             public bool? IsVector(SolusEnvironment env)
             {
-                Check(env);
+                if (!env.ContainsVariable(_va.VariableName)) return null;
                 var varexpr = env.GetVariable(_va.VariableName);
                 return varexpr.Result.IsVector(env);
             }
 
             public bool? IsMatrix(SolusEnvironment env)
             {
-                Check(env);
+                if (!env.ContainsVariable(_va.VariableName)) return null;
                 var varexpr = env.GetVariable(_va.VariableName);
                 return varexpr.Result.IsMatrix(env);
             }
 
             public int? GetTensorRank(SolusEnvironment env)
             {
-                Check(env);
+                if (!env.ContainsVariable(_va.VariableName)) return null;
                 var varexpr = env.GetVariable(_va.VariableName);
                 return varexpr.Result.GetTensorRank(env);
             }
 
             public bool? IsString(SolusEnvironment env)
             {
-                Check(env);
+                if (!env.ContainsVariable(_va.VariableName)) return null;
                 var varexpr = env.GetVariable(_va.VariableName);
                 return varexpr.Result.IsString(env);
             }
 
             public int? GetDimension(SolusEnvironment env, int index)
             {
-                Check(env);
+                if (!env.ContainsVariable(_va.VariableName)) return null;
                 var varexpr = env.GetVariable(_va.VariableName);
                 return varexpr.Result.GetDimension(env, index);
             }
 
             public int[] GetDimensions(SolusEnvironment env)
             {
-                Check(env);
+                if (!env.ContainsVariable(_va.VariableName)) return null;
                 var varexpr = env.GetVariable(_va.VariableName);
                 return varexpr.Result.GetDimensions(env);
             }
 
             public int? GetVectorLength(SolusEnvironment env)
             {
-                Check(env);
+                if (!env.ContainsVariable(_va.VariableName)) return null;
                 var varexpr = env.GetVariable(_va.VariableName);
                 return varexpr.Result.GetVectorLength(env);
             }

--- a/Expressions/VariableAccess.cs
+++ b/Expressions/VariableAccess.cs
@@ -110,42 +110,42 @@ namespace MetaphysicsIndustries.Solus.Expressions
                         _va.VariableName);
             }
 
-            public bool IsScalar(SolusEnvironment env)
+            public bool? IsScalar(SolusEnvironment env)
             {
                 Check(env);
                 var varexpr = env.GetVariable(_va.VariableName);
                 return varexpr.Result.IsScalar(env);
             }
 
-            public bool IsVector(SolusEnvironment env)
+            public bool? IsVector(SolusEnvironment env)
             {
                 Check(env);
                 var varexpr = env.GetVariable(_va.VariableName);
                 return varexpr.Result.IsVector(env);
             }
 
-            public bool IsMatrix(SolusEnvironment env)
+            public bool? IsMatrix(SolusEnvironment env)
             {
                 Check(env);
                 var varexpr = env.GetVariable(_va.VariableName);
                 return varexpr.Result.IsMatrix(env);
             }
 
-            public int GetTensorRank(SolusEnvironment env)
+            public int? GetTensorRank(SolusEnvironment env)
             {
                 Check(env);
                 var varexpr = env.GetVariable(_va.VariableName);
                 return varexpr.Result.GetTensorRank(env);
             }
 
-            public bool IsString(SolusEnvironment env)
+            public bool? IsString(SolusEnvironment env)
             {
                 Check(env);
                 var varexpr = env.GetVariable(_va.VariableName);
                 return varexpr.Result.IsString(env);
             }
 
-            public int GetDimension(SolusEnvironment env, int index)
+            public int? GetDimension(SolusEnvironment env, int index)
             {
                 Check(env);
                 var varexpr = env.GetVariable(_va.VariableName);
@@ -159,7 +159,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
                 return varexpr.Result.GetDimensions(env);
             }
 
-            public int GetVectorLength(SolusEnvironment env)
+            public int? GetVectorLength(SolusEnvironment env)
             {
                 Check(env);
                 var varexpr = env.GetVariable(_va.VariableName);

--- a/Expressions/VectorExpression.cs
+++ b/Expressions/VectorExpression.cs
@@ -22,7 +22,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using MetaphysicsIndustries.Solus.Functions;
 using MetaphysicsIndustries.Solus.Transformers;
@@ -289,14 +288,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
             public bool? IsMatrix(SolusEnvironment env) => false;
             public int? GetTensorRank(SolusEnvironment env) => 1;
             public bool? IsString(SolusEnvironment env) => false;
-
-            public int? GetDimension(SolusEnvironment env, int index)
-            {
-                if (index == 0) return _ve.Length;
-                throw new IndexOutOfRangeException(
-                    "The index must be zero for a vector");
-            }
-
+            public int? GetDimension(SolusEnvironment env, int index) => null;
             private int[] __GetDimensions;
 
             public int[] GetDimensions(SolusEnvironment env)

--- a/Expressions/VectorExpression.cs
+++ b/Expressions/VectorExpression.cs
@@ -288,7 +288,13 @@ namespace MetaphysicsIndustries.Solus.Expressions
             public bool? IsMatrix(SolusEnvironment env) => false;
             public int? GetTensorRank(SolusEnvironment env) => 1;
             public bool? IsString(SolusEnvironment env) => false;
-            public int? GetDimension(SolusEnvironment env, int index) => null;
+
+            public int? GetDimension(SolusEnvironment env, int index)
+            {
+                if (index == 0) return _ve.Length;
+                return null;
+            }
+
             private int[] __GetDimensions;
 
             public int[] GetDimensions(SolusEnvironment env)

--- a/Expressions/VectorExpression.cs
+++ b/Expressions/VectorExpression.cs
@@ -284,13 +284,13 @@ namespace MetaphysicsIndustries.Solus.Expressions
         {
             public ResultC(VectorExpression ve) => _ve = ve;
             private readonly VectorExpression _ve;
-            public bool IsScalar(SolusEnvironment env) => false;
-            public bool IsVector(SolusEnvironment env) => true;
-            public bool IsMatrix(SolusEnvironment env) => false;
-            public int GetTensorRank(SolusEnvironment env) => 1;
-            public bool IsString(SolusEnvironment env) => false;
+            public bool? IsScalar(SolusEnvironment env) => false;
+            public bool? IsVector(SolusEnvironment env) => true;
+            public bool? IsMatrix(SolusEnvironment env) => false;
+            public int? GetTensorRank(SolusEnvironment env) => 1;
+            public bool? IsString(SolusEnvironment env) => false;
 
-            public int GetDimension(SolusEnvironment env, int index)
+            public int? GetDimension(SolusEnvironment env, int index)
             {
                 if (index == 0) return _ve.Length;
                 throw new IndexOutOfRangeException(
@@ -306,7 +306,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
                 return __GetDimensions;
             }
 
-            public int GetVectorLength(SolusEnvironment env) => _ve.Length;
+            public int? GetVectorLength(SolusEnvironment env) => _ve.Length;
 
             public bool IsConcrete => false;
         }

--- a/Functions/CatmullRomSpline.cs
+++ b/Functions/CatmullRomSpline.cs
@@ -55,7 +55,7 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         readonly float[] Times;
         readonly float[] Values;
-            
+
         protected override IMathObject InternalCall(SolusEnvironment env,
             IMathObject[] args)
         {

--- a/Functions/EqualComparisonOperation.cs
+++ b/Functions/EqualComparisonOperation.cs
@@ -54,6 +54,10 @@ namespace MetaphysicsIndustries.Solus.Functions
         public override IMathObject GetResult(IEnumerable<IMathObject> args)
         {
             // TODO: boolean
+            // TODO: matrix
+            // TODO: vector
+            // TODO: string
+            // TODO: complex
             return ScalarMathObject.Value;
         }
     }

--- a/Functions/LoadImageFunction.cs
+++ b/Functions/LoadImageFunction.cs
@@ -66,9 +66,24 @@ namespace MetaphysicsIndustries.Solus.Functions
                 loader);
         }
 
+        private class ResultC : IMathObject
+        {
+            public bool? IsScalar(SolusEnvironment env) => false;
+            public bool? IsVector(SolusEnvironment env) => false;
+            public bool? IsMatrix(SolusEnvironment env) => true;
+            public int? GetTensorRank(SolusEnvironment env) => 2;
+            public bool? IsString(SolusEnvironment env) => false;
+            public int? GetDimension(SolusEnvironment env, int index) => null;
+            public int[] GetDimensions(SolusEnvironment env) => null;
+            public int? GetVectorLength(SolusEnvironment env) => null;
+            public bool IsConcrete => false;
+        }
+
+        private readonly ResultC _result = new ResultC();
+
         public override IMathObject GetResult(IEnumerable<IMathObject> args)
         {
-            throw new NotImplementedException();
+            return _result;
         }
     }
 }

--- a/Functions/NotEqualComparisonOperation.cs
+++ b/Functions/NotEqualComparisonOperation.cs
@@ -56,6 +56,10 @@ namespace MetaphysicsIndustries.Solus.Functions
         public override IMathObject GetResult(IEnumerable<IMathObject> args)
         {
             // TODO: boolean
+            // TODO: matrix
+            // TODO: vector
+            // TODO: string
+            // TODO: complex
             return ScalarMathObject.Value;
         }
     }

--- a/Functions/SizeFunction.cs
+++ b/Functions/SizeFunction.cs
@@ -61,8 +61,13 @@ namespace MetaphysicsIndustries.Solus.Functions
             // TODO: this function should be able to operate on things that
             // aren't IMathObject, namely TensorExpression
             var arg = args[0];
-            if (arg.IsString(env) || arg.IsVector(env))
-                return arg.GetDimension(env, 0).ToNumber();
+            if (arg.IsIsString(env) || arg.IsIsVector(env))
+            {
+                var dim = arg.GetDimension(env, 0);
+                if (dim.HasValue)
+                    return dim.Value.ToNumber();
+            }
+
             return arg.GetDimensions(env).ToVector();
         }
 
@@ -70,13 +75,13 @@ namespace MetaphysicsIndustries.Solus.Functions
         {
             public ResultC(IMathObject obj) => _obj = obj;
             private readonly IMathObject _obj;
-            public bool IsScalar(SolusEnvironment env) => false;
-            public bool IsVector(SolusEnvironment env) => true;
-            public bool IsMatrix(SolusEnvironment env) => false;
-            public int GetTensorRank(SolusEnvironment env) => 1;
-            public bool IsString(SolusEnvironment env) => false;
+            public bool? IsScalar(SolusEnvironment env) => false;
+            public bool? IsVector(SolusEnvironment env) => true;
+            public bool? IsMatrix(SolusEnvironment env) => false;
+            public int? GetTensorRank(SolusEnvironment env) => 1;
+            public bool? IsString(SolusEnvironment env) => false;
 
-            public int GetDimension(SolusEnvironment env, int index)
+            public int? GetDimension(SolusEnvironment env, int index)
             {
                 if (index != 0) throw new IndexException();
                 return _obj.GetTensorRank(env);
@@ -85,13 +90,21 @@ namespace MetaphysicsIndustries.Solus.Functions
             public int[] GetDimensions(SolusEnvironment env)
             {
                 var n = _obj.GetTensorRank(env);
-                var dimensions = new int[n];
+                if (!n.HasValue)
+                    return null;
+                var dimensions = new int[n.Value];
                 for (var i = 0; i < n; i++)
-                    dimensions[i] = _obj.GetDimension(env, i);
+                {
+                    var dim = _obj.GetDimension(env, i);
+                    if (!dim.HasValue)
+                        return null;
+                    dimensions[i] = dim.Value;
+                }
+
                 return dimensions;
             }
 
-            public int GetVectorLength(SolusEnvironment env) =>
+            public int? GetVectorLength(SolusEnvironment env) =>
                 GetDimension(env, 0);
 
             public bool IsConcrete => false;

--- a/IMathObject.cs
+++ b/IMathObject.cs
@@ -45,9 +45,9 @@ namespace MetaphysicsIndustries.Solus
         public bool? IsMatrix(SolusEnvironment env) => false;
         public int? GetTensorRank(SolusEnvironment env) => 0;
         public bool? IsString(SolusEnvironment env) => false;
-        public int? GetDimension(SolusEnvironment env, int index) => 0;
+        public int? GetDimension(SolusEnvironment env, int index) => null;
         public int[] GetDimensions(SolusEnvironment env) => null;
-        public int? GetVectorLength(SolusEnvironment env) => 0;
+        public int? GetVectorLength(SolusEnvironment env) => null;
         public bool IsConcrete => false;
     }
 }

--- a/IMathObject.cs
+++ b/IMathObject.cs
@@ -36,7 +36,7 @@ namespace MetaphysicsIndustries.Solus
 
         bool IsConcrete { get; }
     }
-    
+
     public class ScalarMathObject : IMathObject
     {
         public static readonly ScalarMathObject Value = new ScalarMathObject();

--- a/IMathObject.cs
+++ b/IMathObject.cs
@@ -24,30 +24,30 @@ namespace MetaphysicsIndustries.Solus
 {
     public interface IMathObject
     {
-        bool IsScalar(SolusEnvironment env);
-        bool IsVector(SolusEnvironment env);
-        bool IsMatrix(SolusEnvironment env);
-        int GetTensorRank(SolusEnvironment env);
-        bool IsString(SolusEnvironment env);
-        int GetDimension(SolusEnvironment env, int index);
+        bool? IsScalar(SolusEnvironment env);
+        bool? IsVector(SolusEnvironment env);
+        bool? IsMatrix(SolusEnvironment env);
+        int? GetTensorRank(SolusEnvironment env);
+        bool? IsString(SolusEnvironment env);
+        int? GetDimension(SolusEnvironment env, int index);
         int[] GetDimensions(SolusEnvironment env);
-        int GetVectorLength(SolusEnvironment env);
-        // TODO: int GetStringLength(SolusEnvironment env);
+        int? GetVectorLength(SolusEnvironment env);
+        // TODO: int? GetStringLength(SolusEnvironment env);
 
         bool IsConcrete { get; }
     }
-
+    
     public class ScalarMathObject : IMathObject
     {
         public static readonly ScalarMathObject Value = new ScalarMathObject();
-        public bool IsScalar(SolusEnvironment env) => true;
-        public bool IsVector(SolusEnvironment env) => false;
-        public bool IsMatrix(SolusEnvironment env) => false;
-        public int GetTensorRank(SolusEnvironment env) => 0;
-        public bool IsString(SolusEnvironment env) => false;
-        public int GetDimension(SolusEnvironment env, int index) => 0;
+        public bool? IsScalar(SolusEnvironment env) => true;
+        public bool? IsVector(SolusEnvironment env) => false;
+        public bool? IsMatrix(SolusEnvironment env) => false;
+        public int? GetTensorRank(SolusEnvironment env) => 0;
+        public bool? IsString(SolusEnvironment env) => false;
+        public int? GetDimension(SolusEnvironment env, int index) => 0;
         public int[] GetDimensions(SolusEnvironment env) => null;
-        public int GetVectorLength(SolusEnvironment env) => 0;
+        public int? GetVectorLength(SolusEnvironment env) => 0;
         public bool IsConcrete => false;
     }
 }

--- a/MathObjectHelper.cs
+++ b/MathObjectHelper.cs
@@ -27,7 +27,6 @@ namespace MetaphysicsIndustries.Solus
 {
     public static class MathObjectHelper
     {
-        
         public static bool IsIsScalar(this IMathObject mo,
             SolusEnvironment env)
         {
@@ -98,7 +97,7 @@ namespace MetaphysicsIndustries.Solus
 
         public static IMathObject[,] ToMathObjects(this float[,] values)
         {
-            var result = new IMathObject[values.GetLength(0), 
+            var result = new IMathObject[values.GetLength(0),
                 values.GetLength(1)];
             // TODO: faster
             // TODO: row first or column first?

--- a/MathObjectHelper.cs
+++ b/MathObjectHelper.cs
@@ -21,8 +21,9 @@
  */
 
 using System.Linq;
+using MetaphysicsIndustries.Solus.Values;
 
-namespace MetaphysicsIndustries.Solus.Values
+namespace MetaphysicsIndustries.Solus
 {
     public static class MathObjectHelper
     {

--- a/MetaphysicsIndustries.Solus.Test/EnvironmentT/ChildTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EnvironmentT/ChildTest.cs
@@ -30,7 +30,6 @@ namespace MetaphysicsIndustries.Solus.Test.EnvironmentT
     [TestFixture]
     public class ChildTest
     {
-        
         [Test]
         public void CreateChildEnvironmentCreatesChildEnvironment()
         {
@@ -49,7 +48,7 @@ namespace MetaphysicsIndustries.Solus.Test.EnvironmentT
             Assert.Contains("a", parent.GetVariableNames().ToList());
             Assert.AreEqual(0, parent.CountFunctions());
             Assert.AreEqual(0, parent.CountMacros());
-            
+
             Assert.AreEqual(1, child.CountVariables());
             Assert.Contains("a", child.GetVariableNames().ToList());
             Assert.AreEqual(0, child.CountFunctions());

--- a/MetaphysicsIndustries.Solus.Test/EnvironmentT/CloneTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EnvironmentT/CloneTest.cs
@@ -48,7 +48,7 @@ namespace MetaphysicsIndustries.Solus.Test.EnvironmentT
             Assert.Contains("a", original.GetVariableNames().ToList());
             Assert.AreEqual(0, original.CountFunctions());
             Assert.AreEqual(0, original.CountMacros());
-            
+
             Assert.AreEqual(1, clone.CountVariables());
             Assert.Contains("a", clone.GetVariableNames().ToList());
             Assert.AreEqual(0, clone.CountFunctions());
@@ -63,16 +63,16 @@ namespace MetaphysicsIndustries.Solus.Test.EnvironmentT
             original.SetVariable("a", new Literal(1));
             var clone = original.Clone();
             // precondition
-            Assert.AreEqual(1, 
+            Assert.AreEqual(1,
                 ((Literal)original.GetVariable("a")).Value.ToFloat());
-            Assert.AreEqual(1, 
+            Assert.AreEqual(1,
                 ((Literal)clone.GetVariable("a")).Value.ToFloat());
             // when
             ((Literal) original.GetVariable("a")).Value = 2.ToNumber();
             // then
-            Assert.AreEqual(2, 
+            Assert.AreEqual(2,
                 ((Literal)original.GetVariable("a")).Value.ToFloat());
-            Assert.AreEqual(2, 
+            Assert.AreEqual(2,
                 ((Literal)clone.GetVariable("a")).Value.ToFloat());
         }
 

--- a/MetaphysicsIndustries.Solus.Test/EnvironmentT/EnvironmentTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EnvironmentT/EnvironmentTest.cs
@@ -71,7 +71,7 @@ namespace MetaphysicsIndustries.Solus.Test.EnvironmentT
         [Test]
         public void UseDefaultsTrueAddsDefaultItems()
         {
-            // when 
+            // when
             var result = new SolusEnvironment(useDefaults: true);
             // then
             Assert.AreEqual(0, result.CountVariables());

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/ColorExpressionT/ResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/ColorExpressionT/ResultTest.cs
@@ -43,6 +43,9 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ColorExpressionT
             Assert.IsFalse(result.IsMatrix(env));
             Assert.AreEqual(0, result.GetTensorRank(env));
             Assert.IsFalse(result.IsString(env));
+            Assert.IsNull(result.GetDimension(env, 0));
+            Assert.IsNull(result.GetDimensions(env));
+            Assert.IsNull(result.GetVectorLength(env));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/ComponentAccessT/ResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/ComponentAccessT/ResultTest.cs
@@ -29,7 +29,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
     public class ResultTest
     {
         [Test]
-        public void IsResultScalarDelegatesToComponent1()
+        public void IsResultScalarYieldsNull1()
         {
             // given
             var expr = new ComponentAccess(
@@ -37,20 +37,22 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
                     new MockExpression(
                         result: new MockMathObjectF(
                             isScalarF: e => false)),
-                    new MockExpression(result: new MockMathObjectF(
-                        isScalarF: e => true)),
-                    new MockExpression(result: new MockMathObjectF(
-                        isScalarF: e => false))),
+                    new MockExpression(
+                        result: new MockMathObjectF(
+                            isScalarF: e => true)),
+                    new MockExpression(
+                        result: new MockMathObjectF(
+                            isScalarF: e => false))),
                 new[] { new Literal(1) });
             var env = new SolusEnvironment();
             // when
             var result = expr.Result.IsScalar(env);
             // then
-            Assert.IsTrue(result);
+            Assert.IsNull(result);
         }
 
         [Test]
-        public void IsResultScalarDelegatesToComponent2()
+        public void IsResultScalarYieldsNull2()
         {
             // given
             var expr = new ComponentAccess(
@@ -67,11 +69,11 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = expr.Result.IsScalar(env);
             // then
-            Assert.IsFalse(result);
+            Assert.IsNull(result);
         }
 
         [Test]
-        public void IsResultVectorDelegatesToComponent1()
+        public void IsResultVectorYieldsNull1()
         {
             // given
             var expr = new ComponentAccess(
@@ -90,11 +92,11 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = expr.Result.IsVector(env);
             // then
-            Assert.IsTrue(result);
+            Assert.IsNull(result);
         }
 
         [Test]
-        public void IsResultVectorDelegatesToComponent2()
+        public void IsResultVectorYieldsNull2()
         {
             // given
             var expr = new ComponentAccess(
@@ -113,11 +115,11 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = expr.Result.IsVector(env);
             // then
-            Assert.IsFalse(result);
+            Assert.IsNull(result);
         }
 
         [Test]
-        public void IsResultMatrixDelegatesToComponent1()
+        public void IsResultMatrixYieldsNull1()
         {
             // given
             var expr = new ComponentAccess(
@@ -136,11 +138,11 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = expr.Result.IsMatrix(env);
             // then
-            Assert.IsTrue(result);
+            Assert.IsNull(result);
         }
 
         [Test]
-        public void IsResultMatrixDelegatesToComponent2()
+        public void IsResultMatrixYieldsNull2()
         {
             // given
             var expr = new ComponentAccess(
@@ -159,11 +161,11 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = expr.Result.IsMatrix(env);
             // then
-            Assert.IsFalse(result);
+            Assert.IsNull(result);
         }
 
         [Test]
-        public void IsResultStringDelegatesToComponent1()
+        public void IsResultStringYieldsNull1()
         {
             // given
             var expr = new ComponentAccess(
@@ -182,11 +184,11 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = expr.Result.IsString(env);
             // then
-            Assert.IsTrue(result);
+            Assert.IsNull(result);
         }
 
         [Test]
-        public void IsResultStringDelegatesToComponent2()
+        public void IsResultStringYieldsNull2()
         {
             // given
             var expr = new ComponentAccess(
@@ -205,11 +207,11 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = expr.Result.IsString(env);
             // then
-            Assert.IsFalse(result);
+            Assert.IsNull(result);
         }
 
         [Test]
-        public void GetResultTensorRankDelegatesToComponent1()
+        public void GetResultTensorRankYieldsNull1()
         {
             // given
             var expr = new ComponentAccess(
@@ -228,11 +230,11 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = expr.Result.GetTensorRank(env);
             // then
-            Assert.AreEqual(2, result);
+            Assert.IsNull(result);
         }
 
         [Test]
-        public void GetResultTensorRankDelegatesToComponent2()
+        public void GetResultTensorRankYieldsNull2()
         {
             // given
             var expr = new ComponentAccess(
@@ -251,11 +253,11 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = expr.Result.GetTensorRank(env);
             // then
-            Assert.AreEqual(1, result);
+            Assert.IsNull(result);
         }
 
         [Test]
-        public void GetResultDimensionDelegatesToComponent()
+        public void GetResultDimensionYieldsNull()
         {
             // given
             var expr = new ComponentAccess(
@@ -274,11 +276,11 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = expr.Result.GetDimension(env, 0);
             // then
-            Assert.AreEqual(2, result);
+            Assert.IsNull(result);
         }
 
         [Test]
-        public void GetResultDimensionsDelegatesToComponent()
+        public void GetResultDimensionsYieldsNull()
         {
             // given
             var one = new[] { 1, 1, 1 };
@@ -299,11 +301,11 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = expr.Result.GetDimensions(env);
             // then
-            Assert.AreEqual(new[] { 2, 2, 2 }, result);
+            Assert.IsNull(result);
         }
 
         [Test]
-        public void GetResultVectorLengthDelegatesToComponent()
+        public void GetResultVectorLengthYieldsNull()
         {
             // given
             var expr = new ComponentAccess(
@@ -322,11 +324,11 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = expr.Result.GetVectorLength(env);
             // then
-            Assert.AreEqual(2, result);
+            Assert.IsNull(result);
         }
 
         [Test]
-        public void DelegatesToMatrixComponent()
+        public void MatrixComponentYieldsNull()
         {
             // given
             var expr = new ComponentAccess(
@@ -348,12 +350,11 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = expr.Result.IsScalar(env);
             // then
-            Assert.IsTrue(result);
+            Assert.IsNull(result);
         }
 
         [Test]
-        [Ignore("Can't check index against string length yet")]
-        public void DelegatesToStringComponent()
+        public void StringComponentYieldsNull()
         {
             // given
             var expr = new ComponentAccess(
@@ -369,13 +370,13 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = expr.Result.IsString(env);
             // then
-            Assert.IsTrue(result);
+            Assert.IsNull(result);
         }
+
         // scalar?
         // vector
         // matrix
         // mock tensor?
         // Literal with string value
-
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/RandomExpressionT/ResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/RandomExpressionT/ResultTest.cs
@@ -42,6 +42,9 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.RandomExpressionT
             Assert.IsFalse(result.IsMatrix(env));
             Assert.AreEqual(0, result.GetTensorRank(env));
             Assert.IsFalse(result.IsString(env));
+            Assert.IsNull(result.GetDimension(env, 0));
+            Assert.IsNull(result.GetDimensions(env));
+            Assert.IsNull(result.GetVectorLength(env));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/VariableAccessT/ResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/VariableAccessT/ResultTest.cs
@@ -108,5 +108,24 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.VariableAccessT
             Assert.AreEqual(0, result.GetTensorRank(env));
             Assert.IsTrue(result.IsString(env));
         }
+
+        [Test]
+        public void MissingVariableYieldsNull()
+        {
+            // given
+            var expr = new VariableAccess("a");
+            var env = new SolusEnvironment();  // no "a"
+            // when
+            var result = expr.Result;
+            // then
+            Assert.IsNull(result.IsScalar(env));
+            Assert.IsNull(result.IsVector(env));
+            Assert.IsNull(result.IsMatrix(env));
+            Assert.IsNull(result.GetTensorRank(env));
+            Assert.IsNull(result.IsString(env));
+            Assert.IsNull(result.GetDimension(env, 0));
+            Assert.IsNull(result.GetDimensions(env));
+            Assert.IsNull(result.GetVectorLength(env));
+        }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/VectorExpressionT/ResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/VectorExpressionT/ResultTest.cs
@@ -46,7 +46,9 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.VectorExpressionT
             Assert.IsFalse(result.IsMatrix(env));
             Assert.AreEqual(1, result.GetTensorRank(env));
             Assert.IsFalse(result.IsString(env));
+            Assert.IsNull(result.GetDimension(env, -1));
             Assert.AreEqual(4, result.GetDimension(env, 0));
+            Assert.IsNull(result.GetDimension(env, 1));
             Assert.AreEqual(new int[] { 4 },
                 result.GetDimensions(env));
             Assert.AreEqual(4, result.GetVectorLength(env));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/LoadImageFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/LoadImageFunctionT/GetResultTest.cs
@@ -31,7 +31,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.LoadImageFunctionT
     public class GetResultTest
     {
         [Test]
-        public void ResultIsScalar()
+        public void ResultIsMatrixOfUnknownSize()
         {
             // given
             var arg1 = 1.ToNumber();
@@ -42,9 +42,20 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.LoadImageFunctionT
             Assert.IsFalse(arg1.IsMatrix(null));
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
-            // expect
-            Assert.Throws<NotImplementedException>(
-                () => LoadImageFunction.Value.GetResult(args));
+            // when
+            var result = LoadImageFunction.Value.GetResult(args);
+            // then
+            Assert.IsFalse(result.IsScalar(null));
+            Assert.IsFalse(result.IsVector(null));
+            Assert.IsTrue(result.IsMatrix(null));
+            Assert.AreEqual(2, result.GetTensorRank(null));
+            Assert.IsFalse(result.IsString(null));
+            Assert.IsNull(result.GetDimension(null, -1));
+            Assert.IsNull(result.GetDimension(null, 0));
+            Assert.IsNull(result.GetDimension(null, 1));
+            Assert.IsNull(result.GetDimension(null, 2));
+            Assert.IsNull(result.GetDimensions(null));
+            Assert.IsNull(result.GetVectorLength(null));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/MockMathObject.cs
+++ b/MetaphysicsIndustries.Solus.Test/MockMathObject.cs
@@ -44,26 +44,26 @@ namespace MetaphysicsIndustries.Solus.Test
         }
 
         private readonly bool _isScalar;
-        public bool IsScalar(SolusEnvironment env) => _isScalar;
+        public bool? IsScalar(SolusEnvironment env) => _isScalar;
 
         private readonly bool _isVector;
-        public bool IsVector(SolusEnvironment env) => _isVector;
+        public bool? IsVector(SolusEnvironment env) => _isVector;
 
         private readonly bool _isMatrix;
-        public bool IsMatrix(SolusEnvironment env) => _isMatrix;
+        public bool? IsMatrix(SolusEnvironment env) => _isMatrix;
 
         private readonly int _tensorRank;
-        public int GetTensorRank(SolusEnvironment env) => _tensorRank;
+        public int? GetTensorRank(SolusEnvironment env) => _tensorRank;
 
         private readonly bool _isString;
-        public bool IsString(SolusEnvironment env) => _isString;
+        public bool? IsString(SolusEnvironment env) => _isString;
 
         private readonly int[] _dimensions;
-        public int GetDimension(SolusEnvironment env, int index) =>
+        public int? GetDimension(SolusEnvironment env, int index) =>
             _dimensions[index];
         public int[] GetDimensions(SolusEnvironment env) => _dimensions;
 
-        public int GetVectorLength(SolusEnvironment env) =>
+        public int? GetVectorLength(SolusEnvironment env) =>
             throw new NotImplementedException();
 
         private readonly bool _isConcrete;

--- a/MetaphysicsIndustries.Solus.Test/MockMathObjectF.cs
+++ b/MetaphysicsIndustries.Solus.Test/MockMathObjectF.cs
@@ -50,42 +50,42 @@ namespace MetaphysicsIndustries.Solus.Test
         }
 
         public Func<SolusEnvironment, bool> IsScalarF;
-        public bool IsScalar(SolusEnvironment env)
+        public bool? IsScalar(SolusEnvironment env)
         {
             if (IsScalarF != null) return IsScalarF(env);
             throw new NotImplementedException();
         }
 
         public Func<SolusEnvironment, bool> IsVectorF;
-        public bool IsVector(SolusEnvironment env)
+        public bool? IsVector(SolusEnvironment env)
         {
             if (IsVectorF != null) return IsVectorF(env);
             throw new NotImplementedException();
         }
 
         public Func<SolusEnvironment, bool> IsMatrixF;
-        public bool IsMatrix(SolusEnvironment env)
+        public bool? IsMatrix(SolusEnvironment env)
         {
             if (IsMatrixF != null) return IsMatrixF(env);
             throw new NotImplementedException();
         }
 
         public Func<SolusEnvironment, int> GetTensorRankF;
-        public int GetTensorRank(SolusEnvironment env)
+        public int? GetTensorRank(SolusEnvironment env)
         {
             if (GetTensorRankF != null) return GetTensorRankF(env);
             throw new NotImplementedException();
         }
 
         public Func<SolusEnvironment, bool> IsStringF;
-        public bool IsString(SolusEnvironment env)
+        public bool? IsString(SolusEnvironment env)
         {
             if (IsStringF != null) return IsStringF(env);
             throw new NotImplementedException();
         }
 
         public Func<SolusEnvironment, int, int> GetDimensionF;
-        public int GetDimension(SolusEnvironment env, int index)
+        public int? GetDimension(SolusEnvironment env, int index)
         {
             if (GetDimensionF != null) return GetDimensionF(env, index);
             throw new NotImplementedException();
@@ -99,7 +99,7 @@ namespace MetaphysicsIndustries.Solus.Test
         }
 
         public Func<SolusEnvironment, int> GetVectorLengthF;
-        public int GetVectorLength(SolusEnvironment env)
+        public int? GetVectorLength(SolusEnvironment env)
         {
             if (GetVectorLengthF != null) return GetVectorLengthF(env);
             throw new NotImplementedException();

--- a/MetaphysicsIndustries.Solus.Test/ValuesT/MatrixT/MatrixTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ValuesT/MatrixT/MatrixTest.cs
@@ -56,18 +56,8 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.MatrixT
             Assert.IsFalse(result.IsString(null));
             Assert.AreEqual(2, result.GetDimension(null, 0));
             Assert.AreEqual(2, result.GetDimension(null, 1));
-            var ex = Assert.Throws<ArgumentOutOfRangeException>(
-                () => result.GetDimension(null, -1));
-            Assert.AreEqual("index", ex.ParamName);
-            Assert.AreEqual("Index must not be negative\n" +
-                            "Parameter name: index",
-                ex.Message);
-            ex = Assert.Throws<ArgumentOutOfRangeException>(
-                () => result.GetDimension(null, 3));
-            Assert.AreEqual("index", ex.ParamName);
-            Assert.AreEqual("Matrices only have two dimensions\n" +
-                            "Parameter name: index",
-                ex.Message);
+            Assert.IsNull(result.GetDimension(null, -1));
+            Assert.IsNull(result.GetDimension(null, 3));
             Assert.AreEqual(new[] {2, 2}, result.GetDimensions(null));
         }
 

--- a/MetaphysicsIndustries.Solus.Test/ValuesT/NumberT/NumberTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ValuesT/NumberT/NumberTest.cs
@@ -41,10 +41,8 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.NumberT
             Assert.IsFalse(result.IsMatrix(null));
             Assert.AreEqual(0, result.GetTensorRank(null));
             Assert.IsFalse(result.IsString(null));
-            Assert.Throws<InvalidOperationException>(
-                () => result.GetDimension(null, 0));
-            Assert.Throws<InvalidOperationException>(
-                () => result.GetDimensions(null));
+            Assert.IsNull(result.GetDimension(null, 0));
+            Assert.IsNull(result.GetDimensions(null));
         }
 
         [Test]

--- a/MetaphysicsIndustries.Solus.Test/ValuesT/StringValueT/StringValueTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ValuesT/StringValueT/StringValueTest.cs
@@ -63,28 +63,16 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.StringValueT
             // given
             var value = new StringValue("abc");
             // expect
-            var ex = Assert.Throws<ArgumentOutOfRangeException>(
-                () => value.GetDimension(null, -1));
-            // and
-            Assert.AreEqual("index", ex.ParamName);
-            Assert.AreEqual("Index must not be negative\n" +
-                            "Parameter name: index",
-                ex.Message);
+            Assert.IsNull(value.GetDimension(null, -1));
         }
 
         [Test]
-        public void GetDimensionIndexTooLargeThrows()
+        public void GetDimensionIndexTooLargeYieldsNull()
         {
             // given
             var value = new StringValue("abc");
             // expect
-            var ex = Assert.Throws<ArgumentOutOfRangeException>(
-                () => value.GetDimension(null, 1));
-            // and
-            Assert.AreEqual("index", ex.ParamName);
-            Assert.AreEqual("Strings only have a single dimension\n" +
-                            "Parameter name: index",
-                ex.Message);
+            Assert.IsNull(value.GetDimension(null, 1));
         }
 
         [Test]

--- a/MetaphysicsIndustries.Solus.Test/ValuesT/VectorT/VectorTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ValuesT/VectorT/VectorTest.cs
@@ -49,18 +49,8 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.VectorT
             Assert.AreEqual(1, result.GetTensorRank(null));
             Assert.IsFalse(result.IsString(null));
             Assert.AreEqual(3, result.GetDimension(null, 0));
-            var ex = Assert.Throws<ArgumentOutOfRangeException>(
-                () => result.GetDimension(null, -1));
-            Assert.AreEqual("index", ex.ParamName);
-            Assert.AreEqual("Index must not be negative\n" +
-                            "Parameter name: index",
-                ex.Message);
-            ex = Assert.Throws<ArgumentOutOfRangeException>(
-                () => result.GetDimension(null, 2));
-            Assert.AreEqual("index", ex.ParamName);
-            Assert.AreEqual("Vectors only have a single dimension\n" +
-                            "Parameter name: index",
-                ex.Message);
+            Assert.IsNull(result.GetDimension(null, -1));
+            Assert.IsNull(result.GetDimension(null, 2));
             Assert.AreEqual(new[] {3}, result.GetDimensions(null));
         }
 

--- a/MetaphysicsIndustries.Solus.csproj
+++ b/MetaphysicsIndustries.Solus.csproj
@@ -144,6 +144,7 @@
     <Compile Include="Macros\RandMacro.cs" />
     <Compile Include="Macros\SqrtMacro.cs" />
     <Compile Include="Macros\SubstMacro.cs" />
+    <Compile Include="MathObjectHelper.cs" />
     <Compile Include="Settings.cs" />
     <Compile Include="SolusEngine.Statistics.cs" />
     <Compile Include="SolusEngine.Eval.cs" />
@@ -170,7 +171,6 @@
     <Compile Include="Transformers\VariableTransformArgs.cs" />
     <Compile Include="STuple.cs" />
     <Compile Include="MemoryImage.cs" />
-    <Compile Include="Values\MathObjectHelper.cs" />
     <Compile Include="Values\Matrix.cs" />
     <Compile Include="Values\Number.cs" />
     <Compile Include="Values\StringValue.cs" />

--- a/SolusGrammar.giza
+++ b/SolusGrammar.giza
@@ -44,9 +44,9 @@ expr = subexpr ( binop subexpr )*;
 function-call = identifier:name '(' ( expr:arg ( ',' expr:arg )* )? ')';
 
 <ignore case, token> number = (
-    '0b' [01]+ | 
-    '0o' [01234567]+ | 
-    '0x' [\dabcdef]+ | 
+    '0b' [01]+ |
+    '0o' [01234567]+ |
+    '0x' [\dabcdef]+ |
      float-number
 );
 

--- a/Values/MathObjectHelper.cs
+++ b/Values/MathObjectHelper.cs
@@ -26,6 +26,32 @@ namespace MetaphysicsIndustries.Solus.Values
 {
     public static class MathObjectHelper
     {
+        
+        public static bool IsIsScalar(this IMathObject mo,
+            SolusEnvironment env)
+        {
+            var iss = mo.IsScalar(env);
+            return iss.HasValue && iss.Value;
+        }
+        public static bool IsIsVector(this IMathObject mo,
+            SolusEnvironment env)
+        {
+            var iss = mo.IsVector(env);
+            return iss.HasValue && iss.Value;
+        }
+        public static bool IsIsMatrix(this IMathObject mo,
+            SolusEnvironment env)
+        {
+            var iss = mo.IsMatrix(env);
+            return iss.HasValue && iss.Value;
+        }
+        public static bool IsIsString(this IMathObject mo,
+            SolusEnvironment env)
+        {
+            var iss = mo.IsString(env);
+            return iss.HasValue && iss.Value;
+        }
+
         public static Number ToNumber(this IMathObject mo) => (Number) mo;
 
         public static StringValue ToStringValue(this IMathObject mo) =>
@@ -56,10 +82,10 @@ namespace MetaphysicsIndustries.Solus.Values
         public static Types GetMathType(this IMathObject mo,
             SolusEnvironment env=null)
         {
-            if (mo.IsScalar(env)) return Types.Scalar;
-            if (mo.IsVector(env)) return Types.Vector;
-            if (mo.IsMatrix(env)) return Types.Matrix;
-            if (mo.IsString(env)) return Types.String;
+            if (mo.IsIsScalar(env)) return Types.Scalar;
+            if (mo.IsIsVector(env)) return Types.Vector;
+            if (mo.IsIsMatrix(env)) return Types.Matrix;
+            if (mo.IsIsString(env)) return Types.String;
             return Types.Unknown;
         }
 

--- a/Values/Matrix.cs
+++ b/Values/Matrix.cs
@@ -58,13 +58,13 @@ namespace MetaphysicsIndustries.Solus.Values
         public int ColumnCount => _components.GetLength(1);
         public Types ComponentType { get; }
 
-        public bool IsScalar(SolusEnvironment env) => false;
-        public bool IsVector(SolusEnvironment env) => false;
-        public bool IsMatrix(SolusEnvironment env) => true;
-        public int GetTensorRank(SolusEnvironment env) => 2;
-        public bool IsString(SolusEnvironment env) => false;
+        public bool? IsScalar(SolusEnvironment env) => false;
+        public bool? IsVector(SolusEnvironment env) => false;
+        public bool? IsMatrix(SolusEnvironment env) => true;
+        public int? GetTensorRank(SolusEnvironment env) => 2;
+        public bool? IsString(SolusEnvironment env) => false;
 
-        public int GetDimension(SolusEnvironment env, int index)
+        public int? GetDimension(SolusEnvironment env, int index)
         {
             if (index < 0)
                 throw new ArgumentOutOfRangeException(nameof(index),
@@ -78,7 +78,7 @@ namespace MetaphysicsIndustries.Solus.Values
         public int[] GetDimensions(SolusEnvironment env) =>
             new[] { RowCount, ColumnCount };
 
-        public int GetVectorLength(SolusEnvironment env) =>
+        public int? GetVectorLength(SolusEnvironment env) =>
             throw new InvalidOperationException(
                 "A matrix is not a vector");
 

--- a/Values/Matrix.cs
+++ b/Values/Matrix.cs
@@ -66,21 +66,15 @@ namespace MetaphysicsIndustries.Solus.Values
 
         public int? GetDimension(SolusEnvironment env, int index)
         {
-            if (index < 0)
-                throw new ArgumentOutOfRangeException(nameof(index),
-                    "Index must not be negative");
-            if (index > 1)
-                throw new ArgumentOutOfRangeException(nameof(index),
-                    "Matrices only have two dimensions");
+            if (index < 0) return null;
+            if (index > 1) return null;
             return _components.GetLength(index);
         }
 
         public int[] GetDimensions(SolusEnvironment env) =>
             new[] { RowCount, ColumnCount };
 
-        public int? GetVectorLength(SolusEnvironment env) =>
-            throw new InvalidOperationException(
-                "A matrix is not a vector");
+        public int? GetVectorLength(SolusEnvironment env) => null;
 
         public bool IsConcrete => true;
 

--- a/Values/Number.cs
+++ b/Values/Number.cs
@@ -38,23 +38,9 @@ namespace MetaphysicsIndustries.Solus.Values
         public bool? IsMatrix(SolusEnvironment env) => false;
         public int? GetTensorRank(SolusEnvironment env) => 0;
         public bool? IsString(SolusEnvironment env) => false;
-
-        public int? GetDimension(SolusEnvironment env, int index)
-        {
-            throw new InvalidOperationException(
-                "Scalars do not have dimensions");
-        }
-
-        public int[] GetDimensions(SolusEnvironment env)
-        {
-            throw new InvalidOperationException(
-                "Scalars do not have dimensions");
-        }
-
-        public int? GetVectorLength(SolusEnvironment env) =>
-            throw new InvalidOperationException(
-                "A number is not a vector");
-
+        public int? GetDimension(SolusEnvironment env, int index) => null;
+        public int[] GetDimensions(SolusEnvironment env) => null;
+        public int? GetVectorLength(SolusEnvironment env) => null;
         public bool IsConcrete => true;
 
         public override string ToString()

--- a/Values/Number.cs
+++ b/Values/Number.cs
@@ -33,13 +33,13 @@ namespace MetaphysicsIndustries.Solus.Values
 
         public float Value { get; }
 
-        public bool IsScalar(SolusEnvironment env) => true;
-        public bool IsVector(SolusEnvironment env) => false;
-        public bool IsMatrix(SolusEnvironment env) => false;
-        public int GetTensorRank(SolusEnvironment env) => 0;
-        public bool IsString(SolusEnvironment env) => false;
+        public bool? IsScalar(SolusEnvironment env) => true;
+        public bool? IsVector(SolusEnvironment env) => false;
+        public bool? IsMatrix(SolusEnvironment env) => false;
+        public int? GetTensorRank(SolusEnvironment env) => 0;
+        public bool? IsString(SolusEnvironment env) => false;
 
-        public int GetDimension(SolusEnvironment env, int index)
+        public int? GetDimension(SolusEnvironment env, int index)
         {
             throw new InvalidOperationException(
                 "Scalars do not have dimensions");
@@ -51,7 +51,7 @@ namespace MetaphysicsIndustries.Solus.Values
                 "Scalars do not have dimensions");
         }
 
-        public int GetVectorLength(SolusEnvironment env) =>
+        public int? GetVectorLength(SolusEnvironment env) =>
             throw new InvalidOperationException(
                 "A number is not a vector");
 

--- a/Values/StringValue.cs
+++ b/Values/StringValue.cs
@@ -43,12 +43,8 @@ namespace MetaphysicsIndustries.Solus.Values
 
         public int? GetDimension(SolusEnvironment env, int index)
         {
-            if (index < 0)
-                throw new ArgumentOutOfRangeException(nameof(index),
-                    "Index must not be negative");
-            if (index > 0)
-                throw new ArgumentOutOfRangeException(nameof(index),
-                    "Strings only have a single dimension");
+            if (index < 0) return null;
+            if (index > 0) return null;
             return Length;
         }
 
@@ -57,10 +53,7 @@ namespace MetaphysicsIndustries.Solus.Values
             return new[] {Length};
         }
 
-        public int? GetVectorLength(SolusEnvironment env) =>
-            throw new InvalidOperationException(
-                "A string is not a vector");
-
+        public int? GetVectorLength(SolusEnvironment env) => null;
         public bool IsConcrete => true;
 
         public int Length => Value?.Length ?? 0;

--- a/Values/StringValue.cs
+++ b/Values/StringValue.cs
@@ -33,15 +33,15 @@ namespace MetaphysicsIndustries.Solus.Values
 
         public readonly string Value;
 
-        public bool IsScalar(SolusEnvironment env) => false;
-        public bool IsVector(SolusEnvironment env) => false;
-        public bool IsMatrix(SolusEnvironment env) => false;
-        public int GetTensorRank(SolusEnvironment env) => 0;
+        public bool? IsScalar(SolusEnvironment env) => false;
+        public bool? IsVector(SolusEnvironment env) => false;
+        public bool? IsMatrix(SolusEnvironment env) => false;
+        public int? GetTensorRank(SolusEnvironment env) => 0;
 
-        public bool IsString(SolusEnvironment env) => true;
+        public bool? IsString(SolusEnvironment env) => true;
         // TODO: IsTuple => true
 
-        public int GetDimension(SolusEnvironment env, int index)
+        public int? GetDimension(SolusEnvironment env, int index)
         {
             if (index < 0)
                 throw new ArgumentOutOfRangeException(nameof(index),
@@ -57,7 +57,7 @@ namespace MetaphysicsIndustries.Solus.Values
             return new[] {Length};
         }
 
-        public int GetVectorLength(SolusEnvironment env) =>
+        public int? GetVectorLength(SolusEnvironment env) =>
             throw new InvalidOperationException(
                 "A string is not a vector");
 

--- a/Values/Vector.cs
+++ b/Values/Vector.cs
@@ -60,12 +60,8 @@ namespace MetaphysicsIndustries.Solus.Values
 
         public int? GetDimension(SolusEnvironment env, int index)
         {
-            if (index < 0)
-                throw new ArgumentOutOfRangeException(nameof(index),
-                    "Index must not be negative");
-            if (index > 0)
-                throw new ArgumentOutOfRangeException(nameof(index),
-                    "Vectors only have a single dimension");
+            if (index < 0) return null;
+            if (index > 0) return null;
             return Length;
         }
 

--- a/Values/Vector.cs
+++ b/Values/Vector.cs
@@ -52,13 +52,13 @@ namespace MetaphysicsIndustries.Solus.Values
         public int Length => _components.Length;
         public Types ComponentType { get; }
 
-        public bool IsScalar(SolusEnvironment env) => false;
-        public bool IsVector(SolusEnvironment env) => true;
-        public bool IsMatrix(SolusEnvironment env) => false;
-        public int GetTensorRank(SolusEnvironment env) => 1;
-        public bool IsString(SolusEnvironment env) => false;
+        public bool? IsScalar(SolusEnvironment env) => false;
+        public bool? IsVector(SolusEnvironment env) => true;
+        public bool? IsMatrix(SolusEnvironment env) => false;
+        public int? GetTensorRank(SolusEnvironment env) => 1;
+        public bool? IsString(SolusEnvironment env) => false;
 
-        public int GetDimension(SolusEnvironment env, int index)
+        public int? GetDimension(SolusEnvironment env, int index)
         {
             if (index < 0)
                 throw new ArgumentOutOfRangeException(nameof(index),
@@ -70,7 +70,7 @@ namespace MetaphysicsIndustries.Solus.Values
         }
 
         public int[] GetDimensions(SolusEnvironment env) => new[] {Length};
-        public int GetVectorLength(SolusEnvironment env) => Length;
+        public int? GetVectorLength(SolusEnvironment env) => Length;
 
         public bool IsConcrete => true;
 

--- a/check_code_style.sh
+++ b/check_code_style.sh
@@ -18,6 +18,9 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
 # USA
 
+echo ""
+echo "Long lines:"
+
 #grep -n '................................................................................' $(find . -name \*.cs)
 git diff -U0 | \
     grep -v -e '^@@' -e '^diff --git' -e '^+++' -e '^---' -e '^-' | \
@@ -28,6 +31,17 @@ git diff --cached -U0 | \
     grep -n '[-+]................................................................................'
 #                12345678901234567890123456789012345678901234567890123456789012345678901234567890
 
+echo ""
+echo "Trailing whitespace:"
+
+git diff -U0 | \
+    grep -v -e '^@@' -e '^diff --git' -e '^+++' -e '^---' -e '^-' | \
+    grep -n '[ 	]$'  # space or literal tab
+git diff --cached -U0 | \
+    grep -v -e '^@@' -e '^diff --git' -e '^+++' -e '^---' -e '^-' | \
+    grep -n '[ 	]$'  # space or literal tab
+#grep -rnE '[ 	]$' \
+# $(git ls-files | grep -v -e 'solus/getline.cs' -e 'solus/NDesk.Options.cs')
 
 # TODO: check for tabs rather than spaces
 # TODO: check for trailing whitespace on lines


### PR DESCRIPTION
This PR modifies the `IMathObject` interface to allow all method to return `null`. A null return value indicates that the callee is not able to respond for some reason. For example, scalars do not have dimensions, so calls to `GetDimension` should not return any particular number. Now, in such a case, `GetDimension` should return `null`.