### PR TITLE
Intervals

### DIFF
--- a/Expressions/ComponentAccess.cs
+++ b/Expressions/ComponentAccess.cs
@@ -271,6 +271,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
             public int? GetDimension(SolusEnvironment env, int index) => null;
             public int[] GetDimensions(SolusEnvironment env) => null;
             public int? GetVectorLength(SolusEnvironment env) => null;
+            public bool? IsInterval(SolusEnvironment env) => false;
             public bool IsConcrete => false;
         }
 

--- a/Expressions/IExpressionVisitor.cs
+++ b/Expressions/IExpressionVisitor.cs
@@ -34,6 +34,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
         void Visit(MatrixExpression matrix);
         void Visit(VectorExpression vector);
         void Visit(ComponentAccess ca);
+        void Visit(IntervalExpression interval);
     }
 
     public class DelegateExpressionVisitor : IExpressionVisitor
@@ -47,6 +48,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
         public Action<MatrixExpression> MatrixVisitor = DoNothing;
         public Action<VectorExpression> VectorVisitor = DoNothing;
         public Action<ComponentAccess> ComponentAccessVisitor = DoNothing;
+        public Action<IntervalExpression> IntervalVisitor = DoNothing;
 
         public void Visit(Literal literal)
         {
@@ -79,6 +81,11 @@ namespace MetaphysicsIndustries.Solus.Expressions
         public void Visit(ComponentAccess ca)
         {
             ComponentAccessVisitor(ca);
+        }
+
+        public void Visit(IntervalExpression interval)
+        {
+            IntervalVisitor(interval);
         }
     }
 }

--- a/Expressions/IntervalExpression.cs
+++ b/Expressions/IntervalExpression.cs
@@ -1,0 +1,71 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2021 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Exceptions;
+using MetaphysicsIndustries.Solus.Values;
+
+namespace MetaphysicsIndustries.Solus.Expressions
+{
+    public class IntervalExpression : Expression
+    {
+        public IntervalExpression(Expression lowerBound, bool openLowerBound,
+            Expression upperBound, bool openUpperBound)
+        {
+            LowerBound = lowerBound;
+            OpenLowerBound = openLowerBound;
+            UpperBound = upperBound;
+            OpenUpperBound = openUpperBound;
+        }
+
+        public Expression LowerBound { get; }
+        public bool OpenLowerBound { get; }
+        public Expression UpperBound { get; }
+        public bool OpenUpperBound { get; }
+
+        public override IMathObject Eval(SolusEnvironment env)
+        {
+            var lower = LowerBound.Eval(env);
+            if (!lower.IsIsScalar(env))
+                throw new OperandException("Lower bound is not a scalar");
+            var upper = UpperBound.Eval(env);
+            if (!upper.IsIsScalar(env))
+                throw new OperandException("Upper bound is not a scalar");
+            return new Interval(lower.ToNumber().Value, OpenLowerBound,
+                upper.ToNumber().Value, OpenUpperBound, false);
+        }
+
+        public override Expression Clone()
+        {
+            return new IntervalExpression(LowerBound, OpenLowerBound,
+                UpperBound, OpenUpperBound);
+        }
+
+        public override void AcceptVisitor(IExpressionVisitor visitor)
+        {
+            visitor.Visit(this);
+            LowerBound.AcceptVisitor(visitor);
+            UpperBound.AcceptVisitor(visitor);
+        }
+
+        public override IMathObject Result => IntervalMathObject.Value;
+    }
+}

--- a/Expressions/MatrixExpression.cs
+++ b/Expressions/MatrixExpression.cs
@@ -783,6 +783,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
             }
 
             public int? GetVectorLength(SolusEnvironment env) => null;
+            public bool? IsInterval(SolusEnvironment env) => false;
 
             public bool IsConcrete => false;
         }

--- a/Expressions/RandomExpression.cs
+++ b/Expressions/RandomExpression.cs
@@ -58,6 +58,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
             public int? GetDimension(SolusEnvironment env, int index) => null;
             public int[] GetDimensions(SolusEnvironment env) => null;
             public int? GetVectorLength(SolusEnvironment env) => null;
+            public bool? IsInterval(SolusEnvironment env) => false;
             public bool IsConcrete => false;
         }
     }

--- a/Expressions/VariableAccess.cs
+++ b/Expressions/VariableAccess.cs
@@ -158,6 +158,13 @@ namespace MetaphysicsIndustries.Solus.Expressions
                 return varexpr.Result.GetVectorLength(env);
             }
 
+            public bool? IsInterval(SolusEnvironment env)
+            {
+                if (!env.ContainsVariable(_va.VariableName)) return null;
+                var varexpr = env.GetVariable(_va.VariableName);
+                return varexpr.Result.IsInterval(env);
+            }
+
             public bool IsConcrete => false;
         }
     }

--- a/Expressions/VectorExpression.cs
+++ b/Expressions/VectorExpression.cs
@@ -305,6 +305,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
             }
 
             public int? GetVectorLength(SolusEnvironment env) => _ve.Length;
+            public bool? IsInterval(SolusEnvironment env) => false;
 
             public bool IsConcrete => false;
         }

--- a/Functions/LoadImageFunction.cs
+++ b/Functions/LoadImageFunction.cs
@@ -76,6 +76,7 @@ namespace MetaphysicsIndustries.Solus.Functions
             public int? GetDimension(SolusEnvironment env, int index) => null;
             public int[] GetDimensions(SolusEnvironment env) => null;
             public int? GetVectorLength(SolusEnvironment env) => null;
+            public bool? IsInterval(SolusEnvironment env) => false;
             public bool IsConcrete => false;
         }
 

--- a/Functions/SizeFunction.cs
+++ b/Functions/SizeFunction.cs
@@ -107,6 +107,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             public int? GetVectorLength(SolusEnvironment env) =>
                 GetDimension(env, 0);
 
+            public bool? IsInterval(SolusEnvironment env) => false;
+
             public bool IsConcrete => false;
         }
 

--- a/IMathObject.cs
+++ b/IMathObject.cs
@@ -33,6 +33,7 @@ namespace MetaphysicsIndustries.Solus
         int[] GetDimensions(SolusEnvironment env);
         int? GetVectorLength(SolusEnvironment env);
         // TODO: int? GetStringLength(SolusEnvironment env);
+        bool? IsInterval(SolusEnvironment env);
 
         bool IsConcrete { get; }
     }
@@ -48,6 +49,8 @@ namespace MetaphysicsIndustries.Solus
         public int? GetDimension(SolusEnvironment env, int index) => null;
         public int[] GetDimensions(SolusEnvironment env) => null;
         public int? GetVectorLength(SolusEnvironment env) => null;
+        public bool? IsInterval(SolusEnvironment env) => false;
+
         public bool IsConcrete => false;
     }
 }

--- a/IMathObject.cs
+++ b/IMathObject.cs
@@ -53,4 +53,21 @@ namespace MetaphysicsIndustries.Solus
 
         public bool IsConcrete => false;
     }
+
+    public class IntervalMathObject : IMathObject
+    {
+        public static readonly IntervalMathObject Value =
+            new IntervalMathObject();
+        public bool? IsScalar(SolusEnvironment env) => false;
+        public bool? IsVector(SolusEnvironment env) => false;
+        public bool? IsMatrix(SolusEnvironment env) => false;
+        public int? GetTensorRank(SolusEnvironment env) => null;
+        public bool? IsString(SolusEnvironment env) => false;
+        public int? GetDimension(SolusEnvironment env, int index) => null;
+        public int[] GetDimensions(SolusEnvironment env) => null;
+        public int? GetVectorLength(SolusEnvironment env) => null;
+        public bool? IsInterval(SolusEnvironment env) => true;
+
+        public bool IsConcrete => false;
+    }
 }

--- a/MathObjectHelper.cs
+++ b/MathObjectHelper.cs
@@ -51,6 +51,12 @@ namespace MetaphysicsIndustries.Solus
             var iss = mo.IsString(env);
             return iss.HasValue && iss.Value;
         }
+        public static bool IsIsInterval(this IMathObject mo,
+            SolusEnvironment env)
+        {
+            var iss = mo.IsInterval(env);
+            return iss.HasValue && iss.Value;
+        }
 
         public static Number ToNumber(this IMathObject mo) => (Number) mo;
 

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/IntervalExpressionT/CloneTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/IntervalExpressionT/CloneTest.cs
@@ -1,0 +1,54 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2021 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Expressions;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.IntervalExpressionT
+{
+    [TestFixture]
+    public class CloneTest
+    {
+        [Test]
+        public void CloneCreatesNewDuplicateObject()
+        {
+            // given
+            var i = new IntervalExpression(
+                new Literal(1), false,
+                new Literal(2), false);
+            // when
+            var result0 = i.Clone();
+            // then
+            Assert.IsInstanceOf<IntervalExpression>(result0);
+            var result = (IntervalExpression)result0;
+            Assert.AreNotSame(i, result);
+
+            // shallow, for now
+            Assert.AreSame(i.LowerBound, result.LowerBound);
+            Assert.AreEqual(i.OpenLowerBound, result.OpenLowerBound);
+
+            // shallow, for now
+            Assert.AreSame(i.UpperBound, result.UpperBound);
+            Assert.AreEqual(i.OpenUpperBound, result.OpenUpperBound);
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/IntervalExpressionT/EvalTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/IntervalExpressionT/EvalTest.cs
@@ -1,0 +1,52 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2021 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Expressions;
+using MetaphysicsIndustries.Solus.Values;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.IntervalExpressionT
+{
+    [TestFixture]
+    public class EvalTest
+    {
+        [Test]
+        public void EvalYieldsConcreteInterval()
+        {
+            // given
+            var i = new IntervalExpression(
+                new Literal(1), true,
+                new Literal(2), true);
+            // when
+            var result = i.Eval(null);
+            // then
+            Assert.IsTrue(result.IsConcrete);
+            Assert.IsTrue(result.IsInterval(null));
+            Assert.IsInstanceOf<Interval>(result);
+            var interval = (Interval)result;
+            Assert.AreEqual(1, interval.LowerBound);
+            Assert.IsTrue(interval.OpenLowerBound);
+            Assert.AreEqual(2, interval.UpperBound);
+            Assert.IsTrue(interval.OpenUpperBound);
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/IntervalExpressionT/ResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/IntervalExpressionT/ResultTest.cs
@@ -1,0 +1,74 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2021 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Expressions;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.IntervalExpressionT
+{
+    [TestFixture]
+    public class ResultTest
+    {
+        [Test]
+        public void ResultIsInterval()
+        {
+            // given
+            var expr = new IntervalExpression(
+                new Literal(1), true,
+                new Literal(2), true);
+            var env = new SolusEnvironment();
+            // when
+            var result = expr.Result;
+            // then
+            Assert.IsFalse(result.IsScalar(env));
+            Assert.IsFalse(result.IsVector(env));
+            Assert.IsFalse(result.IsMatrix(env));
+            Assert.IsNull(result.GetTensorRank(env));
+            Assert.IsFalse(result.IsString(env));
+            Assert.IsNull(result.GetDimension(env, 0));
+            Assert.IsNull(result.GetDimensions(env));
+            Assert.IsNull(result.GetVectorLength(env));
+            Assert.IsTrue(result.IsInterval(env));
+        }
+        [Test]
+        public void ResultIsInterval2()
+        {
+            // given
+            var expr = new IntervalExpression(
+                new VariableAccess("a"), true,
+                new VariableAccess("b"), true);
+            var env = new SolusEnvironment();
+            // when
+            var result = expr.Result;
+            // then
+            Assert.IsFalse(result.IsScalar(env));
+            Assert.IsFalse(result.IsVector(env));
+            Assert.IsFalse(result.IsMatrix(env));
+            Assert.IsNull(result.GetTensorRank(env));
+            Assert.IsFalse(result.IsString(env));
+            Assert.IsNull(result.GetDimension(env, 0));
+            Assert.IsNull(result.GetDimensions(env));
+            Assert.IsNull(result.GetVectorLength(env));
+            Assert.IsTrue(result.IsInterval(env));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/MetaphysicsIndustries.Solus.Test.csproj
+++ b/MetaphysicsIndustries.Solus.Test/MetaphysicsIndustries.Solus.Test.csproj
@@ -44,6 +44,9 @@
     <Compile Include="ExpressionsT\ComponentAccessT\ResultTest.cs" />
     <Compile Include="ExpressionsT\DerivativeOfVariableT\ResultTest.cs" />
     <Compile Include="ExpressionsT\FunctionCallT\ResultTest.cs" />
+    <Compile Include="ExpressionsT\IntervalExpressionT\CloneTest.cs" />
+    <Compile Include="ExpressionsT\IntervalExpressionT\EvalTest.cs" />
+    <Compile Include="ExpressionsT\IntervalExpressionT\ResultTest.cs" />
     <Compile Include="ExpressionsT\LiteralT\ResultTest.cs" />
     <Compile Include="ExpressionsT\MatrixExpressionT\EvalTest.cs" />
     <Compile Include="ExpressionsT\MatrixExpressionT\ResultTest.cs" />

--- a/MetaphysicsIndustries.Solus.Test/MetaphysicsIndustries.Solus.Test.csproj
+++ b/MetaphysicsIndustries.Solus.Test/MetaphysicsIndustries.Solus.Test.csproj
@@ -157,10 +157,12 @@
     <Compile Include="MockMathObject.cs" />
     <Compile Include="SolusEngineT\LoadImageTest.cs" />
     <Compile Include="SolusParserT\SolusParserTest.cs" />
+    <Compile Include="ValuesT\IntervalT\IntervalTest.cs" />
     <Compile Include="ValuesT\MathObjectHelperT\MathObjectHelperTest.cs" />
     <Compile Include="ValuesT\MatrixT\MatrixTest.cs" />
     <Compile Include="ValuesT\NumberT\NumberTest.cs" />
     <Compile Include="ValuesT\StringValueT\StringValueTest.cs" />
+    <Compile Include="ValuesT\VarIntervalT\VarIntervalTest.cs" />
     <Compile Include="ValuesT\VectorT\VectorTest.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/MetaphysicsIndustries.Solus.Test/MetaphysicsIndustries.Solus.Test.csproj
+++ b/MetaphysicsIndustries.Solus.Test/MetaphysicsIndustries.Solus.Test.csproj
@@ -157,6 +157,7 @@
     <Compile Include="MockMathObject.cs" />
     <Compile Include="SolusEngineT\LoadImageTest.cs" />
     <Compile Include="SolusParserT\SolusParserTest.cs" />
+    <Compile Include="ValuesT\IntervalT\ContainsTest.cs" />
     <Compile Include="ValuesT\IntervalT\IntervalTest.cs" />
     <Compile Include="ValuesT\MathObjectHelperT\MathObjectHelperTest.cs" />
     <Compile Include="ValuesT\MatrixT\MatrixTest.cs" />

--- a/MetaphysicsIndustries.Solus.Test/MetaphysicsIndustries.Solus.Test.csproj
+++ b/MetaphysicsIndustries.Solus.Test/MetaphysicsIndustries.Solus.Test.csproj
@@ -159,6 +159,7 @@
     <Compile Include="SolusParserT\SolusParserTest.cs" />
     <Compile Include="ValuesT\IntervalT\ContainsTest.cs" />
     <Compile Include="ValuesT\IntervalT\EmptyDegenerateTest.cs" />
+    <Compile Include="ValuesT\IntervalT\EqualsTest.cs" />
     <Compile Include="ValuesT\IntervalT\IntervalTest.cs" />
     <Compile Include="ValuesT\MathObjectHelperT\MathObjectHelperTest.cs" />
     <Compile Include="ValuesT\MatrixT\MatrixTest.cs" />

--- a/MetaphysicsIndustries.Solus.Test/MetaphysicsIndustries.Solus.Test.csproj
+++ b/MetaphysicsIndustries.Solus.Test/MetaphysicsIndustries.Solus.Test.csproj
@@ -158,6 +158,7 @@
     <Compile Include="SolusEngineT\LoadImageTest.cs" />
     <Compile Include="SolusParserT\SolusParserTest.cs" />
     <Compile Include="ValuesT\IntervalT\ContainsTest.cs" />
+    <Compile Include="ValuesT\IntervalT\EmptyDegenerateTest.cs" />
     <Compile Include="ValuesT\IntervalT\IntervalTest.cs" />
     <Compile Include="ValuesT\MathObjectHelperT\MathObjectHelperTest.cs" />
     <Compile Include="ValuesT\MatrixT\MatrixTest.cs" />

--- a/MetaphysicsIndustries.Solus.Test/MockMathObject.cs
+++ b/MetaphysicsIndustries.Solus.Test/MockMathObject.cs
@@ -30,7 +30,8 @@ namespace MetaphysicsIndustries.Solus.Test
     {
         public MockMathObject(bool isScalar = true, bool isVector = false,
             bool isMatrix = false, int tensorRank = 0, bool isString = false,
-            int[] dimensions = null, bool isConcrete = false)
+            int[] dimensions = null, bool isInterval = false,
+            bool isConcrete = false)
         {
             _isScalar = isScalar;
             _isVector = isVector;
@@ -40,6 +41,7 @@ namespace MetaphysicsIndustries.Solus.Test
             if (dimensions == null)
                 dimensions = Enumerable.Repeat(1, tensorRank).ToArray();
             _dimensions = dimensions;
+            _isInterval = isInterval;
             _isConcrete = isConcrete;
         }
 
@@ -65,6 +67,9 @@ namespace MetaphysicsIndustries.Solus.Test
 
         public int? GetVectorLength(SolusEnvironment env) =>
             throw new NotImplementedException();
+
+        private readonly bool? _isInterval;
+        public bool? IsInterval(SolusEnvironment env) => _isInterval;
 
         private readonly bool _isConcrete;
         public bool IsConcrete => _isConcrete;

--- a/MetaphysicsIndustries.Solus.Test/MockMathObjectF.cs
+++ b/MetaphysicsIndustries.Solus.Test/MockMathObjectF.cs
@@ -36,6 +36,7 @@ namespace MetaphysicsIndustries.Solus.Test
             Func<SolusEnvironment, int, int> getDimensionF = null,
             Func<SolusEnvironment, int[]> getDimensionsF = null,
             Func<SolusEnvironment, int> getVectorLengthF = null,
+            Func<SolusEnvironment, bool?> isIntervalF = null,
             bool isConcreteV = false)
         {
             IsScalarF = isScalarF;
@@ -46,6 +47,7 @@ namespace MetaphysicsIndustries.Solus.Test
             GetDimensionF = getDimensionF;
             GetDimensionsF = getDimensionsF;
             GetVectorLengthF = getVectorLengthF;
+            IsIntervalF = isIntervalF;
             IsConcreteV = isConcreteV;
         }
 
@@ -102,6 +104,13 @@ namespace MetaphysicsIndustries.Solus.Test
         public int? GetVectorLength(SolusEnvironment env)
         {
             if (GetVectorLengthF != null) return GetVectorLengthF(env);
+            throw new NotImplementedException();
+        }
+
+        public Func<SolusEnvironment, bool?> IsIntervalF;
+        public bool? IsInterval(SolusEnvironment env)
+        {
+            if (IsIntervalF != null) return IsIntervalF(env);
             throw new NotImplementedException();
         }
 

--- a/MetaphysicsIndustries.Solus.Test/ValuesT/IntervalT/ContainsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ValuesT/IntervalT/ContainsTest.cs
@@ -1,0 +1,202 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2021 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Values;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
+{
+    [TestFixture]
+    public class ContainsTest
+    {
+        [Test]
+        public void TypicalValueYields1()
+        {
+            // given
+            var interval = new Interval(1, false, 2, false, false);
+            // expect
+            Assert.IsTrue(interval.Contains(1.5f));
+            // and
+            Assert.IsFalse(interval.Contains(0));
+            Assert.IsFalse(interval.Contains(3));
+        }
+
+        [Test]
+        public void TypicalValueYields2()
+        {
+            // given
+            var interval = new Interval(1, true, 2, false, false);
+            // expect
+            Assert.IsTrue(interval.Contains(1.5f));
+            // and
+            Assert.IsFalse(interval.Contains(0));
+            Assert.IsFalse(interval.Contains(3));
+        }
+
+        [Test]
+        public void TypicalValueYields3()
+        {
+            // given
+            var interval = new Interval(1, false, 2, true, false);
+            // expect
+            Assert.IsTrue(interval.Contains(1.5f));
+            // and
+            Assert.IsFalse(interval.Contains(0));
+            Assert.IsFalse(interval.Contains(3));
+        }
+
+        [Test]
+        public void TypicalValueYields4()
+        {
+            // given
+            var interval = new Interval(1, true, 2, true, false);
+            // expect
+            Assert.IsTrue(interval.Contains(1.5f));
+            // and
+            Assert.IsFalse(interval.Contains(0));
+            Assert.IsFalse(interval.Contains(3));
+        }
+
+        [Test]
+        public void BoundaryOnClosedLowerYieldsTrue()
+        {
+            // given
+            var interval = new Interval(1, false, 2, false, false);
+            // expect
+            Assert.IsTrue(interval.Contains(1));
+        }
+
+        [Test]
+        public void BoundaryOnOpenLowerYieldsFalse()
+        {
+            // given
+            var interval = new Interval(1, true, 2, false, false);
+            // expect
+            Assert.IsFalse(interval.Contains(1));
+        }
+
+        [Test]
+        public void BoundaryOnClosedUpperYieldsTrue()
+        {
+            // given
+            var interval = new Interval(1, false, 2, false, false);
+            // expect
+            Assert.IsTrue(interval.Contains(2));
+        }
+
+        [Test]
+        public void BoundaryOnOpenUpperYieldsTrue()
+        {
+            // given
+            var interval = new Interval(1, false, 2, true, false);
+            // expect
+            Assert.IsFalse(interval.Contains(2));
+        }
+
+        [Test]
+        public void OutsideValuesOnDegenerateClosedClosedYieldsFalse()
+        {
+            // given
+            var interval = new Interval(1, false, 1, false, false);
+            // expect
+            Assert.IsFalse(interval.Contains(0));
+            Assert.IsFalse(interval.Contains(2));
+        }
+
+        [Test]
+        public void OutsideValuesOnDegenerateOpenClosedYieldsFalse()
+        {
+            // given
+            var interval = new Interval(1, true, 1, false, false);
+            // expect
+            Assert.IsFalse(interval.Contains(0));
+            Assert.IsFalse(interval.Contains(2));
+        }
+
+        [Test]
+        public void OutsideValuesOnDegenerateClosedOpenYieldsFalse()
+        {
+            // given
+            var interval = new Interval(1, false, 1, true, false);
+            // expect
+            Assert.IsFalse(interval.Contains(0));
+            Assert.IsFalse(interval.Contains(2));
+        }
+
+        [Test]
+        public void OutsideValuesOnDegenerateOpenOpenYieldsFalse()
+        {
+            // given
+            var interval = new Interval(1, true, 1, true, false);
+            // expect
+            Assert.IsFalse(interval.Contains(0));
+            Assert.IsFalse(interval.Contains(2));
+        }
+
+        [Test]
+        public void BoundaryOnDegenerateClosedClosedYieldsTrue()
+        {
+            // given
+            var interval = new Interval(1, false, 1, false, false);
+            // expect
+            Assert.IsTrue(interval.Contains(1));
+        }
+
+        [Test]
+        public void BoundaryOnDegenerateOpenClosedYieldsTrue()
+        {
+            // given
+            var interval = new Interval(1, true, 1, false, false);
+            // expect
+            Assert.IsTrue(interval.Contains(1));
+        }
+
+        [Test]
+        public void BoundaryOnDegenerateClosedOpenYieldsTrue()
+        {
+            // given
+            var interval = new Interval(1, false, 1, true, false);
+            // expect
+            Assert.IsTrue(interval.Contains(1));
+        }
+
+        [Test]
+        public void BoundaryOnDegenerateOpenOpenYieldsFalse()
+        {
+            // given
+            var interval = new Interval(1, true, 1, true, false);
+            // expect
+            Assert.IsFalse(interval.Contains(1));
+        }
+
+        [Test]
+        public void NonFiniteValuesYieldFalse()
+        {
+            // given
+            var interval = new Interval(1, false, 2, false, false);
+            // expect
+            Assert.IsFalse(interval.Contains(float.NaN));
+            Assert.IsFalse(interval.Contains(float.NegativeInfinity));
+            Assert.IsFalse(interval.Contains(float.PositiveInfinity));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/ValuesT/IntervalT/EmptyDegenerateTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ValuesT/IntervalT/EmptyDegenerateTest.cs
@@ -1,3 +1,25 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2021 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
 using MetaphysicsIndustries.Solus.Values;
 using NUnit.Framework;
 

--- a/MetaphysicsIndustries.Solus.Test/ValuesT/IntervalT/EmptyDegenerateTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ValuesT/IntervalT/EmptyDegenerateTest.cs
@@ -1,0 +1,89 @@
+using MetaphysicsIndustries.Solus.Values;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
+{
+    [TestFixture]
+    public class EmptyDegenerateTest
+    {
+        [Test]
+        public void EqualBoundsBothClosedIsDegenerateNotEmpty()
+        {
+            // given
+            var i = new Interval(1, false, 1, false, false);
+            // expect
+            Assert.IsTrue(i.IsDegenerate);
+            Assert.IsFalse(i.IsEmpty);
+        }
+
+        [Test]
+        public void EqualBoundsSomeOpenIsEmptyNotDegenerate2()
+        {
+            // given
+            var i = new Interval(1, true, 1, false, false);
+            // expect
+            Assert.IsFalse(i.IsDegenerate);
+            Assert.IsTrue(i.IsEmpty);
+        }
+
+        [Test]
+        public void EqualBoundsSomeOpenIsEmptyNotDegenerate3()
+        {
+            // given
+            var i = new Interval(1, false, 1, true, false);
+            // expect
+            Assert.IsFalse(i.IsDegenerate);
+            Assert.IsTrue(i.IsEmpty);
+        }
+
+        [Test]
+        public void EqualBoundsSomeOpenIsEmptyNotDegenerate4()
+        {
+            // given
+            var i = new Interval(1, true, 1, true, false);
+            // expect
+            Assert.IsFalse(i.IsDegenerate);
+            Assert.IsTrue(i.IsEmpty);
+        }
+
+        [Test]
+        public void NonEqualBoundsNeitherEmptyNorDegenerate1()
+        {
+            // given
+            var i = new Interval(1, false, 2, false, false);
+            // expect
+            Assert.IsFalse(i.IsDegenerate);
+            Assert.IsFalse(i.IsEmpty);
+        }
+
+        [Test]
+        public void NonEqualBoundsNeitherEmptyNorDegenerate2()
+        {
+            // given
+            var i = new Interval(1, true, 2, false, false);
+            // expect
+            Assert.IsFalse(i.IsDegenerate);
+            Assert.IsFalse(i.IsEmpty);
+        }
+
+        [Test]
+        public void NonEqualBoundsNeitherEmptyNorDegenerate3()
+        {
+            // given
+            var i = new Interval(1, false, 2, true, false);
+            // expect
+            Assert.IsFalse(i.IsDegenerate);
+            Assert.IsFalse(i.IsEmpty);
+        }
+
+        [Test]
+        public void NonEqualBoundsNeitherEmptyNorDegenerate4()
+        {
+            // given
+            var i = new Interval(1, true, 2, true, false);
+            // expect
+            Assert.IsFalse(i.IsDegenerate);
+            Assert.IsFalse(i.IsEmpty);
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/ValuesT/IntervalT/EqualsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ValuesT/IntervalT/EqualsTest.cs
@@ -1,0 +1,810 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2021 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Values;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
+{
+    [TestFixture]
+    public class EqualsTest
+    {
+        [Test]
+        public void IdenticalIntervalsAreEqual1()
+        {
+            // given
+            var i1 = new Interval(1, true, 2, true, true);
+            var i2 = new Interval(1, true, 2, true, true);
+            // expect
+            Assert.IsTrue(i1.Equals(i2));
+            Assert.IsTrue(i1.Equals((object)i2));
+            Assert.AreEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void IdenticalIntervalsAreEqual2()
+        {
+            // given
+            var i1 = new Interval(1, true, 2, true, false);
+            var i2 = new Interval(1, true, 2, true, false);
+            // expect
+            Assert.IsTrue(i1.Equals(i2));
+            Assert.IsTrue(i1.Equals((object)i2));
+            Assert.AreEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void IdenticalIntervalsAreEqual3()
+        {
+            // given
+            var i1 = new Interval(1, true, 2, false, true);
+            var i2 = new Interval(1, true, 2, false, true);
+            // expect
+            Assert.IsTrue(i1.Equals(i2));
+            Assert.IsTrue(i1.Equals((object)i2));
+            Assert.AreEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void IdenticalIntervalsAreEqual4()
+        {
+            // given
+            var i1 = new Interval(1, true, 2, false, false);
+            var i2 = new Interval(1, true, 2, false, false);
+            // expect
+            Assert.IsTrue(i1.Equals(i2));
+            Assert.IsTrue(i1.Equals((object)i2));
+            Assert.AreEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void IdenticalIntervalsAreEqual5()
+        {
+            // given
+            var i1 = new Interval(1, false, 2, true, true);
+            var i2 = new Interval(1, false, 2, true, true);
+            // expect
+            Assert.IsTrue(i1.Equals(i2));
+            Assert.IsTrue(i1.Equals((object)i2));
+            Assert.AreEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void IdenticalIntervalsAreEqual6()
+        {
+            // given
+            var i1 = new Interval(1, false, 2, true, false);
+            var i2 = new Interval(1, false, 2, true, false);
+            // expect
+            Assert.IsTrue(i1.Equals(i2));
+            Assert.IsTrue(i1.Equals((object)i2));
+            Assert.AreEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void IdenticalIntervalsAreEqual7()
+        {
+            // given
+            var i1 = new Interval(1, false, 2, false, true);
+            var i2 = new Interval(1, false, 2, false, true);
+            // expect
+            Assert.IsTrue(i1.Equals(i2));
+            Assert.IsTrue(i1.Equals((object)i2));
+            Assert.AreEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void IdenticalIntervalsAreEqual8()
+        {
+            // given
+            var i1 = new Interval(1, false, 2, false, false);
+            var i2 = new Interval(1, false, 2, false, false);
+            // expect
+            Assert.IsTrue(i1.Equals(i2));
+            Assert.IsTrue(i1.Equals((object)i2));
+            Assert.AreEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual1()
+        {
+            // given
+            var i1 = new Interval(1, true, 2, true, true);
+            var i2 = new Interval(1, true, 2, true, false);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual2()
+        {
+            // given
+            var i1 = new Interval(1, true, 2, true, true);
+            var i2 = new Interval(1, true, 2, false, true);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual3()
+        {
+            // given
+            var i1 = new Interval(1, true, 2, true, true);
+            var i2 = new Interval(1, true, 2, false, false);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual4()
+        {
+            // given
+            var i1 = new Interval(1, true, 2, true, true);
+            var i2 = new Interval(1, false, 2, true, true);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual5()
+        {
+            // given
+            var i1 = new Interval(1, true, 2, true, true);
+            var i2 = new Interval(1, false, 2, true, false);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual6()
+        {
+            // given
+            var i1 = new Interval(1, true, 2, true, true);
+            var i2 = new Interval(1, false, 2, false, true);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual7()
+        {
+            // given
+            var i1 = new Interval(1, true, 2, true, true);
+            var i2 = new Interval(1, false, 2, false, false);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual8()
+        {
+            // given
+            var i1 = new Interval(1, true, 2, true, false);
+            var i2 = new Interval(1, true, 2, true, true);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual9()
+        {
+            // given
+            var i1 = new Interval(1, true, 2, true, false);
+            var i2 = new Interval(1, true, 2, false, true);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual10()
+        {
+            // given
+            var i1 = new Interval(1, true, 2, true, false);
+            var i2 = new Interval(1, true, 2, false, false);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual11()
+        {
+            // given
+            var i1 = new Interval(1, true, 2, true, false);
+            var i2 = new Interval(1, false, 2, true, true);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual12()
+        {
+            // given
+            var i1 = new Interval(1, true, 2, true, false);
+            var i2 = new Interval(1, false, 2, true, false);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual13()
+        {
+            // given
+            var i1 = new Interval(1, true, 2, true, false);
+            var i2 = new Interval(1, false, 2, false, true);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual14()
+        {
+            // given
+            var i1 = new Interval(1, true, 2, true, false);
+            var i2 = new Interval(1, false, 2, false, false);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual15()
+        {
+            // given
+            var i1 = new Interval(1, true, 2, false, true);
+            var i2 = new Interval(1, true, 2, true, true);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual16()
+        {
+            // given
+            var i1 = new Interval(1, true, 2, false, true);
+            var i2 = new Interval(1, true, 2, true, false);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual17()
+        {
+            // given
+            var i1 = new Interval(1, true, 2, false, true);
+            var i2 = new Interval(1, true, 2, false, false);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual18()
+        {
+            // given
+            var i1 = new Interval(1, true, 2, false, true);
+            var i2 = new Interval(1, false, 2, true, true);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual19()
+        {
+            // given
+            var i1 = new Interval(1, true, 2, false, true);
+            var i2 = new Interval(1, false, 2, true, false);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual20()
+        {
+            // given
+            var i1 = new Interval(1, true, 2, false, true);
+            var i2 = new Interval(1, false, 2, false, true);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual21()
+        {
+            // given
+            var i1 = new Interval(1, true, 2, false, true);
+            var i2 = new Interval(1, false, 2, false, false);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual22()
+        {
+            // given
+            var i1 = new Interval(1, true, 2, false, false);
+            var i2 = new Interval(1, true, 2, true, true);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual23()
+        {
+            // given
+            var i1 = new Interval(1, true, 2, false, false);
+            var i2 = new Interval(1, true, 2, true, false);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual24()
+        {
+            // given
+            var i1 = new Interval(1, true, 2, false, false);
+            var i2 = new Interval(1, true, 2, false, true);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual25()
+        {
+            // given
+            var i1 = new Interval(1, true, 2, false, false);
+            var i2 = new Interval(1, false, 2, true, true);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual26()
+        {
+            // given
+            var i1 = new Interval(1, true, 2, false, false);
+            var i2 = new Interval(1, false, 2, true, false);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual27()
+        {
+            // given
+            var i1 = new Interval(1, true, 2, false, false);
+            var i2 = new Interval(1, false, 2, false, true);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual28()
+        {
+            // given
+            var i1 = new Interval(1, true, 2, false, false);
+            var i2 = new Interval(1, false, 2, false, false);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual29()
+        {
+            // given
+            var i1 = new Interval(1, false, 2, true, true);
+            var i2 = new Interval(1, true, 2, true, true);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual30()
+        {
+            // given
+            var i1 = new Interval(1, false, 2, true, true);
+            var i2 = new Interval(1, true, 2, true, false);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual31()
+        {
+            // given
+            var i1 = new Interval(1, false, 2, true, true);
+            var i2 = new Interval(1, true, 2, false, true);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual32()
+        {
+            // given
+            var i1 = new Interval(1, false, 2, true, true);
+            var i2 = new Interval(1, true, 2, false, false);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual33()
+        {
+            // given
+            var i1 = new Interval(1, false, 2, true, true);
+            var i2 = new Interval(1, false, 2, true, false);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual34()
+        {
+            // given
+            var i1 = new Interval(1, false, 2, true, true);
+            var i2 = new Interval(1, false, 2, false, true);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual35()
+        {
+            // given
+            var i1 = new Interval(1, false, 2, true, true);
+            var i2 = new Interval(1, false, 2, false, false);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual36()
+        {
+            // given
+            var i1 = new Interval(1, false, 2, true, false);
+            var i2 = new Interval(1, true, 2, true, true);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual37()
+        {
+            // given
+            var i1 = new Interval(1, false, 2, true, false);
+            var i2 = new Interval(1, true, 2, true, false);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual38()
+        {
+            // given
+            var i1 = new Interval(1, false, 2, true, false);
+            var i2 = new Interval(1, true, 2, false, true);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual39()
+        {
+            // given
+            var i1 = new Interval(1, false, 2, true, false);
+            var i2 = new Interval(1, true, 2, false, false);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual40()
+        {
+            // given
+            var i1 = new Interval(1, false, 2, true, false);
+            var i2 = new Interval(1, false, 2, true, true);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual41()
+        {
+            // given
+            var i1 = new Interval(1, false, 2, true, false);
+            var i2 = new Interval(1, false, 2, false, true);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual42()
+        {
+            // given
+            var i1 = new Interval(1, false, 2, true, false);
+            var i2 = new Interval(1, false, 2, false, false);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual43()
+        {
+            // given
+            var i1 = new Interval(1, false, 2, false, true);
+            var i2 = new Interval(1, true, 2, true, true);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual44()
+        {
+            // given
+            var i1 = new Interval(1, false, 2, false, true);
+            var i2 = new Interval(1, true, 2, true, false);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual45()
+        {
+            // given
+            var i1 = new Interval(1, false, 2, false, true);
+            var i2 = new Interval(1, true, 2, false, true);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual46()
+        {
+            // given
+            var i1 = new Interval(1, false, 2, false, true);
+            var i2 = new Interval(1, true, 2, false, false);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual47()
+        {
+            // given
+            var i1 = new Interval(1, false, 2, false, true);
+            var i2 = new Interval(1, false, 2, true, true);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual48()
+        {
+            // given
+            var i1 = new Interval(1, false, 2, false, true);
+            var i2 = new Interval(1, false, 2, true, false);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual49()
+        {
+            // given
+            var i1 = new Interval(1, false, 2, false, true);
+            var i2 = new Interval(1, false, 2, false, false);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual50()
+        {
+            // given
+            var i1 = new Interval(1, false, 2, false, false);
+            var i2 = new Interval(1, true, 2, true, true);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual51()
+        {
+            // given
+            var i1 = new Interval(1, false, 2, false, false);
+            var i2 = new Interval(1, true, 2, true, false);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual52()
+        {
+            // given
+            var i1 = new Interval(1, false, 2, false, false);
+            var i2 = new Interval(1, true, 2, false, true);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual53()
+        {
+            // given
+            var i1 = new Interval(1, false, 2, false, false);
+            var i2 = new Interval(1, true, 2, false, false);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual54()
+        {
+            // given
+            var i1 = new Interval(1, false, 2, false, false);
+            var i2 = new Interval(1, false, 2, true, true);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual55()
+        {
+            // given
+            var i1 = new Interval(1, false, 2, false, false);
+            var i2 = new Interval(1, false, 2, true, false);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual56()
+        {
+            // given
+            var i1 = new Interval(1, false, 2, false, false);
+            var i2 = new Interval(1, false, 2, false, true);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+        }
+
+        [Test]
+        public void DifferentIntervalsAreNotEqual57()
+        {
+            // given
+            var i1 = new Interval(1, false, 2, false, false);
+            var i2 = new Interval(1, false, 3, false, false);
+            // expect
+            Assert.IsFalse(i1.Equals(i2));
+            Assert.IsFalse(i1.Equals((object)i2));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/ValuesT/IntervalT/IntervalTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ValuesT/IntervalT/IntervalTest.cs
@@ -20,6 +20,7 @@
  *
  */
 
+using System;
 using MetaphysicsIndustries.Solus.Values;
 using NUnit.Framework;
 
@@ -39,6 +40,72 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             Assert.AreEqual(2, result.UpperBound);
             Assert.IsTrue(result.OpenUpperBound);
             Assert.IsFalse(result.IsIntegerInterval);
+        }
+
+        [Test]
+        public void CreateWithNaNLowerThrows()
+        {
+            // expect
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(
+                () =>
+                {
+                    var i = new Interval(float.NaN, false, 1, false, false);
+                });
+            // and
+            Assert.AreEqual("lowerBound", ex.ParamName);
+            Assert.AreEqual(
+                "Not a number\nParameter name: lowerBound", ex.Message);
+        }
+
+        [Test]
+        public void CreateWithNaNUpperThrows()
+        {
+            // expect
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(
+                () =>
+                {
+                    var i = new Interval(1, false, float.NaN, false, false);
+                });
+            // and
+            Assert.AreEqual("upperBound", ex.ParamName);
+            Assert.AreEqual(
+                "Not a number\nParameter name: upperBound", ex.Message);
+        }
+
+        [Test]
+        public void CreateWithInfinityLowerDoesNotThrow()
+        {
+            // expect
+            Assert.DoesNotThrow(
+                () =>
+                {
+                    var i = new Interval(float.NegativeInfinity, false,
+                        1, false, false);
+                });
+        }
+
+        [Test]
+        public void CreateWithInfinityUpperDoesNotThrow()
+        {
+            // expect
+            Assert.DoesNotThrow(
+                () =>
+                {
+                    var i = new Interval(1, false,
+                        float.PositiveInfinity, false, false);
+                });
+        }
+
+        [Test]
+        public void LowerGreaterThanHigherYieldsBoundsReversed()
+        {
+            // when
+            var result = new Interval(2, false, 1, true, false);
+            // then
+            Assert.AreEqual(1, result.LowerBound);
+            Assert.IsTrue(result.OpenLowerBound);
+            Assert.AreEqual(2, result.UpperBound);
+            Assert.IsFalse(result.OpenUpperBound);
         }
 
         [Test]

--- a/MetaphysicsIndustries.Solus.Test/ValuesT/IntervalT/IntervalTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ValuesT/IntervalT/IntervalTest.cs
@@ -1,0 +1,134 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2021 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Values;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
+{
+    [TestFixture]
+    public class IntervalTest
+    {
+        [Test]
+        public void CreateYieldsValues1()
+        {
+            // when
+            var result = new Interval(1, false, 2, true, false);
+            // then
+            Assert.AreEqual(1, result.LowerBound);
+            Assert.IsFalse(result.OpenLowerBound);
+            Assert.AreEqual(2, result.UpperBound);
+            Assert.IsTrue(result.OpenUpperBound);
+            Assert.IsFalse(result.IsIntegerInterval);
+        }
+
+        [Test]
+        public void CreateYieldsValues2()
+        {
+            // when
+            var result = new Interval(3, true, 4, false, true);
+            // then
+            Assert.AreEqual(3, result.LowerBound);
+            Assert.IsTrue(result.OpenLowerBound);
+            Assert.AreEqual(4, result.UpperBound);
+            Assert.IsFalse(result.OpenUpperBound);
+            Assert.IsTrue(result.IsIntegerInterval);
+        }
+
+        // TODO: what if LowerBound > UpperBound?
+        // TODO: what if LowerBound == UpperBound?
+
+        [Test]
+        public void LengthYieldsDifferenceBetweenBounds()
+        {
+            // given
+            var interval = new Interval(1, false, 3, false, false);
+            // expect
+            Assert.AreEqual(2, interval.Length);
+        }
+
+        [Test]
+        public void IntegerYieldsIntegerInterval()
+        {
+            // when
+            var result = Interval.Integer(1, 3);
+            // then
+            Assert.AreEqual(1, result.LowerBound);
+            Assert.IsFalse(result.OpenLowerBound);
+            Assert.AreEqual(3, result.UpperBound);
+            Assert.IsFalse(result.OpenUpperBound);
+            Assert.IsTrue(result.IsIntegerInterval);
+        }
+
+        [Test]
+        public void RoundYieldsIntegerInterval()
+        {
+            // given
+            var interval = new Interval(1.1f, false, 3.1f, false, false);
+            // when
+            var result = interval.Round();
+            // then
+            Assert.AreEqual(1, result.LowerBound);
+            Assert.IsFalse(result.OpenLowerBound);
+            Assert.AreEqual(3, result.UpperBound);
+            Assert.IsFalse(result.OpenUpperBound);
+            Assert.IsTrue(result.IsIntegerInterval);
+        }
+
+        // TODO: CalcDelta 1
+        // TODO: CalcDelta 0
+        // TODO: CalcDelta -1
+
+        [Test]
+        public void CalcDeltaTwoStepsYieldsLength()
+        {
+            // given
+            var interval = new Interval(1.1f, false, 3.1f, false, false);
+            // when
+            var result = interval.CalcDelta(2);
+            // then
+            Assert.AreEqual(2, result, 0.000001f);
+        }
+
+        [Test]
+        public void CalcDeltaThreeStepsYieldsHalfLength()
+        {
+            // given
+            var interval = new Interval(1.1f, false, 3.1f, false, false);
+            // when
+            var result = interval.CalcDelta(3);
+            // then
+            Assert.AreEqual(1, result, 0.000001f);
+        }
+
+        [Test]
+        public void CalcDeltaYieldsValue()
+        {
+            // given
+            var interval = new Interval(1.1f, false, 3.1f, false, false);
+            // when
+            var result = interval.CalcDelta(101);
+            // then
+            Assert.AreEqual(0.02f, result, 0.000001f);
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/ValuesT/IntervalT/IntervalTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ValuesT/IntervalT/IntervalTest.cs
@@ -130,5 +130,22 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // then
             Assert.AreEqual(0.02f, result, 0.000001f);
         }
+
+        [Test]
+        public void MathObjectIsInterval()
+        {
+            // given
+            var interval = new Interval(1, false, 2, false, false);
+            // expect
+            Assert.IsFalse(interval.IsScalar(null));
+            Assert.IsFalse(interval.IsVector(null));
+            Assert.IsFalse(interval.IsMatrix(null));
+            Assert.IsNull(interval.GetTensorRank(null));
+            Assert.IsFalse(interval.IsString(null));
+            Assert.IsNull(interval.GetDimension(null, 0));
+            Assert.IsNull(interval.GetDimensions(null));
+            Assert.IsNull(interval.GetVectorLength(null));
+            Assert.IsTrue(interval.IsConcrete);
+        }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/ValuesT/VarIntervalT/VarIntervalTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ValuesT/VarIntervalT/VarIntervalTest.cs
@@ -1,0 +1,111 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2021 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Values;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.ValuesT.VarIntervalT
+{
+    [TestFixture]
+    public class VarIntervalTest
+    {
+        [Test]
+        public void CreateSetsValues()
+        {
+            // given
+            var varname = "a";
+            var interval = new Interval(1.1f, true, 3.1f, true, false);
+            // when
+            var result = new VarInterval(varname, interval);
+            // then
+            Assert.AreEqual("a", result.Variable);
+            Assert.AreEqual(interval, result.Interval);
+        }
+
+        [Test]
+        public void ToString1()
+        {
+            // given
+            var vi = new VarInterval(
+                "a",
+                new Interval(1.1f, true, 3.1f, true, false));
+            // when
+            var result = vi.ToString();
+            // then
+            Assert.AreEqual("1.1 < a < 3.1", result);
+        }
+
+        [Test]
+        public void ToString2()
+        {
+            // given
+            var vi = new VarInterval(
+                "a",
+                new Interval(1.1f, true, 3.1f, false, false));
+            // when
+            var result = vi.ToString();
+            // then
+            Assert.AreEqual("1.1 < a <= 3.1", result);
+        }
+
+        [Test]
+        public void ToString3()
+        {
+            // given
+            var vi = new VarInterval(
+                "a",
+                new Interval(1.1f, false, 3.1f, true, false));
+            // when
+            var result = vi.ToString();
+            // then
+            Assert.AreEqual("1.1 <= a < 3.1", result);
+        }
+
+        [Test]
+        public void ToString4()
+        {
+            // given
+            var vi = new VarInterval(
+                "a",
+                new Interval(1.1f, false, 3.1f, false, false));
+            // when
+            var result = vi.ToString();
+            // then
+            Assert.AreEqual("1.1 <= a <= 3.1", result);
+        }
+
+        // TODO: string representation doesn't show integer
+        // TODO: integer interval bounds should be rounded (?)
+        [Test]
+        public void ToString5()
+        {
+            // given
+            var vi = new VarInterval(
+                "a",
+                new Interval(1.1f, false, 3.1f, false, true));
+            // when
+            var result = vi.ToString();
+            // then
+            Assert.AreEqual("1.1 <= a <= 3.1", result);
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.csproj
+++ b/MetaphysicsIndustries.Solus.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Expressions\Expression.cs" />
     <Compile Include="Expressions\FunctionCall.cs" />
     <Compile Include="Expressions\IExpressionVisitor.cs" />
+    <Compile Include="Expressions\IntervalExpression.cs" />
     <Compile Include="Expressions\Literal.cs" />
     <Compile Include="Expressions\ProductExpression.cs" />
     <Compile Include="Expressions\RandomExpression.cs" />

--- a/MetaphysicsIndustries.Solus.csproj
+++ b/MetaphysicsIndustries.Solus.csproj
@@ -171,10 +171,12 @@
     <Compile Include="Transformers\VariableTransformArgs.cs" />
     <Compile Include="STuple.cs" />
     <Compile Include="MemoryImage.cs" />
+    <Compile Include="Values\Interval.cs" />
     <Compile Include="Values\Matrix.cs" />
     <Compile Include="Values\Number.cs" />
     <Compile Include="Values\StringValue.cs" />
     <Compile Include="Values\Types.cs" />
+    <Compile Include="Values\VarInterval.cs" />
     <Compile Include="Values\Vector.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/SolusGrammar.cs
+++ b/SolusGrammar.cs
@@ -29,16 +29,21 @@ namespace MetaphysicsIndustries.Solus
     {
         public static readonly SolusGrammar Instance = new SolusGrammar();
 
+        public NDefinition def__0024_implicit_0020_char_0020_class_0020__0028__005C__005B_ = new NDefinition("$implicit char class (\\[");
+        public NDefinition def__0024_implicit_0020_char_0020_class_0020__0029__005C__005D_ = new NDefinition("$implicit char class )\\]");
         public NDefinition def__0024_implicit_0020_char_0020_class_0020__002B__002D_ = new NDefinition("$implicit char class +-");
         public NDefinition def__0024_implicit_0020_literal_0020__0028_ = new NDefinition("$implicit literal (");
         public NDefinition def__0024_implicit_0020_literal_0020__0029_ = new NDefinition("$implicit literal )");
         public NDefinition def__0024_implicit_0020_literal_0020__002C_ = new NDefinition("$implicit literal ,");
         public NDefinition def__0024_implicit_0020_literal_0020__003A__003D_ = new NDefinition("$implicit literal :=");
         public NDefinition def__0024_implicit_0020_literal_0020__003B_ = new NDefinition("$implicit literal ;");
+        public NDefinition def__0024_implicit_0020_literal_0020__003C_ = new NDefinition("$implicit literal <");
+        public NDefinition def__0024_implicit_0020_literal_0020__003C__003D_ = new NDefinition("$implicit literal <=");
         public NDefinition def__0024_implicit_0020_literal_0020__005B_ = new NDefinition("$implicit literal [");
         public NDefinition def__0024_implicit_0020_literal_0020__005D_ = new NDefinition("$implicit literal ]");
         public NDefinition def__0024_implicit_0020_literal_0020_delete = new NDefinition("$implicit literal delete");
         public NDefinition def__0024_implicit_0020_literal_0020_help = new NDefinition("$implicit literal help");
+        public NDefinition def__0024_implicit_0020_literal_0020_in = new NDefinition("$implicit literal in");
         public NDefinition def__0024_implicit_0020_literal_0020_variables = new NDefinition("$implicit literal variables");
         public NDefinition def__0024_implicit_0020_literal_0020_vars = new NDefinition("$implicit literal vars");
         public NDefinition def_array_002D_index = new NDefinition("array-index");
@@ -55,6 +60,7 @@ namespace MetaphysicsIndustries.Solus
         public NDefinition def_function_002D_call = new NDefinition("function-call");
         public NDefinition def_help_002D_command = new NDefinition("help-command");
         public NDefinition def_identifier = new NDefinition("identifier");
+        public NDefinition def_interval = new NDefinition("interval");
         public NDefinition def_number = new NDefinition("number");
         public NDefinition def_paren = new NDefinition("paren");
         public NDefinition def_string = new NDefinition("string");
@@ -62,9 +68,12 @@ namespace MetaphysicsIndustries.Solus
         public NDefinition def_unary_002D_op = new NDefinition("unary-op");
         public NDefinition def_unicodechar = new NDefinition("unicodechar");
         public NDefinition def_var_002D_assign_002D_command = new NDefinition("var-assign-command");
+        public NDefinition def_var_002D_interval = new NDefinition("var-interval");
         public NDefinition def_varref = new NDefinition("varref");
         public NDefinition def_vars_002D_command = new NDefinition("vars-command");
 
+        public CharNode node__0024_implicit_0020_char_0020_class_0020__0028__005C__005B__0_;
+        public CharNode node__0024_implicit_0020_char_0020_class_0020__0029__005C__005D__0_;
         public CharNode node__0024_implicit_0020_char_0020_class_0020__002B__002D__0_;
         public CharNode node__0024_implicit_0020_literal_0020__0028__0_;
         public CharNode node__0024_implicit_0020_literal_0020__0029__0_;
@@ -72,6 +81,9 @@ namespace MetaphysicsIndustries.Solus
         public CharNode node__0024_implicit_0020_literal_0020__003A__003D__0_;
         public CharNode node__0024_implicit_0020_literal_0020__003A__003D__1_;
         public CharNode node__0024_implicit_0020_literal_0020__003B__0_;
+        public CharNode node__0024_implicit_0020_literal_0020__003C__0_;
+        public CharNode node__0024_implicit_0020_literal_0020__003C__003D__0_;
+        public CharNode node__0024_implicit_0020_literal_0020__003C__003D__1_;
         public CharNode node__0024_implicit_0020_literal_0020__005B__0_;
         public CharNode node__0024_implicit_0020_literal_0020__005D__0_;
         public CharNode node__0024_implicit_0020_literal_0020_delete_0_;
@@ -84,6 +96,8 @@ namespace MetaphysicsIndustries.Solus
         public CharNode node__0024_implicit_0020_literal_0020_help_1_;
         public CharNode node__0024_implicit_0020_literal_0020_help_2_;
         public CharNode node__0024_implicit_0020_literal_0020_help_3_;
+        public CharNode node__0024_implicit_0020_literal_0020_in_0_;
+        public CharNode node__0024_implicit_0020_literal_0020_in_1_;
         public CharNode node__0024_implicit_0020_literal_0020_variables_0_;
         public CharNode node__0024_implicit_0020_literal_0020_variables_1_;
         public CharNode node__0024_implicit_0020_literal_0020_variables_2_;
@@ -169,6 +183,11 @@ namespace MetaphysicsIndustries.Solus
         public DefRefNode node_help_002D_command_1_topic;
         public CharNode node_identifier_0__005C_l;
         public CharNode node_identifier_1__005C_l_005C_d_005F_;
+        public DefRefNode node_interval_0__0028__005C__005B_;
+        public DefRefNode node_interval_1_number;
+        public DefRefNode node_interval_2__002C_;
+        public DefRefNode node_interval_3_number;
+        public DefRefNode node_interval_4__0029__005C__005D_;
         public CharNode node_number_0_0b;
         public CharNode node_number_1_0b;
         public CharNode node_number_2_01;
@@ -219,22 +238,37 @@ namespace MetaphysicsIndustries.Solus
         public DefRefNode node_var_002D_assign_002D_command_0_varref;
         public DefRefNode node_var_002D_assign_002D_command_1__003A__003D_;
         public DefRefNode node_var_002D_assign_002D_command_2_expr;
+        public DefRefNode node_var_002D_interval_0_varref;
+        public DefRefNode node_var_002D_interval_1_in;
+        public DefRefNode node_var_002D_interval_2_interval;
+        public DefRefNode node_var_002D_interval_3_expr;
+        public DefRefNode node_var_002D_interval_4__003C_;
+        public DefRefNode node_var_002D_interval_5__003C__003D_;
+        public DefRefNode node_var_002D_interval_6_varref;
+        public DefRefNode node_var_002D_interval_7__003C_;
+        public DefRefNode node_var_002D_interval_8__003C__003D_;
+        public DefRefNode node_var_002D_interval_9_expr;
         public DefRefNode node_varref_0_identifier;
         public DefRefNode node_vars_002D_command_0_vars;
         public DefRefNode node_vars_002D_command_1_variables;
 
         public SolusGrammar()
         {
+            Definitions.Add(def__0024_implicit_0020_char_0020_class_0020__0028__005C__005B_);
+            Definitions.Add(def__0024_implicit_0020_char_0020_class_0020__0029__005C__005D_);
             Definitions.Add(def__0024_implicit_0020_char_0020_class_0020__002B__002D_);
             Definitions.Add(def__0024_implicit_0020_literal_0020__0028_);
             Definitions.Add(def__0024_implicit_0020_literal_0020__0029_);
             Definitions.Add(def__0024_implicit_0020_literal_0020__002C_);
             Definitions.Add(def__0024_implicit_0020_literal_0020__003A__003D_);
             Definitions.Add(def__0024_implicit_0020_literal_0020__003B_);
+            Definitions.Add(def__0024_implicit_0020_literal_0020__003C_);
+            Definitions.Add(def__0024_implicit_0020_literal_0020__003C__003D_);
             Definitions.Add(def__0024_implicit_0020_literal_0020__005B_);
             Definitions.Add(def__0024_implicit_0020_literal_0020__005D_);
             Definitions.Add(def__0024_implicit_0020_literal_0020_delete);
             Definitions.Add(def__0024_implicit_0020_literal_0020_help);
+            Definitions.Add(def__0024_implicit_0020_literal_0020_in);
             Definitions.Add(def__0024_implicit_0020_literal_0020_variables);
             Definitions.Add(def__0024_implicit_0020_literal_0020_vars);
             Definitions.Add(def_array_002D_index);
@@ -251,6 +285,7 @@ namespace MetaphysicsIndustries.Solus
             Definitions.Add(def_function_002D_call);
             Definitions.Add(def_help_002D_command);
             Definitions.Add(def_identifier);
+            Definitions.Add(def_interval);
             Definitions.Add(def_number);
             Definitions.Add(def_paren);
             Definitions.Add(def_string);
@@ -258,8 +293,25 @@ namespace MetaphysicsIndustries.Solus
             Definitions.Add(def_unary_002D_op);
             Definitions.Add(def_unicodechar);
             Definitions.Add(def_var_002D_assign_002D_command);
+            Definitions.Add(def_var_002D_interval);
             Definitions.Add(def_varref);
             Definitions.Add(def_vars_002D_command);
+
+            def__0024_implicit_0020_char_0020_class_0020__0028__005C__005B_.Directives.Add(DefinitionDirective.Token);
+            def__0024_implicit_0020_char_0020_class_0020__0028__005C__005B_.Directives.Add(DefinitionDirective.Atomic);
+            def__0024_implicit_0020_char_0020_class_0020__0028__005C__005B_.Directives.Add(DefinitionDirective.MindWhitespace);
+            node__0024_implicit_0020_char_0020_class_0020__0028__005C__005B__0_ = new CharNode(CharClass.FromUndelimitedCharClassText("(\\["), "");
+            def__0024_implicit_0020_char_0020_class_0020__0028__005C__005B_.Nodes.Add(node__0024_implicit_0020_char_0020_class_0020__0028__005C__005B__0_);
+            def__0024_implicit_0020_char_0020_class_0020__0028__005C__005B_.StartNodes.Add(node__0024_implicit_0020_char_0020_class_0020__0028__005C__005B__0_);
+            def__0024_implicit_0020_char_0020_class_0020__0028__005C__005B_.EndNodes.Add(node__0024_implicit_0020_char_0020_class_0020__0028__005C__005B__0_);
+
+            def__0024_implicit_0020_char_0020_class_0020__0029__005C__005D_.Directives.Add(DefinitionDirective.Token);
+            def__0024_implicit_0020_char_0020_class_0020__0029__005C__005D_.Directives.Add(DefinitionDirective.Atomic);
+            def__0024_implicit_0020_char_0020_class_0020__0029__005C__005D_.Directives.Add(DefinitionDirective.MindWhitespace);
+            node__0024_implicit_0020_char_0020_class_0020__0029__005C__005D__0_ = new CharNode(CharClass.FromUndelimitedCharClassText(")\\]"), "");
+            def__0024_implicit_0020_char_0020_class_0020__0029__005C__005D_.Nodes.Add(node__0024_implicit_0020_char_0020_class_0020__0029__005C__005D__0_);
+            def__0024_implicit_0020_char_0020_class_0020__0029__005C__005D_.StartNodes.Add(node__0024_implicit_0020_char_0020_class_0020__0029__005C__005D__0_);
+            def__0024_implicit_0020_char_0020_class_0020__0029__005C__005D_.EndNodes.Add(node__0024_implicit_0020_char_0020_class_0020__0029__005C__005D__0_);
 
             def__0024_implicit_0020_char_0020_class_0020__002B__002D_.Directives.Add(DefinitionDirective.Token);
             def__0024_implicit_0020_char_0020_class_0020__002B__002D_.Directives.Add(DefinitionDirective.Atomic);
@@ -311,6 +363,25 @@ namespace MetaphysicsIndustries.Solus
             def__0024_implicit_0020_literal_0020__003B_.Nodes.Add(node__0024_implicit_0020_literal_0020__003B__0_);
             def__0024_implicit_0020_literal_0020__003B_.StartNodes.Add(node__0024_implicit_0020_literal_0020__003B__0_);
             def__0024_implicit_0020_literal_0020__003B_.EndNodes.Add(node__0024_implicit_0020_literal_0020__003B__0_);
+
+            def__0024_implicit_0020_literal_0020__003C_.Directives.Add(DefinitionDirective.Token);
+            def__0024_implicit_0020_literal_0020__003C_.Directives.Add(DefinitionDirective.Atomic);
+            def__0024_implicit_0020_literal_0020__003C_.Directives.Add(DefinitionDirective.MindWhitespace);
+            node__0024_implicit_0020_literal_0020__003C__0_ = new CharNode(CharClass.FromUndelimitedCharClassText("<"), "");
+            def__0024_implicit_0020_literal_0020__003C_.Nodes.Add(node__0024_implicit_0020_literal_0020__003C__0_);
+            def__0024_implicit_0020_literal_0020__003C_.StartNodes.Add(node__0024_implicit_0020_literal_0020__003C__0_);
+            def__0024_implicit_0020_literal_0020__003C_.EndNodes.Add(node__0024_implicit_0020_literal_0020__003C__0_);
+
+            def__0024_implicit_0020_literal_0020__003C__003D_.Directives.Add(DefinitionDirective.Token);
+            def__0024_implicit_0020_literal_0020__003C__003D_.Directives.Add(DefinitionDirective.Atomic);
+            def__0024_implicit_0020_literal_0020__003C__003D_.Directives.Add(DefinitionDirective.MindWhitespace);
+            node__0024_implicit_0020_literal_0020__003C__003D__0_ = new CharNode(CharClass.FromUndelimitedCharClassText("<"), "");
+            node__0024_implicit_0020_literal_0020__003C__003D__1_ = new CharNode(CharClass.FromUndelimitedCharClassText("="), "");
+            def__0024_implicit_0020_literal_0020__003C__003D_.Nodes.Add(node__0024_implicit_0020_literal_0020__003C__003D__0_);
+            def__0024_implicit_0020_literal_0020__003C__003D_.Nodes.Add(node__0024_implicit_0020_literal_0020__003C__003D__1_);
+            def__0024_implicit_0020_literal_0020__003C__003D_.StartNodes.Add(node__0024_implicit_0020_literal_0020__003C__003D__0_);
+            def__0024_implicit_0020_literal_0020__003C__003D_.EndNodes.Add(node__0024_implicit_0020_literal_0020__003C__003D__1_);
+            node__0024_implicit_0020_literal_0020__003C__003D__0_.NextNodes.Add(node__0024_implicit_0020_literal_0020__003C__003D__1_);
 
             def__0024_implicit_0020_literal_0020__005B_.Directives.Add(DefinitionDirective.Token);
             def__0024_implicit_0020_literal_0020__005B_.Directives.Add(DefinitionDirective.Atomic);
@@ -367,6 +438,17 @@ namespace MetaphysicsIndustries.Solus
             node__0024_implicit_0020_literal_0020_help_0_.NextNodes.Add(node__0024_implicit_0020_literal_0020_help_1_);
             node__0024_implicit_0020_literal_0020_help_1_.NextNodes.Add(node__0024_implicit_0020_literal_0020_help_2_);
             node__0024_implicit_0020_literal_0020_help_2_.NextNodes.Add(node__0024_implicit_0020_literal_0020_help_3_);
+
+            def__0024_implicit_0020_literal_0020_in.Directives.Add(DefinitionDirective.Token);
+            def__0024_implicit_0020_literal_0020_in.Directives.Add(DefinitionDirective.Atomic);
+            def__0024_implicit_0020_literal_0020_in.Directives.Add(DefinitionDirective.MindWhitespace);
+            node__0024_implicit_0020_literal_0020_in_0_ = new CharNode(CharClass.FromUndelimitedCharClassText("i"), "");
+            node__0024_implicit_0020_literal_0020_in_1_ = new CharNode(CharClass.FromUndelimitedCharClassText("n"), "");
+            def__0024_implicit_0020_literal_0020_in.Nodes.Add(node__0024_implicit_0020_literal_0020_in_0_);
+            def__0024_implicit_0020_literal_0020_in.Nodes.Add(node__0024_implicit_0020_literal_0020_in_1_);
+            def__0024_implicit_0020_literal_0020_in.StartNodes.Add(node__0024_implicit_0020_literal_0020_in_0_);
+            def__0024_implicit_0020_literal_0020_in.EndNodes.Add(node__0024_implicit_0020_literal_0020_in_1_);
+            node__0024_implicit_0020_literal_0020_in_0_.NextNodes.Add(node__0024_implicit_0020_literal_0020_in_1_);
 
             def__0024_implicit_0020_literal_0020_variables.Directives.Add(DefinitionDirective.Token);
             def__0024_implicit_0020_literal_0020_variables.Directives.Add(DefinitionDirective.Atomic);
@@ -730,6 +812,23 @@ namespace MetaphysicsIndustries.Solus
             node_identifier_0__005C_l.NextNodes.Add(node_identifier_1__005C_l_005C_d_005F_);
             node_identifier_1__005C_l_005C_d_005F_.NextNodes.Add(node_identifier_1__005C_l_005C_d_005F_);
 
+            node_interval_0__0028__005C__005B_ = new DefRefNode(def__0024_implicit_0020_char_0020_class_0020__0028__005C__005B_, "(\\[");
+            node_interval_1_number = new DefRefNode(def_number, "number");
+            node_interval_2__002C_ = new DefRefNode(def__0024_implicit_0020_literal_0020__002C_, ",");
+            node_interval_3_number = new DefRefNode(def_number, "number");
+            node_interval_4__0029__005C__005D_ = new DefRefNode(def__0024_implicit_0020_char_0020_class_0020__0029__005C__005D_, ")\\]");
+            def_interval.Nodes.Add(node_interval_0__0028__005C__005B_);
+            def_interval.Nodes.Add(node_interval_1_number);
+            def_interval.Nodes.Add(node_interval_2__002C_);
+            def_interval.Nodes.Add(node_interval_3_number);
+            def_interval.Nodes.Add(node_interval_4__0029__005C__005D_);
+            def_interval.StartNodes.Add(node_interval_0__0028__005C__005B_);
+            def_interval.EndNodes.Add(node_interval_4__0029__005C__005D_);
+            node_interval_0__0028__005C__005B_.NextNodes.Add(node_interval_1_number);
+            node_interval_1_number.NextNodes.Add(node_interval_2__002C_);
+            node_interval_2__002C_.NextNodes.Add(node_interval_3_number);
+            node_interval_3_number.NextNodes.Add(node_interval_4__0029__005C__005D_);
+
             def_number.Directives.Add(DefinitionDirective.IgnoreCase);
             def_number.Directives.Add(DefinitionDirective.Token);
             def_number.Directives.Add(DefinitionDirective.Atomic);
@@ -945,6 +1044,41 @@ namespace MetaphysicsIndustries.Solus
             def_var_002D_assign_002D_command.EndNodes.Add(node_var_002D_assign_002D_command_2_expr);
             node_var_002D_assign_002D_command_0_varref.NextNodes.Add(node_var_002D_assign_002D_command_1__003A__003D_);
             node_var_002D_assign_002D_command_1__003A__003D_.NextNodes.Add(node_var_002D_assign_002D_command_2_expr);
+
+            node_var_002D_interval_0_varref = new DefRefNode(def_varref, "varref");
+            node_var_002D_interval_1_in = new DefRefNode(def__0024_implicit_0020_literal_0020_in, "in");
+            node_var_002D_interval_2_interval = new DefRefNode(def_interval, "interval");
+            node_var_002D_interval_3_expr = new DefRefNode(def_expr, "expr");
+            node_var_002D_interval_4__003C_ = new DefRefNode(def__0024_implicit_0020_literal_0020__003C_, "<");
+            node_var_002D_interval_5__003C__003D_ = new DefRefNode(def__0024_implicit_0020_literal_0020__003C__003D_, "<=");
+            node_var_002D_interval_6_varref = new DefRefNode(def_varref, "varref");
+            node_var_002D_interval_7__003C_ = new DefRefNode(def__0024_implicit_0020_literal_0020__003C_, "<");
+            node_var_002D_interval_8__003C__003D_ = new DefRefNode(def__0024_implicit_0020_literal_0020__003C__003D_, "<=");
+            node_var_002D_interval_9_expr = new DefRefNode(def_expr, "expr");
+            def_var_002D_interval.Nodes.Add(node_var_002D_interval_0_varref);
+            def_var_002D_interval.Nodes.Add(node_var_002D_interval_1_in);
+            def_var_002D_interval.Nodes.Add(node_var_002D_interval_2_interval);
+            def_var_002D_interval.Nodes.Add(node_var_002D_interval_3_expr);
+            def_var_002D_interval.Nodes.Add(node_var_002D_interval_4__003C_);
+            def_var_002D_interval.Nodes.Add(node_var_002D_interval_5__003C__003D_);
+            def_var_002D_interval.Nodes.Add(node_var_002D_interval_6_varref);
+            def_var_002D_interval.Nodes.Add(node_var_002D_interval_7__003C_);
+            def_var_002D_interval.Nodes.Add(node_var_002D_interval_8__003C__003D_);
+            def_var_002D_interval.Nodes.Add(node_var_002D_interval_9_expr);
+            def_var_002D_interval.StartNodes.Add(node_var_002D_interval_0_varref);
+            def_var_002D_interval.StartNodes.Add(node_var_002D_interval_3_expr);
+            def_var_002D_interval.EndNodes.Add(node_var_002D_interval_2_interval);
+            def_var_002D_interval.EndNodes.Add(node_var_002D_interval_9_expr);
+            node_var_002D_interval_0_varref.NextNodes.Add(node_var_002D_interval_1_in);
+            node_var_002D_interval_1_in.NextNodes.Add(node_var_002D_interval_2_interval);
+            node_var_002D_interval_3_expr.NextNodes.Add(node_var_002D_interval_4__003C_);
+            node_var_002D_interval_3_expr.NextNodes.Add(node_var_002D_interval_5__003C__003D_);
+            node_var_002D_interval_4__003C_.NextNodes.Add(node_var_002D_interval_6_varref);
+            node_var_002D_interval_5__003C__003D_.NextNodes.Add(node_var_002D_interval_6_varref);
+            node_var_002D_interval_6_varref.NextNodes.Add(node_var_002D_interval_7__003C_);
+            node_var_002D_interval_6_varref.NextNodes.Add(node_var_002D_interval_8__003C__003D_);
+            node_var_002D_interval_7__003C_.NextNodes.Add(node_var_002D_interval_9_expr);
+            node_var_002D_interval_8__003C__003D_.NextNodes.Add(node_var_002D_interval_9_expr);
 
             node_varref_0_identifier = new DefRefNode(def_identifier, "identifier");
             def_varref.Nodes.Add(node_varref_0_identifier);

--- a/SolusGrammar.giza
+++ b/SolusGrammar.giza
@@ -103,3 +103,11 @@ comp-subexpr = (
 );
 
 array-index = '[' expr ( ',' expr )* ','? ']';
+
+// TODO: <expr> instead of <number> -> requires taking env out of parsing
+interval = [\[(] number ',' number [\])];
+
+var-interval = (
+    varref 'in' interval |
+    expr ( '<' | '<=' ) varref ( '<' | '<=' ) expr
+);

--- a/SolusParser.cs
+++ b/SolusParser.cs
@@ -685,5 +685,54 @@ namespace MetaphysicsIndustries.Solus
 
             return indexes;
         }
+
+        public VarInterval GetVarIntervalFromVarInterval(Span span,
+            SolusEnvironment env)
+        {
+            if (span.Subspans[0].Node ==
+                _grammar.node_var_002D_interval_0_varref)
+            {
+                // var in [lower,upper)
+                var varname = span.Subspans[0].Subspans[0].Value;
+                var interval = GetIntervalFromInterval(span.Subspans[2]);
+                return new VarInterval(varname, interval);
+            }
+            else
+            {
+                // lower <= var <= upper
+
+                var lower = GetExpressionFromExpr(span.Subspans[0], env);
+                var lowerf = (float)Math.Round(
+                    lower.Eval(env).ToNumber().Value);
+
+                var openLower = (span.Subspans[1].Value == "<");
+
+                string varname = span.Subspans[2].Subspans[0].Value;
+
+                var openUpper = (span.Subspans[3].Value == "<");
+
+                var upper = GetExpressionFromExpr(span.Subspans[4], env);
+                var upperf = (float)Math.Round(
+                    upper.Eval(env).ToNumber().Value);
+
+                return new VarInterval(
+                    varname,
+                    new Interval(lowerf, openLower,
+                        upperf, openUpper, false));
+            }
+        }
+
+        public Interval GetIntervalFromInterval(Span span)
+        {
+            var openLower = (span.Subspans[0].Value == "(");
+            var lower =
+                GetLiteralFromNumber(span.Subspans[1]).Value.ToNumber();
+            var upper =
+                GetLiteralFromNumber(span.Subspans[3]).Value.ToNumber();
+            var openUpper = (span.Subspans[4].Value == ")");
+
+            return new Interval(lower.Value, openLower,
+                upper.Value, openUpper, false);
+        }
     }
 }

--- a/Values/Interval.cs
+++ b/Values/Interval.cs
@@ -97,14 +97,6 @@ namespace MetaphysicsIndustries.Solus.Values
             return !OpenLowerBound || !OpenUpperBound;
         }
 
-        // TODO: intersects other interval
-        // TODO: interior
-        // TODO: closure
-        // TODO: interval closure/interval span (may require sets)
-        // TODO: is subinterval of
-        // TODO: is proper subinterval of
-        // TODO: bounded vs unbounded (requires infinity)
-
         public bool IsEmpty
         {
             get

--- a/Values/Interval.cs
+++ b/Values/Interval.cs
@@ -105,7 +105,28 @@ namespace MetaphysicsIndustries.Solus.Values
         // TODO: is proper subinterval of
         // TODO: equality, hash code
         // TODO: bounded vs unbounded (requires infinity)
-        // TODO: degenerate intervals
+
+        public bool IsEmpty
+        {
+            get
+            {
+                // assuming that neither bound is NaN
+                if (UpperBound < LowerBound) return true;
+                if (LowerBound < UpperBound) return false;
+                return OpenLowerBound || OpenUpperBound;
+            }
+        }
+
+        public bool IsDegenerate
+        {
+            get
+            {
+                // assuming that neither bound is NaN
+                if (UpperBound < LowerBound) return false;
+                if (LowerBound < UpperBound) return false;
+                return !OpenLowerBound && !OpenUpperBound;
+            }
+        }
 
         public bool? IsScalar(SolusEnvironment env) => false;
         public bool? IsVector(SolusEnvironment env) => false;

--- a/Values/Interval.cs
+++ b/Values/Interval.cs
@@ -61,6 +61,14 @@ namespace MetaphysicsIndustries.Solus.Values
 
         // TODO: Contains number
         // TODO: intersects other interval
+        // TODO: interior
+        // TODO: closure
+        // TODO: interval closure/interval span (may require sets)
+        // TODO: is subinterval of
+        // TODO: is proper subinterval of
+        // TODO: equality, hash code
+        // TODO: bounded vs unbounded (requires infinity)
+        // TODO: degenerate intervals
 
         public bool? IsScalar(SolusEnvironment env) => false;
         public bool? IsVector(SolusEnvironment env) => false;

--- a/Values/Interval.cs
+++ b/Values/Interval.cs
@@ -103,7 +103,6 @@ namespace MetaphysicsIndustries.Solus.Values
         // TODO: interval closure/interval span (may require sets)
         // TODO: is subinterval of
         // TODO: is proper subinterval of
-        // TODO: equality, hash code
         // TODO: bounded vs unbounded (requires infinity)
 
         public bool IsEmpty
@@ -126,6 +125,49 @@ namespace MetaphysicsIndustries.Solus.Values
                 if (LowerBound < UpperBound) return false;
                 return !OpenLowerBound && !OpenUpperBound;
             }
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Interval interval)
+                return Equals(interval);
+            return false;
+        }
+
+        public bool Equals(Interval other)
+        {
+            return LowerBound <= other.LowerBound &&
+                   LowerBound >= other.LowerBound &&
+                   OpenLowerBound == other.OpenLowerBound &&
+                   UpperBound <= other.UpperBound &&
+                   UpperBound >= other.UpperBound &&
+                   OpenUpperBound == other.OpenUpperBound &&
+                   IsIntegerInterval == other.IsIntegerInterval;
+        }
+
+        public override int GetHashCode()
+        {
+            var s1 = (19 * LowerBound).GetHashCode();
+            s1 ^= (23 * UpperBound).GetHashCode();
+            float s2;
+            if (OpenLowerBound && OpenUpperBound && IsIntegerInterval)
+                s2 = 29;
+            else if (OpenLowerBound && OpenUpperBound)
+                s2 = 31;
+            else if (OpenLowerBound && IsIntegerInterval)
+                s2 = 37;
+            else if (OpenUpperBound && IsIntegerInterval)
+                s2 = 41;
+            else if (OpenLowerBound)
+                s2 = 43;
+            else if (OpenUpperBound)
+                s2 = 47;
+            else if (IsIntegerInterval)
+                s2 = 53;
+            else
+                s2 = 59;
+            s1 ^= s2.GetHashCode();
+            return s1;
         }
 
         public bool? IsScalar(SolusEnvironment env) => false;

--- a/Values/Interval.cs
+++ b/Values/Interval.cs
@@ -59,7 +59,24 @@ namespace MetaphysicsIndustries.Solus.Values
         public float CalcDelta(int numSteps) =>
             (UpperBound - LowerBound) / (numSteps - 1);
 
-        // TODO: Contains number
+        public bool Contains(float value)
+        {
+            if (float.IsNaN(value)) return false;
+            if (float.IsInfinity(value)) return false;
+            if (value < LowerBound) return false;
+            if (value > UpperBound) return false;
+            if (value > LowerBound && value < UpperBound) return true;
+            if (LowerBound < UpperBound) // not degenerate
+            {
+                if (value < UpperBound) // equal to lower
+                    return !OpenLowerBound;
+                // equal to upper
+                return !OpenUpperBound;
+            }
+            // interval is degenerate, lower == upper
+            return !OpenLowerBound || !OpenUpperBound;
+        }
+
         // TODO: intersects other interval
         // TODO: interior
         // TODO: closure

--- a/Values/Interval.cs
+++ b/Values/Interval.cs
@@ -22,7 +22,7 @@
 
 namespace MetaphysicsIndustries.Solus.Values
 {
-    public readonly struct Interval
+    public readonly struct Interval : IMathObject
     {
         public Interval(float lowerBound, bool openLowerBound,
             float upperBound, bool openUpperBound, bool isIntegerInterval)
@@ -61,6 +61,16 @@ namespace MetaphysicsIndustries.Solus.Values
 
         // TODO: Contains number
         // TODO: intersects other interval
-        // TODO: IMathObject
+
+        public bool? IsScalar(SolusEnvironment env) => false;
+        public bool? IsVector(SolusEnvironment env) => false;
+        public bool? IsMatrix(SolusEnvironment env) => false;
+        public int? GetTensorRank(SolusEnvironment env) => null;
+        public bool? IsString(SolusEnvironment env) => false;
+        public int? GetDimension(SolusEnvironment env, int index) => null;
+        public int[] GetDimensions(SolusEnvironment env) => null;
+        public int? GetVectorLength(SolusEnvironment env) => null;
+        public bool? IsInterval(SolusEnvironment env) => true;
+        public bool IsConcrete => true;
     }
 }

--- a/Values/Interval.cs
+++ b/Values/Interval.cs
@@ -20,6 +20,8 @@
  *
  */
 
+using System;
+
 namespace MetaphysicsIndustries.Solus.Values
 {
     public readonly struct Interval : IMathObject
@@ -27,6 +29,24 @@ namespace MetaphysicsIndustries.Solus.Values
         public Interval(float lowerBound, bool openLowerBound,
             float upperBound, bool openUpperBound, bool isIntegerInterval)
         {
+            if (float.IsNaN(lowerBound))
+                throw new ArgumentOutOfRangeException(
+                    nameof(lowerBound), "Not a number");
+            if (float.IsNaN(upperBound))
+                throw new ArgumentOutOfRangeException(
+                    nameof(upperBound), "Not a number");
+
+            if (lowerBound > upperBound)
+            {
+                var tempf = upperBound;
+                upperBound = lowerBound;
+                lowerBound = tempf;
+
+                var tempb = openUpperBound;
+                openUpperBound = openLowerBound;
+                openLowerBound = tempb;
+            }
+
             LowerBound = lowerBound;
             OpenLowerBound = openLowerBound;
             UpperBound = upperBound;

--- a/Values/Interval.cs
+++ b/Values/Interval.cs
@@ -1,0 +1,66 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2021 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+namespace MetaphysicsIndustries.Solus.Values
+{
+    public readonly struct Interval
+    {
+        public Interval(float lowerBound, bool openLowerBound,
+            float upperBound, bool openUpperBound, bool isIntegerInterval)
+        {
+            LowerBound = lowerBound;
+            OpenLowerBound = openLowerBound;
+            UpperBound = upperBound;
+            OpenUpperBound = openUpperBound;
+            IsIntegerInterval = isIntegerInterval;
+        }
+
+        public readonly float LowerBound;
+        public readonly float UpperBound;
+        public float Length => UpperBound - LowerBound;
+
+        public readonly bool OpenLowerBound;
+        public readonly bool OpenUpperBound;
+
+        public readonly bool IsIntegerInterval;
+
+        public static Interval Integer(int lower, int upper)
+        {
+            return new Interval(
+                lower, false,
+                upper, false,
+                true);
+        }
+
+        public Interval Round()
+        {
+            return Integer(LowerBound.RoundInt(), UpperBound.RoundInt());
+        }
+
+        public float CalcDelta(int numSteps) =>
+            (UpperBound - LowerBound) / (numSteps - 1);
+
+        // TODO: Contains number
+        // TODO: intersects other interval
+        // TODO: IMathObject
+    }
+}

--- a/Values/Matrix.cs
+++ b/Values/Matrix.cs
@@ -75,6 +75,7 @@ namespace MetaphysicsIndustries.Solus.Values
             new[] { RowCount, ColumnCount };
 
         public int? GetVectorLength(SolusEnvironment env) => null;
+        public bool? IsInterval(SolusEnvironment env) => false;
 
         public bool IsConcrete => true;
 

--- a/Values/Number.cs
+++ b/Values/Number.cs
@@ -41,6 +41,7 @@ namespace MetaphysicsIndustries.Solus.Values
         public int? GetDimension(SolusEnvironment env, int index) => null;
         public int[] GetDimensions(SolusEnvironment env) => null;
         public int? GetVectorLength(SolusEnvironment env) => null;
+        public bool? IsInterval(SolusEnvironment env) => false;
         public bool IsConcrete => true;
 
         public override string ToString()

--- a/Values/StringValue.cs
+++ b/Values/StringValue.cs
@@ -54,6 +54,7 @@ namespace MetaphysicsIndustries.Solus.Values
         }
 
         public int? GetVectorLength(SolusEnvironment env) => null;
+        public bool? IsInterval(SolusEnvironment env) => false;
         public bool IsConcrete => true;
 
         public int Length => Value?.Length ?? 0;

--- a/Values/VarInterval.cs
+++ b/Values/VarInterval.cs
@@ -1,0 +1,47 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2021 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+namespace MetaphysicsIndustries.Solus.Values
+{
+    public readonly struct VarInterval
+    {
+        public VarInterval(string variable, Interval interval)
+        {
+            Variable = variable;
+            Interval = interval;
+        }
+
+        public readonly string Variable;
+        public readonly Interval Interval;
+
+        public override string ToString()
+        {
+            return string.Format(
+                "{0} {1} {2} {3} {4}",
+                Interval.LowerBound,
+                (Interval.OpenLowerBound ? "<" : "<="),
+                Variable,
+                (Interval.OpenUpperBound ? "<" : "<="),
+                Interval.UpperBound);
+        }
+    }
+}

--- a/Values/Vector.cs
+++ b/Values/Vector.cs
@@ -67,6 +67,7 @@ namespace MetaphysicsIndustries.Solus.Values
 
         public int[] GetDimensions(SolusEnvironment env) => new[] {Length};
         public int? GetVectorLength(SolusEnvironment env) => Length;
+        public bool? IsInterval(SolusEnvironment env) => false;
 
         public bool IsConcrete => true;
 

--- a/todo.txt
+++ b/todo.txt
@@ -15,6 +15,8 @@ bug: when assigning a variable, any variables in its expression are
     Basically, this is caused by calling PreliminaryEval on inputs. Probably
         we should call PreliminaryEval and just pass it an empty environment.
         That way, it wouldn't automatically resolve variable references.
+should Expression.Clone be shallow or deep?
+    or should it be removed altogether?
 unify the namespace
     so that `vars` and `delete` and friends all work consistently and
     predictably

--- a/todo.txt
+++ b/todo.txt
@@ -36,6 +36,7 @@ figure out some solution to the problem of values being boxed and unboxed so
     much. It's causing lots of allocations and is just slow in general.
 simple sets as IMathObject
 intervals
+    syntax
     intersects other interval
     interior
     closure
@@ -43,6 +44,7 @@ intervals
     is subinterval of
     is proper subinterval of
     bounded vs unbounded (requires infinity)
+    IMathObject.IsSet(env) => true
 
 more complicated expression-based sets
 complex numbers

--- a/todo.txt
+++ b/todo.txt
@@ -32,7 +32,16 @@ markers of the type of the result of an expression (or return value of a
     function), based on inputs
 figure out some solution to the problem of values being boxed and unboxed so
     much. It's causing lots of allocations and is just slow in general.
-simple sets and intervals as IMathObject
+simple sets as IMathObject
+intervals
+    intersects other interval
+    interior
+    closure
+    interval closure/interval span (may require sets)
+    is subinterval of
+    is proper subinterval of
+    bounded vs unbounded (requires infinity)
+
 more complicated expression-based sets
 complex numbers
 tensors of rank 3 or more


### PR DESCRIPTION
This PR adds functionality for intervals. There is no real way to use them via the grammar, yet. Typical interval notation (e.g `[a,b]`, `(a,b]`) conflicts with existing syntax. Nevertheless, a lot of the plumbing is herein provided. They will useful for alot of internal things, even if the CLI end-user can't use them yet.

Most of the code changes are new test code.