### PR TITLE
Evaluator 2 storage and aggregate ops

### DIFF
--- a/Evaluator.cs
+++ b/Evaluator.cs
@@ -41,15 +41,31 @@ namespace MetaphysicsIndustries.Solus
             return cleanup.CleanUp(expr.Simplify(env));
         }
 
-        public class StoreOp1<T>
+        public abstract class StoreOp1
+        {
+            public abstract void Store(int index, IMathObject value);
+            public abstract void SetMinArraySize(int length);
+        }
+
+        public class StoreOp1<T> : StoreOp1
             where T : IMathObject
         {
             public T[] Values;
+
+            public override void Store(int index, IMathObject value)
+            {
+                Values[index] = (T)value;
+            }
+
+            public override void SetMinArraySize(int length)
+            {
+                if (Values == null || Values.Length < length)
+                    Values = new T[length];
+            }
         }
 
-        public void EvalInterval<T>(Expression expr, SolusEnvironment env,
-            VarInterval interval, int numSteps, StoreOp1<T> store)
-            where T : IMathObject
+        public void EvalInterval(Expression expr, SolusEnvironment env,
+            VarInterval interval, int numSteps, StoreOp1 store)
         {
             var delta = interval.Interval.CalcDelta(numSteps);
 
@@ -61,8 +77,7 @@ namespace MetaphysicsIndustries.Solus
             env2.SetVariable(interval.Variable, literal);
 
             if (store != null)
-                if (store.Values == null || store.Values.Length < numSteps)
-                    store.Values = new T[numSteps];
+                store.SetMinArraySize(numSteps);
 
             int i;
             for (i = 0; i < numSteps; i++)
@@ -71,22 +86,45 @@ namespace MetaphysicsIndustries.Solus
                 literal.Value = xx.ToNumber();
                 var v = Eval(expr2, env2);
                 if (store != null)
-                    store.Values[i] = (T)v;
+                    store.Store(i, v);
             }
         }
 
-        public class StoreOp2<T>
+        public abstract class StoreOp2
+        {
+            public abstract void Store(int index0, int index1,
+                IMathObject value);
+
+            public abstract void SetMinArraySize(int length0, int length1);
+        }
+
+        public class StoreOp2<T> : StoreOp2
             where T : IMathObject
         {
             public T[,] Values;
+
+            public override void Store(int index0, int index1,
+                IMathObject value)
+            {
+                Values[index0, index1] = (T)value;
+            }
+
+            public override void SetMinArraySize(int length0, int length1)
+            {
+                if (Values == null ||
+                    Values.GetLength(0) < length0 ||
+                    Values.GetLength(1) < length1)
+                {
+                    Values = new T[length0, length1];
+                }
+            }
         }
 
-        public void EvalInterval<T>(
+        public void EvalInterval(
             Expression expr, SolusEnvironment env,
             VarInterval interval1, int numSteps1,
             VarInterval interval2, int numSteps2,
-            StoreOp2<T> store)
-            where T : IMathObject
+            StoreOp2 store)
         {
             var delta1 = interval1.Interval.CalcDelta(numSteps1);
             var delta2 = interval2.Interval.CalcDelta(numSteps2);
@@ -113,12 +151,7 @@ namespace MetaphysicsIndustries.Solus
             env2.SetVariable(interval2.Variable, literal2);
 
             if (store != null)
-                if (store.Values == null ||
-                    store.Values.GetLength(0) < numSteps1 ||
-                    store.Values.GetLength(1) < numSteps2)
-                {
-                    store.Values = new T[numSteps1, numSteps2];
-                }
+                store.SetMinArraySize(numSteps1, numSteps2);
 
             for (i = 0; i < numSteps1; i++)
             {
@@ -129,24 +162,50 @@ namespace MetaphysicsIndustries.Solus
                     literal2.Value = inputs2[j];
                     var v = Eval(expr2, env2);
                     if (store != null)
-                        store.Values[i, j] = (T)v;
+                        store.Store(i, j, v);
                 }
             }
         }
 
-        public class StoreOp3<T>
+        public abstract class StoreOp3
+        {
+            public abstract void Store(int index0, int index1, int index2,
+                IMathObject value);
+
+            public abstract void SetMinArraySize(int length0, int length1,
+                int length2);
+        }
+
+        public class StoreOp3<T> : StoreOp3
             where T : IMathObject
         {
             public T[,,] Values;
+
+            public override void Store(int index0, int index1, int index2,
+                IMathObject value)
+            {
+                Values[index0, index1, index2] = (T)value;
+            }
+
+            public override void SetMinArraySize(int length0, int length1,
+                int length2)
+            {
+                if (Values == null ||
+                    Values.GetLength(0) < length0 ||
+                    Values.GetLength(1) < length1 ||
+                    Values.GetLength(2) < length2)
+                {
+                    Values = new T[length0, length1, length2];
+                }
+            }
         }
 
-        public void EvalInterval<T>(
+        public void EvalInterval(
             Expression expr, SolusEnvironment env,
             VarInterval interval1, int numSteps1,
             VarInterval interval2, int numSteps2,
             VarInterval interval3, int numSteps3,
-            StoreOp3<T> store)
-            where T : IMathObject
+            StoreOp3 store)
         {
             var delta1 = interval1.Interval.CalcDelta(numSteps1);
             var delta2 = interval2.Interval.CalcDelta(numSteps2);
@@ -181,13 +240,7 @@ namespace MetaphysicsIndustries.Solus
             env2.SetVariable(interval3.Variable, literal3);
 
             if (store != null)
-                if (store.Values == null ||
-                    store.Values.GetLength(0) < numSteps1 ||
-                    store.Values.GetLength(1) < numSteps2 ||
-                    store.Values.GetLength(2) < numSteps3)
-                {
-                    store.Values = new T[numSteps1, numSteps2, numSteps3];
-                }
+                store.SetMinArraySize(numSteps1, numSteps2, numSteps3);
 
             for (i = 0; i < numSteps1; i++)
             {
@@ -202,7 +255,7 @@ namespace MetaphysicsIndustries.Solus
                         literal3.Value = inputs3[k];
                         var v = Eval(expr2, env2);
                         if (store != null)
-                            store.Values[i, j, k] = (T)v;
+                            store.Store(i, j, k, v);
                     }
                 }
             }

--- a/Evaluator.cs
+++ b/Evaluator.cs
@@ -83,7 +83,7 @@ namespace MetaphysicsIndustries.Solus
 
         public void EvalInterval(Expression expr, SolusEnvironment env,
             VarInterval interval, int numSteps, StoreOp1 store,
-            AggregateOp aggr=null)
+            AggregateOp[] aggrs = null)
         {
             var delta = interval.Interval.CalcDelta(numSteps);
 
@@ -105,7 +105,9 @@ namespace MetaphysicsIndustries.Solus
                 var v = Eval(expr2, env2);
                 if (store != null)
                     store.Store(i, v);
-                aggr?.Operate(v);
+                if (aggrs != null)
+                    foreach (var aggr in aggrs)
+                        aggr?.Operate(v);
             }
         }
 
@@ -143,7 +145,7 @@ namespace MetaphysicsIndustries.Solus
             Expression expr, SolusEnvironment env,
             VarInterval interval1, int numSteps1,
             VarInterval interval2, int numSteps2,
-            StoreOp2 store, AggregateOp aggr=null)
+            StoreOp2 store, AggregateOp[] aggrs = null)
         {
             var delta1 = interval1.Interval.CalcDelta(numSteps1);
             var delta2 = interval2.Interval.CalcDelta(numSteps2);
@@ -182,7 +184,9 @@ namespace MetaphysicsIndustries.Solus
                     var v = Eval(expr2, env2);
                     if (store != null)
                         store.Store(i, j, v);
-                    aggr?.Operate(v);
+                    if (aggrs != null)
+                        foreach (var aggr in aggrs)
+                            aggr?.Operate(v);
                 }
             }
         }
@@ -225,7 +229,7 @@ namespace MetaphysicsIndustries.Solus
             VarInterval interval1, int numSteps1,
             VarInterval interval2, int numSteps2,
             VarInterval interval3, int numSteps3,
-            StoreOp3 store, AggregateOp aggr=null)
+            StoreOp3 store, AggregateOp[] aggrs = null)
         {
             var delta1 = interval1.Interval.CalcDelta(numSteps1);
             var delta2 = interval2.Interval.CalcDelta(numSteps2);
@@ -276,7 +280,9 @@ namespace MetaphysicsIndustries.Solus
                         var v = Eval(expr2, env2);
                         if (store != null)
                             store.Store(i, j, k, v);
-                        aggr?.Operate(v);
+                        if (aggrs != null)
+                            foreach (var aggr in aggrs)
+                                aggr?.Operate(v);
                     }
                 }
             }

--- a/Evaluator.cs
+++ b/Evaluator.cs
@@ -20,6 +20,7 @@
  *
  */
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using MetaphysicsIndustries.Solus.Expressions;
@@ -64,8 +65,25 @@ namespace MetaphysicsIndustries.Solus
             }
         }
 
+        public abstract class AggregateOp
+        {
+            public abstract void Operate(IMathObject input);
+        }
+
+        public class AggregateOp<TIn, TOut> : AggregateOp
+        {
+            public TOut State;
+            public Func<TIn, TOut, TOut> Function;
+
+            public override void Operate(IMathObject input)
+            {
+                State = Function((TIn)input, State);
+            }
+        }
+
         public void EvalInterval(Expression expr, SolusEnvironment env,
-            VarInterval interval, int numSteps, StoreOp1 store)
+            VarInterval interval, int numSteps, StoreOp1 store,
+            AggregateOp aggr=null)
         {
             var delta = interval.Interval.CalcDelta(numSteps);
 
@@ -87,6 +105,7 @@ namespace MetaphysicsIndustries.Solus
                 var v = Eval(expr2, env2);
                 if (store != null)
                     store.Store(i, v);
+                aggr?.Operate(v);
             }
         }
 
@@ -124,7 +143,7 @@ namespace MetaphysicsIndustries.Solus
             Expression expr, SolusEnvironment env,
             VarInterval interval1, int numSteps1,
             VarInterval interval2, int numSteps2,
-            StoreOp2 store)
+            StoreOp2 store, AggregateOp aggr=null)
         {
             var delta1 = interval1.Interval.CalcDelta(numSteps1);
             var delta2 = interval2.Interval.CalcDelta(numSteps2);
@@ -163,6 +182,7 @@ namespace MetaphysicsIndustries.Solus
                     var v = Eval(expr2, env2);
                     if (store != null)
                         store.Store(i, j, v);
+                    aggr?.Operate(v);
                 }
             }
         }
@@ -205,7 +225,7 @@ namespace MetaphysicsIndustries.Solus
             VarInterval interval1, int numSteps1,
             VarInterval interval2, int numSteps2,
             VarInterval interval3, int numSteps3,
-            StoreOp3 store)
+            StoreOp3 store, AggregateOp aggr=null)
         {
             var delta1 = interval1.Interval.CalcDelta(numSteps1);
             var delta2 = interval2.Interval.CalcDelta(numSteps2);
@@ -256,6 +276,7 @@ namespace MetaphysicsIndustries.Solus
                         var v = Eval(expr2, env2);
                         if (store != null)
                             store.Store(i, j, k, v);
+                        aggr?.Operate(v);
                     }
                 }
             }

--- a/Evaluator.cs
+++ b/Evaluator.cs
@@ -41,8 +41,13 @@ namespace MetaphysicsIndustries.Solus
             return cleanup.CleanUp(expr.Simplify(env));
         }
 
+        public class StoreOp1
+        {
+            public float[] Values;
+        }
+
         public void EvalInterval(Expression expr, SolusEnvironment env,
-            VarInterval interval, int numSteps, ref float[] values)
+            VarInterval interval, int numSteps, StoreOp1 store)
         {
             var delta = interval.Interval.CalcDelta(numSteps);
 
@@ -53,23 +58,31 @@ namespace MetaphysicsIndustries.Solus
             var literal = new Literal(0);
             env2.SetVariable(interval.Variable, literal);
 
-            if (values == null || values.Length < numSteps)
-                values = new float[numSteps];
+            if (store != null)
+                if (store.Values == null || store.Values.Length < numSteps)
+                    store.Values = new float[numSteps];
 
             int i;
             for (i = 0; i < numSteps; i++)
             {
                 var xx = delta * i + interval.Interval.LowerBound;
                 literal.Value = xx.ToNumber();
-                values[i] = Eval(expr2, env2).ToNumber().Value;
+                var v = Eval(expr2, env2).ToNumber().Value;
+                if (store != null)
+                    store.Values[i] = v;
             }
+        }
+
+        public class StoreOp2
+        {
+            public float[,] Values;
         }
 
         public void EvalInterval(
             Expression expr, SolusEnvironment env,
             VarInterval interval1, int numSteps1,
             VarInterval interval2, int numSteps2,
-            ref float[,] values)
+            StoreOp2 store)
         {
             var delta1 = interval1.Interval.CalcDelta(numSteps1);
             var delta2 = interval2.Interval.CalcDelta(numSteps2);
@@ -95,12 +108,13 @@ namespace MetaphysicsIndustries.Solus
             env2.SetVariable(interval1.Variable, literal1);
             env2.SetVariable(interval2.Variable, literal2);
 
-            if (values == null ||
-                values.GetLength(0) < numSteps1 ||
-                values.GetLength(1) < numSteps2)
-            {
-                values = new float[numSteps1, numSteps2];
-            }
+            if (store != null)
+                if (store.Values == null ||
+                    store.Values.GetLength(0) < numSteps1 ||
+                    store.Values.GetLength(1) < numSteps2)
+                {
+                    store.Values = new float[numSteps1, numSteps2];
+                }
 
             for (i = 0; i < numSteps1; i++)
             {
@@ -109,9 +123,16 @@ namespace MetaphysicsIndustries.Solus
                 for (j = 0; j < numSteps2; j++)
                 {
                     literal2.Value = inputs2[j];
-                    values[i, j] = Eval(expr2, env2).ToNumber().Value;
+                    var v = Eval(expr2, env2).ToNumber().Value;
+                    if (store != null)
+                        store.Values[i, j] = v;
                 }
             }
+        }
+
+        public class StoreOp3
+        {
+            public float[,,] Values;
         }
 
         public void EvalInterval(
@@ -119,7 +140,7 @@ namespace MetaphysicsIndustries.Solus
             VarInterval interval1, int numSteps1,
             VarInterval interval2, int numSteps2,
             VarInterval interval3, int numSteps3,
-            ref float[,,] values)
+            StoreOp3 store)
         {
             var delta1 = interval1.Interval.CalcDelta(numSteps1);
             var delta2 = interval2.Interval.CalcDelta(numSteps2);
@@ -153,13 +174,14 @@ namespace MetaphysicsIndustries.Solus
             env2.SetVariable(interval2.Variable, literal2);
             env2.SetVariable(interval3.Variable, literal3);
 
-            if (values == null ||
-                values.GetLength(0) < numSteps1 ||
-                values.GetLength(1) < numSteps2 ||
-                values.GetLength(2) < numSteps3)
-            {
-                values = new float[numSteps1, numSteps2, numSteps3];
-            }
+            if (store != null)
+                if (store.Values == null ||
+                    store.Values.GetLength(0) < numSteps1 ||
+                    store.Values.GetLength(1) < numSteps2 ||
+                    store.Values.GetLength(2) < numSteps3)
+                {
+                    store.Values = new float[numSteps1, numSteps2, numSteps3];
+                }
 
             for (i = 0; i < numSteps1; i++)
             {
@@ -172,14 +194,16 @@ namespace MetaphysicsIndustries.Solus
                     for (k = 0; k < numSteps3; k++)
                     {
                         literal3.Value = inputs3[k];
-                        values[i, j, k] = Eval(expr2, env2).ToNumber().Value;
+                        var v = Eval(expr2, env2).ToNumber().Value;
+                        if (store != null)
+                            store.Values[i, j, k] = v;
                     }
                 }
             }
         }
 
         public void EvalMathPaint(Expression expr, SolusEnvironment env,
-            int width, int height, ref float[,] values)
+            int width, int height, StoreOp2 store)
         {
             //previous values?
             SolusParser parser = new SolusParser();
@@ -198,13 +222,13 @@ namespace MetaphysicsIndustries.Solus
             EvalInterval(expr, env,
                 interval1, width,
                 interval2, height,
-                ref values);
+                store);
         }
 
 
         public void EvalMathPaint3D(Expression expr,
             SolusEnvironment env, int width, int height, int numFrames,
-            ref float[,,] values)
+            StoreOp3 store)
         {
             //previous values?
             SolusParser parser = new SolusParser();
@@ -229,7 +253,7 @@ namespace MetaphysicsIndustries.Solus
                 interval1, width,
                 interval2, height,
                 interval3, numFrames,
-                ref values);
+                store);
         }
 
         public static string[] GatherVariables(Expression expr)

--- a/Evaluator.cs
+++ b/Evaluator.cs
@@ -41,13 +41,15 @@ namespace MetaphysicsIndustries.Solus
             return cleanup.CleanUp(expr.Simplify(env));
         }
 
-        public class StoreOp1
+        public class StoreOp1<T>
+            where T : IMathObject
         {
-            public float[] Values;
+            public T[] Values;
         }
 
-        public void EvalInterval(Expression expr, SolusEnvironment env,
-            VarInterval interval, int numSteps, StoreOp1 store)
+        public void EvalInterval<T>(Expression expr, SolusEnvironment env,
+            VarInterval interval, int numSteps, StoreOp1<T> store)
+            where T : IMathObject
         {
             var delta = interval.Interval.CalcDelta(numSteps);
 
@@ -60,29 +62,31 @@ namespace MetaphysicsIndustries.Solus
 
             if (store != null)
                 if (store.Values == null || store.Values.Length < numSteps)
-                    store.Values = new float[numSteps];
+                    store.Values = new T[numSteps];
 
             int i;
             for (i = 0; i < numSteps; i++)
             {
                 var xx = delta * i + interval.Interval.LowerBound;
                 literal.Value = xx.ToNumber();
-                var v = Eval(expr2, env2).ToNumber().Value;
+                var v = Eval(expr2, env2);
                 if (store != null)
-                    store.Values[i] = v;
+                    store.Values[i] = (T)v;
             }
         }
 
-        public class StoreOp2
+        public class StoreOp2<T>
+            where T : IMathObject
         {
-            public float[,] Values;
+            public T[,] Values;
         }
 
-        public void EvalInterval(
+        public void EvalInterval<T>(
             Expression expr, SolusEnvironment env,
             VarInterval interval1, int numSteps1,
             VarInterval interval2, int numSteps2,
-            StoreOp2 store)
+            StoreOp2<T> store)
+            where T : IMathObject
         {
             var delta1 = interval1.Interval.CalcDelta(numSteps1);
             var delta2 = interval2.Interval.CalcDelta(numSteps2);
@@ -113,7 +117,7 @@ namespace MetaphysicsIndustries.Solus
                     store.Values.GetLength(0) < numSteps1 ||
                     store.Values.GetLength(1) < numSteps2)
                 {
-                    store.Values = new float[numSteps1, numSteps2];
+                    store.Values = new T[numSteps1, numSteps2];
                 }
 
             for (i = 0; i < numSteps1; i++)
@@ -123,24 +127,26 @@ namespace MetaphysicsIndustries.Solus
                 for (j = 0; j < numSteps2; j++)
                 {
                     literal2.Value = inputs2[j];
-                    var v = Eval(expr2, env2).ToNumber().Value;
+                    var v = Eval(expr2, env2);
                     if (store != null)
-                        store.Values[i, j] = v;
+                        store.Values[i, j] = (T)v;
                 }
             }
         }
 
-        public class StoreOp3
+        public class StoreOp3<T>
+            where T : IMathObject
         {
-            public float[,,] Values;
+            public T[,,] Values;
         }
 
-        public void EvalInterval(
+        public void EvalInterval<T>(
             Expression expr, SolusEnvironment env,
             VarInterval interval1, int numSteps1,
             VarInterval interval2, int numSteps2,
             VarInterval interval3, int numSteps3,
-            StoreOp3 store)
+            StoreOp3<T> store)
+            where T : IMathObject
         {
             var delta1 = interval1.Interval.CalcDelta(numSteps1);
             var delta2 = interval2.Interval.CalcDelta(numSteps2);
@@ -180,7 +186,7 @@ namespace MetaphysicsIndustries.Solus
                     store.Values.GetLength(1) < numSteps2 ||
                     store.Values.GetLength(2) < numSteps3)
                 {
-                    store.Values = new float[numSteps1, numSteps2, numSteps3];
+                    store.Values = new T[numSteps1, numSteps2, numSteps3];
                 }
 
             for (i = 0; i < numSteps1; i++)
@@ -194,16 +200,16 @@ namespace MetaphysicsIndustries.Solus
                     for (k = 0; k < numSteps3; k++)
                     {
                         literal3.Value = inputs3[k];
-                        var v = Eval(expr2, env2).ToNumber().Value;
+                        var v = Eval(expr2, env2);
                         if (store != null)
-                            store.Values[i, j, k] = v;
+                            store.Values[i, j, k] = (T)v;
                     }
                 }
             }
         }
 
         public void EvalMathPaint(Expression expr, SolusEnvironment env,
-            int width, int height, StoreOp2 store)
+            int width, int height, StoreOp2<Number> store)
         {
             //previous values?
             SolusParser parser = new SolusParser();
@@ -228,7 +234,7 @@ namespace MetaphysicsIndustries.Solus
 
         public void EvalMathPaint3D(Expression expr,
             SolusEnvironment env, int width, int height, int numFrames,
-            StoreOp3 store)
+            StoreOp3<Number> store)
         {
             //previous values?
             SolusParser parser = new SolusParser();

--- a/Functions/MaximumFiniteFunction.cs
+++ b/Functions/MaximumFiniteFunction.cs
@@ -1,0 +1,89 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2021 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using System;
+using System.Collections.Generic;
+using MetaphysicsIndustries.Solus.Values;
+
+namespace MetaphysicsIndustries.Solus.Functions
+{
+    public class MaximumFiniteFunction : Function
+    {
+        public static readonly MaximumFiniteFunction Value =
+            new MaximumFiniteFunction();
+
+        public MaximumFiniteFunction() :
+            base(new Types[0], "maxf")
+        {
+        }
+
+        public override string DocString =>
+            "The maxf function\n  maxf(x1, x2, ..., xn)\n\n" +
+            "Returns the maximum of all finite arguments. Infinities and " +
+            "NaN are ignored. If no finite numbers are given, NaN is " +
+            "returned.";
+
+        public override void CheckArguments(IMathObject[] args)
+        {
+            if (args.Length < 1)
+                throw new ArgumentException("No arguments passed");
+            for (var i = 0; i < args.Length; i++)
+            {
+                var argtype = args[i].GetMathType();
+                if (argtype != Types.Scalar)
+                    throw new ArgumentException(
+                        $"Argument {i} wrong type: expected " +
+                        $"Scalar but got {argtype}");
+            }
+        }
+
+        protected override IMathObject InternalCall(SolusEnvironment env,
+            IMathObject[] args)
+        {
+            int i;
+            float current = float.NaN;
+            bool first = true;
+            for (i = 0; i < args.Length; i++)
+            {
+                var value = args[i].ToNumber().Value;
+                if (!float.IsInfinity(value) &&
+                    !float.IsNaN(value))
+                {
+                    if (first)
+                    {
+                        current = value;
+                        first = false;
+                    }
+                    else
+                        current = Math.Max(current, value);
+                }
+            }
+
+            return current.ToNumber();
+        }
+
+        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        {
+            return ScalarMathObject.Value;
+        }
+    }
+}

--- a/Functions/MaximumFunction.cs
+++ b/Functions/MaximumFunction.cs
@@ -1,0 +1,73 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2021 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using System;
+using System.Collections.Generic;
+using MetaphysicsIndustries.Solus.Values;
+
+namespace MetaphysicsIndustries.Solus.Functions
+{
+    public class MaximumFunction : Function
+    {
+        public static readonly MaximumFunction Value = new MaximumFunction();
+
+        public MaximumFunction() :
+            base(new Types[0], "max")
+        {
+        }
+
+        public override string DocString =>
+            "The max function\n  max(x1, x2, ..., xn)\n\n" +
+            "Returns the maximum of all arguments.";
+
+        public override void CheckArguments(IMathObject[] args)
+        {
+            if (args.Length < 1)
+                throw new ArgumentException("No arguments passed");
+            for (var i = 0; i < args.Length; i++)
+            {
+                var argtype = args[i].GetMathType();
+                if (argtype != Types.Scalar)
+                    throw new ArgumentException(
+                        $"Argument {i} wrong type: expected " +
+                        $"Scalar but got {argtype}");
+            }
+        }
+
+        protected override IMathObject InternalCall(SolusEnvironment env,
+            IMathObject[] args)
+        {
+            int i;
+            var current = args[0].ToNumber().Value;
+            for (i = 1; i < args.Length; i++)
+                current = Math.Max(
+                    current,
+                    args[i].ToNumber().Value);
+            return current.ToNumber();
+        }
+
+        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        {
+            return ScalarMathObject.Value;
+        }
+    }
+}

--- a/Functions/MinimumFiniteFunction.cs
+++ b/Functions/MinimumFiniteFunction.cs
@@ -1,0 +1,89 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2021 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using System;
+using System.Collections.Generic;
+using MetaphysicsIndustries.Solus.Values;
+
+namespace MetaphysicsIndustries.Solus.Functions
+{
+    public class MinimumFiniteFunction : Function
+    {
+        public static readonly MinimumFiniteFunction Value =
+            new MinimumFiniteFunction();
+
+        public MinimumFiniteFunction() :
+            base(new Types[0], "minf")
+        {
+        }
+
+        public override string DocString =>
+            "The minf function\n  minf(x1, x2, ..., xn)\n\n" +
+            "Returns the minimum of all finite arguments. Infinities and " +
+            "NaN are ignored. If no finite numbers are given, NaN is " +
+            "returned.";
+
+        public override void CheckArguments(IMathObject[] args)
+        {
+            if (args.Length < 1)
+                throw new ArgumentException("No arguments passed");
+            for (var i = 0; i < args.Length; i++)
+            {
+                var argtype = args[i].GetMathType();
+                if (argtype != Types.Scalar)
+                    throw new ArgumentException(
+                        $"Argument {i} wrong type: expected " +
+                        $"Scalar but got {argtype}");
+            }
+        }
+
+        protected override IMathObject InternalCall(SolusEnvironment env,
+            IMathObject[] args)
+        {
+            int i;
+            float current = float.NaN;
+            bool first = true;
+            for (i = 0; i < args.Length; i++)
+            {
+                var value = args[i].ToNumber().Value;
+                if (!float.IsInfinity(value) &&
+                    !float.IsNaN(value))
+                {
+                    if (first)
+                    {
+                        current = value;
+                        first = false;
+                    }
+                    else
+                        current = Math.Min(current, value);
+                }
+            }
+
+            return current.ToNumber();
+        }
+
+        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        {
+            return ScalarMathObject.Value;
+        }
+    }
+}

--- a/Functions/MinimumFunction.cs
+++ b/Functions/MinimumFunction.cs
@@ -1,0 +1,73 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2021 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using System;
+using System.Collections.Generic;
+using MetaphysicsIndustries.Solus.Values;
+
+namespace MetaphysicsIndustries.Solus.Functions
+{
+    public class MinimumFunction : Function
+    {
+        public static readonly MinimumFunction Value = new MinimumFunction();
+
+        public MinimumFunction() :
+            base(new Types[0], "min")
+        {
+        }
+
+        public override string DocString =>
+            "The min function\n  min(x1, x2, ..., xn)\n\n" +
+            "Returns the minimum of all arguments.";
+
+        public override void CheckArguments(IMathObject[] args)
+        {
+            if (args.Length < 1)
+                throw new ArgumentException("No arguments passed");
+            for (var i = 0; i < args.Length; i++)
+            {
+                var argtype = args[i].GetMathType();
+                if (argtype != Types.Scalar)
+                    throw new ArgumentException(
+                        $"Argument {i} wrong type: expected " +
+                        $"Scalar but got {argtype}");
+            }
+        }
+
+        protected override IMathObject InternalCall(SolusEnvironment env,
+            IMathObject[] args)
+        {
+            int i;
+            var current = args[0].ToNumber().Value;
+            for (i = 1; i < args.Length; i++)
+                current = Math.Min(
+                    current,
+                    args[i].ToNumber().Value);
+            return current.ToNumber();
+        }
+
+        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        {
+            return ScalarMathObject.Value;
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorT/EvalIntervalTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorT/EvalIntervalTest.cs
@@ -42,17 +42,17 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorT
             var interval = new VarInterval("x",
                 new Interval(2, false, 6, false, false));
             var numSteps = 5;
-            float[] values = null;
+            var store = new Evaluator.StoreOp1();
             // when
-            eval.EvalInterval(expr, env, interval, numSteps, ref values);
+            eval.EvalInterval(expr, env, interval, numSteps, store);
             // then
-            Assert.IsNotNull(values);
-            Assert.AreEqual(5, values.Length);
-            Assert.AreEqual(4, values[0]);
-            Assert.AreEqual(9, values[1]);
-            Assert.AreEqual(16, values[2]);
-            Assert.AreEqual(25, values[3]);
-            Assert.AreEqual(36, values[4]);
+            Assert.IsNotNull(store.Values);
+            Assert.AreEqual(5, store.Values.Length);
+            Assert.AreEqual(4, store.Values[0]);
+            Assert.AreEqual(9, store.Values[1]);
+            Assert.AreEqual(16, store.Values[2]);
+            Assert.AreEqual(25, store.Values[3]);
+            Assert.AreEqual(36, store.Values[4]);
         }
 
         [Test]
@@ -70,51 +70,51 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorT
             var interval2 = new VarInterval("y",
                 new Interval(7, false, 12, false, false));
             var numSteps2 = 6;
-            float[,] values = null;
+            var store = new Evaluator.StoreOp2();
             // when
             eval.EvalInterval(expr, env,
                 interval1, numSteps1,
                 interval2, numSteps2,
-                ref values);
+                store);
             // then
-            Assert.IsNotNull(values);
-            Assert.AreEqual(5, values.GetLength(0));
-            Assert.AreEqual(6, values.GetLength(1));
+            Assert.IsNotNull(store.Values);
+            Assert.AreEqual(5, store.Values.GetLength(0));
+            Assert.AreEqual(6, store.Values.GetLength(1));
 
-            Assert.AreEqual(14, values[0, 0]);
-            Assert.AreEqual(16, values[0, 1]);
-            Assert.AreEqual(18, values[0, 2]);
-            Assert.AreEqual(20, values[0, 3]);
-            Assert.AreEqual(22, values[0, 4]);
-            Assert.AreEqual(24, values[0, 5]);
+            Assert.AreEqual(14, store.Values[0, 0]);
+            Assert.AreEqual(16, store.Values[0, 1]);
+            Assert.AreEqual(18, store.Values[0, 2]);
+            Assert.AreEqual(20, store.Values[0, 3]);
+            Assert.AreEqual(22, store.Values[0, 4]);
+            Assert.AreEqual(24, store.Values[0, 5]);
 
-            Assert.AreEqual(21, values[1, 0]);
-            Assert.AreEqual(24, values[1, 1]);
-            Assert.AreEqual(27, values[1, 2]);
-            Assert.AreEqual(30, values[1, 3]);
-            Assert.AreEqual(33, values[1, 4]);
-            Assert.AreEqual(36, values[1, 5]);
+            Assert.AreEqual(21, store.Values[1, 0]);
+            Assert.AreEqual(24, store.Values[1, 1]);
+            Assert.AreEqual(27, store.Values[1, 2]);
+            Assert.AreEqual(30, store.Values[1, 3]);
+            Assert.AreEqual(33, store.Values[1, 4]);
+            Assert.AreEqual(36, store.Values[1, 5]);
 
-            Assert.AreEqual(28, values[2, 0]);
-            Assert.AreEqual(32, values[2, 1]);
-            Assert.AreEqual(36, values[2, 2]);
-            Assert.AreEqual(40, values[2, 3]);
-            Assert.AreEqual(44, values[2, 4]);
-            Assert.AreEqual(48, values[2, 5]);
+            Assert.AreEqual(28, store.Values[2, 0]);
+            Assert.AreEqual(32, store.Values[2, 1]);
+            Assert.AreEqual(36, store.Values[2, 2]);
+            Assert.AreEqual(40, store.Values[2, 3]);
+            Assert.AreEqual(44, store.Values[2, 4]);
+            Assert.AreEqual(48, store.Values[2, 5]);
 
-            Assert.AreEqual(35, values[3, 0]);
-            Assert.AreEqual(40, values[3, 1]);
-            Assert.AreEqual(45, values[3, 2]);
-            Assert.AreEqual(50, values[3, 3]);
-            Assert.AreEqual(55, values[3, 4]);
-            Assert.AreEqual(60, values[3, 5]);
+            Assert.AreEqual(35, store.Values[3, 0]);
+            Assert.AreEqual(40, store.Values[3, 1]);
+            Assert.AreEqual(45, store.Values[3, 2]);
+            Assert.AreEqual(50, store.Values[3, 3]);
+            Assert.AreEqual(55, store.Values[3, 4]);
+            Assert.AreEqual(60, store.Values[3, 5]);
 
-            Assert.AreEqual(42, values[4, 0]);
-            Assert.AreEqual(48, values[4, 1]);
-            Assert.AreEqual(54, values[4, 2]);
-            Assert.AreEqual(60, values[4, 3]);
-            Assert.AreEqual(66, values[4, 4]);
-            Assert.AreEqual(72, values[4, 5]);
+            Assert.AreEqual(42, store.Values[4, 0]);
+            Assert.AreEqual(48, store.Values[4, 1]);
+            Assert.AreEqual(54, store.Values[4, 2]);
+            Assert.AreEqual(60, store.Values[4, 3]);
+            Assert.AreEqual(66, store.Values[4, 4]);
+            Assert.AreEqual(72, store.Values[4, 5]);
         }
 
         [Test]
@@ -136,54 +136,54 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorT
             var interval3 = new VarInterval("z",
                 new Interval(7, false, 11, false, false));
             var numSteps3 = 5;
-            float[,,] values = null;
+            var store = new Evaluator.StoreOp3();
             // when
             eval.EvalInterval(expr, env,
                 interval1, numSteps1,
                 interval2, numSteps2,
                 interval3, numSteps3,
-                ref values);
+                store);
             // then
-            Assert.IsNotNull(values);
-            Assert.AreEqual(2, values.GetLength(0));
-            Assert.AreEqual(3, values.GetLength(1));
-            Assert.AreEqual(5, values.GetLength(2));
+            Assert.IsNotNull(store.Values);
+            Assert.AreEqual(2, store.Values.GetLength(0));
+            Assert.AreEqual(3, store.Values.GetLength(1));
+            Assert.AreEqual(5, store.Values.GetLength(2));
 
-            Assert.AreEqual(56, values[0, 0, 0]);
-            Assert.AreEqual(64, values[0, 0, 1]);
-            Assert.AreEqual(72, values[0, 0, 2]);
-            Assert.AreEqual(80, values[0, 0, 3]);
-            Assert.AreEqual(88, values[0, 0, 4]);
+            Assert.AreEqual(56, store.Values[0, 0, 0]);
+            Assert.AreEqual(64, store.Values[0, 0, 1]);
+            Assert.AreEqual(72, store.Values[0, 0, 2]);
+            Assert.AreEqual(80, store.Values[0, 0, 3]);
+            Assert.AreEqual(88, store.Values[0, 0, 4]);
 
-            Assert.AreEqual(70, values[0, 1, 0]);
-            Assert.AreEqual(80, values[0, 1, 1]);
-            Assert.AreEqual(90, values[0, 1, 2]);
-            Assert.AreEqual(100, values[0, 1, 3]);
-            Assert.AreEqual(110, values[0, 1, 4]);
+            Assert.AreEqual(70, store.Values[0, 1, 0]);
+            Assert.AreEqual(80, store.Values[0, 1, 1]);
+            Assert.AreEqual(90, store.Values[0, 1, 2]);
+            Assert.AreEqual(100, store.Values[0, 1, 3]);
+            Assert.AreEqual(110, store.Values[0, 1, 4]);
 
-            Assert.AreEqual(84, values[0, 2, 0]);
-            Assert.AreEqual(96, values[0, 2, 1]);
-            Assert.AreEqual(108, values[0, 2, 2]);
-            Assert.AreEqual(120, values[0, 2, 3]);
-            Assert.AreEqual(132, values[0, 2, 4]);
+            Assert.AreEqual(84, store.Values[0, 2, 0]);
+            Assert.AreEqual(96, store.Values[0, 2, 1]);
+            Assert.AreEqual(108, store.Values[0, 2, 2]);
+            Assert.AreEqual(120, store.Values[0, 2, 3]);
+            Assert.AreEqual(132, store.Values[0, 2, 4]);
 
-            Assert.AreEqual(84, values[1, 0, 0]);
-            Assert.AreEqual(96, values[1, 0, 1]);
-            Assert.AreEqual(108, values[1, 0, 2]);
-            Assert.AreEqual(120, values[1, 0, 3]);
-            Assert.AreEqual(132, values[1, 0, 4]);
+            Assert.AreEqual(84, store.Values[1, 0, 0]);
+            Assert.AreEqual(96, store.Values[1, 0, 1]);
+            Assert.AreEqual(108, store.Values[1, 0, 2]);
+            Assert.AreEqual(120, store.Values[1, 0, 3]);
+            Assert.AreEqual(132, store.Values[1, 0, 4]);
 
-            Assert.AreEqual(105, values[1, 1, 0]);
-            Assert.AreEqual(120, values[1, 1, 1]);
-            Assert.AreEqual(135, values[1, 1, 2]);
-            Assert.AreEqual(150, values[1, 1, 3]);
-            Assert.AreEqual(165, values[1, 1, 4]);
+            Assert.AreEqual(105, store.Values[1, 1, 0]);
+            Assert.AreEqual(120, store.Values[1, 1, 1]);
+            Assert.AreEqual(135, store.Values[1, 1, 2]);
+            Assert.AreEqual(150, store.Values[1, 1, 3]);
+            Assert.AreEqual(165, store.Values[1, 1, 4]);
 
-            Assert.AreEqual(126, values[1, 2, 0]);
-            Assert.AreEqual(144, values[1, 2, 1]);
-            Assert.AreEqual(162, values[1, 2, 2]);
-            Assert.AreEqual(180, values[1, 2, 3]);
-            Assert.AreEqual(198, values[1, 2, 4]);
+            Assert.AreEqual(126, store.Values[1, 2, 0]);
+            Assert.AreEqual(144, store.Values[1, 2, 1]);
+            Assert.AreEqual(162, store.Values[1, 2, 2]);
+            Assert.AreEqual(180, store.Values[1, 2, 3]);
+            Assert.AreEqual(198, store.Values[1, 2, 4]);
         }
 
         [Test]
@@ -196,7 +196,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorT
             var expr = parser.GetExpression("x*e^(-x*x-y*y)");
             var interval1 = new VarInterval("x", -2, 2);
             var interval2 = new VarInterval("y", -2, 2);
-            float[,] values = null;
+            var store = new Evaluator.StoreOp2();
             var eval = new Evaluator();
             env.SetVariable("e", new Literal(2.718281828f));
             // when
@@ -204,7 +204,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorT
             eval.EvalInterval(expr, env,
                 interval1, 4000,
                 interval2, 4000,
-                ref values);
+                store);
             int endTime = System.Environment.TickCount;
             // then
             Assert.LessOrEqual(endTime - startTime, 1);

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorT/EvalIntervalTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorT/EvalIntervalTest.cs
@@ -42,17 +42,17 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorT
             var interval = new VarInterval("x",
                 new Interval(2, false, 6, false, false));
             var numSteps = 5;
-            var store = new Evaluator.StoreOp1();
+            var store = new Evaluator.StoreOp1<Number>();
             // when
             eval.EvalInterval(expr, env, interval, numSteps, store);
             // then
             Assert.IsNotNull(store.Values);
             Assert.AreEqual(5, store.Values.Length);
-            Assert.AreEqual(4, store.Values[0]);
-            Assert.AreEqual(9, store.Values[1]);
-            Assert.AreEqual(16, store.Values[2]);
-            Assert.AreEqual(25, store.Values[3]);
-            Assert.AreEqual(36, store.Values[4]);
+            Assert.AreEqual(4, store.Values[0].Value);
+            Assert.AreEqual(9, store.Values[1].Value);
+            Assert.AreEqual(16, store.Values[2].Value);
+            Assert.AreEqual(25, store.Values[3].Value);
+            Assert.AreEqual(36, store.Values[4].Value);
         }
 
         [Test]
@@ -70,7 +70,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorT
             var interval2 = new VarInterval("y",
                 new Interval(7, false, 12, false, false));
             var numSteps2 = 6;
-            var store = new Evaluator.StoreOp2();
+            var store = new Evaluator.StoreOp2<Number>();
             // when
             eval.EvalInterval(expr, env,
                 interval1, numSteps1,
@@ -81,40 +81,40 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorT
             Assert.AreEqual(5, store.Values.GetLength(0));
             Assert.AreEqual(6, store.Values.GetLength(1));
 
-            Assert.AreEqual(14, store.Values[0, 0]);
-            Assert.AreEqual(16, store.Values[0, 1]);
-            Assert.AreEqual(18, store.Values[0, 2]);
-            Assert.AreEqual(20, store.Values[0, 3]);
-            Assert.AreEqual(22, store.Values[0, 4]);
-            Assert.AreEqual(24, store.Values[0, 5]);
+            Assert.AreEqual(14, store.Values[0, 0].Value);
+            Assert.AreEqual(16, store.Values[0, 1].Value);
+            Assert.AreEqual(18, store.Values[0, 2].Value);
+            Assert.AreEqual(20, store.Values[0, 3].Value);
+            Assert.AreEqual(22, store.Values[0, 4].Value);
+            Assert.AreEqual(24, store.Values[0, 5].Value);
 
-            Assert.AreEqual(21, store.Values[1, 0]);
-            Assert.AreEqual(24, store.Values[1, 1]);
-            Assert.AreEqual(27, store.Values[1, 2]);
-            Assert.AreEqual(30, store.Values[1, 3]);
-            Assert.AreEqual(33, store.Values[1, 4]);
-            Assert.AreEqual(36, store.Values[1, 5]);
+            Assert.AreEqual(21, store.Values[1, 0].Value);
+            Assert.AreEqual(24, store.Values[1, 1].Value);
+            Assert.AreEqual(27, store.Values[1, 2].Value);
+            Assert.AreEqual(30, store.Values[1, 3].Value);
+            Assert.AreEqual(33, store.Values[1, 4].Value);
+            Assert.AreEqual(36, store.Values[1, 5].Value);
 
-            Assert.AreEqual(28, store.Values[2, 0]);
-            Assert.AreEqual(32, store.Values[2, 1]);
-            Assert.AreEqual(36, store.Values[2, 2]);
-            Assert.AreEqual(40, store.Values[2, 3]);
-            Assert.AreEqual(44, store.Values[2, 4]);
-            Assert.AreEqual(48, store.Values[2, 5]);
+            Assert.AreEqual(28, store.Values[2, 0].Value);
+            Assert.AreEqual(32, store.Values[2, 1].Value);
+            Assert.AreEqual(36, store.Values[2, 2].Value);
+            Assert.AreEqual(40, store.Values[2, 3].Value);
+            Assert.AreEqual(44, store.Values[2, 4].Value);
+            Assert.AreEqual(48, store.Values[2, 5].Value);
 
-            Assert.AreEqual(35, store.Values[3, 0]);
-            Assert.AreEqual(40, store.Values[3, 1]);
-            Assert.AreEqual(45, store.Values[3, 2]);
-            Assert.AreEqual(50, store.Values[3, 3]);
-            Assert.AreEqual(55, store.Values[3, 4]);
-            Assert.AreEqual(60, store.Values[3, 5]);
+            Assert.AreEqual(35, store.Values[3, 0].Value);
+            Assert.AreEqual(40, store.Values[3, 1].Value);
+            Assert.AreEqual(45, store.Values[3, 2].Value);
+            Assert.AreEqual(50, store.Values[3, 3].Value);
+            Assert.AreEqual(55, store.Values[3, 4].Value);
+            Assert.AreEqual(60, store.Values[3, 5].Value);
 
-            Assert.AreEqual(42, store.Values[4, 0]);
-            Assert.AreEqual(48, store.Values[4, 1]);
-            Assert.AreEqual(54, store.Values[4, 2]);
-            Assert.AreEqual(60, store.Values[4, 3]);
-            Assert.AreEqual(66, store.Values[4, 4]);
-            Assert.AreEqual(72, store.Values[4, 5]);
+            Assert.AreEqual(42, store.Values[4, 0].Value);
+            Assert.AreEqual(48, store.Values[4, 1].Value);
+            Assert.AreEqual(54, store.Values[4, 2].Value);
+            Assert.AreEqual(60, store.Values[4, 3].Value);
+            Assert.AreEqual(66, store.Values[4, 4].Value);
+            Assert.AreEqual(72, store.Values[4, 5].Value);
         }
 
         [Test]
@@ -136,7 +136,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorT
             var interval3 = new VarInterval("z",
                 new Interval(7, false, 11, false, false));
             var numSteps3 = 5;
-            var store = new Evaluator.StoreOp3();
+            var store = new Evaluator.StoreOp3<Number>();
             // when
             eval.EvalInterval(expr, env,
                 interval1, numSteps1,
@@ -149,41 +149,41 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorT
             Assert.AreEqual(3, store.Values.GetLength(1));
             Assert.AreEqual(5, store.Values.GetLength(2));
 
-            Assert.AreEqual(56, store.Values[0, 0, 0]);
-            Assert.AreEqual(64, store.Values[0, 0, 1]);
-            Assert.AreEqual(72, store.Values[0, 0, 2]);
-            Assert.AreEqual(80, store.Values[0, 0, 3]);
-            Assert.AreEqual(88, store.Values[0, 0, 4]);
+            Assert.AreEqual(56, store.Values[0, 0, 0].Value);
+            Assert.AreEqual(64, store.Values[0, 0, 1].Value);
+            Assert.AreEqual(72, store.Values[0, 0, 2].Value);
+            Assert.AreEqual(80, store.Values[0, 0, 3].Value);
+            Assert.AreEqual(88, store.Values[0, 0, 4].Value);
 
-            Assert.AreEqual(70, store.Values[0, 1, 0]);
-            Assert.AreEqual(80, store.Values[0, 1, 1]);
-            Assert.AreEqual(90, store.Values[0, 1, 2]);
-            Assert.AreEqual(100, store.Values[0, 1, 3]);
-            Assert.AreEqual(110, store.Values[0, 1, 4]);
+            Assert.AreEqual(70, store.Values[0, 1, 0].Value);
+            Assert.AreEqual(80, store.Values[0, 1, 1].Value);
+            Assert.AreEqual(90, store.Values[0, 1, 2].Value);
+            Assert.AreEqual(100, store.Values[0, 1, 3].Value);
+            Assert.AreEqual(110, store.Values[0, 1, 4].Value);
 
-            Assert.AreEqual(84, store.Values[0, 2, 0]);
-            Assert.AreEqual(96, store.Values[0, 2, 1]);
-            Assert.AreEqual(108, store.Values[0, 2, 2]);
-            Assert.AreEqual(120, store.Values[0, 2, 3]);
-            Assert.AreEqual(132, store.Values[0, 2, 4]);
+            Assert.AreEqual(84, store.Values[0, 2, 0].Value);
+            Assert.AreEqual(96, store.Values[0, 2, 1].Value);
+            Assert.AreEqual(108, store.Values[0, 2, 2].Value);
+            Assert.AreEqual(120, store.Values[0, 2, 3].Value);
+            Assert.AreEqual(132, store.Values[0, 2, 4].Value);
 
-            Assert.AreEqual(84, store.Values[1, 0, 0]);
-            Assert.AreEqual(96, store.Values[1, 0, 1]);
-            Assert.AreEqual(108, store.Values[1, 0, 2]);
-            Assert.AreEqual(120, store.Values[1, 0, 3]);
-            Assert.AreEqual(132, store.Values[1, 0, 4]);
+            Assert.AreEqual(84, store.Values[1, 0, 0].Value);
+            Assert.AreEqual(96, store.Values[1, 0, 1].Value);
+            Assert.AreEqual(108, store.Values[1, 0, 2].Value);
+            Assert.AreEqual(120, store.Values[1, 0, 3].Value);
+            Assert.AreEqual(132, store.Values[1, 0, 4].Value);
 
-            Assert.AreEqual(105, store.Values[1, 1, 0]);
-            Assert.AreEqual(120, store.Values[1, 1, 1]);
-            Assert.AreEqual(135, store.Values[1, 1, 2]);
-            Assert.AreEqual(150, store.Values[1, 1, 3]);
-            Assert.AreEqual(165, store.Values[1, 1, 4]);
+            Assert.AreEqual(105, store.Values[1, 1, 0].Value);
+            Assert.AreEqual(120, store.Values[1, 1, 1].Value);
+            Assert.AreEqual(135, store.Values[1, 1, 2].Value);
+            Assert.AreEqual(150, store.Values[1, 1, 3].Value);
+            Assert.AreEqual(165, store.Values[1, 1, 4].Value);
 
-            Assert.AreEqual(126, store.Values[1, 2, 0]);
-            Assert.AreEqual(144, store.Values[1, 2, 1]);
-            Assert.AreEqual(162, store.Values[1, 2, 2]);
-            Assert.AreEqual(180, store.Values[1, 2, 3]);
-            Assert.AreEqual(198, store.Values[1, 2, 4]);
+            Assert.AreEqual(126, store.Values[1, 2, 0].Value);
+            Assert.AreEqual(144, store.Values[1, 2, 1].Value);
+            Assert.AreEqual(162, store.Values[1, 2, 2].Value);
+            Assert.AreEqual(180, store.Values[1, 2, 3].Value);
+            Assert.AreEqual(198, store.Values[1, 2, 4].Value);
         }
 
         [Test]
@@ -196,7 +196,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorT
             var expr = parser.GetExpression("x*e^(-x*x-y*y)");
             var interval1 = new VarInterval("x", -2, 2);
             var interval2 = new VarInterval("y", -2, 2);
-            var store = new Evaluator.StoreOp2();
+            var store = new Evaluator.StoreOp2<Number>();
             var eval = new Evaluator();
             env.SetVariable("e", new Literal(2.718281828f));
             // when

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorT/EvalIntervalTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorT/EvalIntervalTest.cs
@@ -209,5 +209,109 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorT
             // then
             Assert.LessOrEqual(endTime - startTime, 1);
         }
+
+        [Test]
+        public void AggregateOpRunsOnEachValue1()
+        {
+            // given
+            var expr = new FunctionCall(
+                MultiplicationOperation.Value,
+                new VariableAccess("x"),
+                new VariableAccess("x"));
+            var eval = new Evaluator();
+
+            Number Collect(Number n, Number state)
+            {
+                // find the max
+                if (n.Value > state.Value)
+                    return n;
+                return state;
+            }
+
+            var interval = new VarInterval("x", 1, 5);
+            var env = new SolusEnvironment();
+            var aggr = new Evaluator.AggregateOp<Number, Number>
+            {
+                Function = Collect,
+                State = 0.ToNumber()
+            };
+            // when
+            eval.EvalInterval(expr, env, interval, 5, null, aggr);
+            // then
+            Assert.AreEqual(25, aggr.State.Value);
+        }
+
+        [Test]
+        public void AggregateOpRunsOnEachValue2()
+        {
+            // given
+            var expr = new FunctionCall(
+                MultiplicationOperation.Value,
+                new VariableAccess("x"),
+                new VariableAccess("y"));
+            var eval = new Evaluator();
+
+            Number Max(Number n, Number state)
+            {
+                // find the max
+                if (n.Value > state.Value)
+                    return n;
+                return state;
+            }
+
+            var interval1 = new VarInterval("x", 1, 3);
+            var interval2 = new VarInterval("y", 4, 6);
+            var env = new SolusEnvironment();
+            var aggr = new Evaluator.AggregateOp<Number, Number>
+            {
+                Function = Max,
+                State = 0.ToNumber()
+            };
+            // when
+            eval.EvalInterval(expr, env,
+                interval1, 3,
+                interval2, 3,
+                null, aggr);
+            // then
+            Assert.AreEqual(18, aggr.State.Value);
+        }
+
+        [Test]
+        public void AggregateOpRunsOnEachValue3()
+        {
+            // given
+            var expr = new FunctionCall(
+                MultiplicationOperation.Value,
+                new VariableAccess("x"),
+                new VariableAccess("y"),
+                new VariableAccess("z"));
+            var eval = new Evaluator();
+
+            Number Max(Number n, Number state)
+            {
+                // find the max
+                if (n.Value > state.Value)
+                    return n;
+                return state;
+            }
+
+            var interval1 = new VarInterval("x", 1, 3);
+            var interval2 = new VarInterval("y", 4, 6);
+            var interval3 = new VarInterval("z", 7, 9);
+            var env = new SolusEnvironment();
+            var aggr = new Evaluator.AggregateOp<Number, Number>
+            {
+                Function = Max,
+                State = 0.ToNumber()
+            };
+            // when
+            eval.EvalInterval(expr, env,
+                interval1, 3,
+                interval2, 3,
+                interval3, 3,
+                null, aggr);
+            // then
+            Assert.AreEqual(162, aggr.State.Value);
+        }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/MaximumFiniteFunctionT/MaximumFiniteFunctionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/MaximumFiniteFunctionT/MaximumFiniteFunctionTest.cs
@@ -1,0 +1,278 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2021 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using System;
+using MetaphysicsIndustries.Solus.Functions;
+using MetaphysicsIndustries.Solus.Values;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.MaximumFiniteFunctionT
+{
+    [TestFixture]
+    public class MaximumFiniteFunctionTest
+    {
+        [Test]
+        public void AscendingYieldsMax()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                1.ToNumber(),
+                2.ToNumber(),
+                3.ToNumber(),
+                4.ToNumber(),
+                5.ToNumber(),
+            };
+            // when
+            var result = MaximumFiniteFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(5, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void DescendingYieldsMax()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                9.ToNumber(),
+                8.ToNumber(),
+                7.ToNumber(),
+                6.ToNumber(),
+            };
+            // when
+            var result = MaximumFiniteFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(9, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NegativeAscendingYieldsMax()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                (-5).ToNumber(),
+                (-4).ToNumber(),
+                (-3).ToNumber(),
+                (-2).ToNumber(),
+                (-1).ToNumber(),
+            };
+            // when
+            var result = MaximumFiniteFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(-1, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NegativeDescendingYieldsMax()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                (-6).ToNumber(),
+                (-7).ToNumber(),
+                (-8).ToNumber(),
+                (-9).ToNumber(),
+            };
+            // when
+            var result = MaximumFiniteFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(-6, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void PositiveAndNegativeYieldsMax()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                (-1).ToNumber(),
+                0.ToNumber(),
+                1.ToNumber(),
+            };
+            // when
+            var result = MaximumFiniteFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(1, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NotInOrderYieldsMax()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                5.ToNumber(),
+                9.ToNumber(),
+                1.ToNumber(),
+                3.ToNumber(),
+                2.ToNumber(),
+            };
+            // when
+            var result = MaximumFiniteFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(9, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void SingleArgumentYieldsMax()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                5.ToNumber(),
+            };
+            // when
+            var result = MaximumFiniteFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(5, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void ZeroArgumentsThrows()
+        {
+            // given
+            var args = new IMathObject[0];
+            // expect
+            var ex = Assert.Throws<ArgumentException>(
+                () => MaximumFiniteFunction.Value.Call(null, args));
+            // and
+            Assert.AreEqual("No arguments passed", ex.Message);
+        }
+
+        [Test]
+        public void NaNIsIgnored()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                1.ToNumber(),
+                2.ToNumber(),
+                float.NaN.ToNumber(),
+                4.ToNumber(),
+                5.ToNumber(),
+            };
+            // when
+            var result = MaximumFiniteFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(5, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void PositiveInfinityIsIgnored()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                1.ToNumber(),
+                2.ToNumber(),
+                float.PositiveInfinity.ToNumber(),
+                4.ToNumber(),
+                5.ToNumber(),
+            };
+            // when
+            var result = MaximumFiniteFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(5, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NegativeInfinityIsIgnored()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                1.ToNumber(),
+                2.ToNumber(),
+                float.NegativeInfinity.ToNumber(),
+                4.ToNumber(),
+                5.ToNumber(),
+            };
+            // when
+            var result = MaximumFiniteFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(5, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void InfinitiesAndNanYieldMax()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                float.PositiveInfinity.ToNumber(),
+                float.NegativeInfinity.ToNumber(),
+                float.NaN.ToNumber(),
+                1.ToNumber()
+            };
+            // when
+            var result = MaximumFiniteFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(1, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NoFiniteNumbersYieldsNaN1()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                float.PositiveInfinity.ToNumber(),
+                float.NegativeInfinity.ToNumber(),
+                float.NaN.ToNumber(),
+            };
+            // when
+            var result = MaximumFiniteFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(float.NaN, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NoFiniteNumbersYieldsNaN2()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                float.PositiveInfinity.ToNumber(),
+                float.NegativeInfinity.ToNumber(),
+            };
+            // when
+            var result = MaximumFiniteFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(float.NaN, result.ToNumber().Value);
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/MaximumFunctionT/MaximumFunctionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/MaximumFunctionT/MaximumFunctionTest.cs
@@ -1,0 +1,244 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2021 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using System;
+using MetaphysicsIndustries.Solus.Functions;
+using MetaphysicsIndustries.Solus.Values;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.MaximumFunctionT
+{
+    [TestFixture]
+    public class MaximumFunctionTest
+    {
+        [Test]
+        public void AscendingYieldsMax()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                1.ToNumber(),
+                2.ToNumber(),
+                3.ToNumber(),
+                4.ToNumber(),
+                5.ToNumber(),
+            };
+            // when
+            var result = MaximumFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(5, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void DescendingYieldsMax()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                9.ToNumber(),
+                8.ToNumber(),
+                7.ToNumber(),
+                6.ToNumber(),
+            };
+            // when
+            var result = MaximumFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(9, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NegativeAscendingYieldsMax()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                (-5).ToNumber(),
+                (-4).ToNumber(),
+                (-3).ToNumber(),
+                (-2).ToNumber(),
+                (-1).ToNumber(),
+            };
+            // when
+            var result = MaximumFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(-1, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NegativeDescendingYieldsMax()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                (-6).ToNumber(),
+                (-7).ToNumber(),
+                (-8).ToNumber(),
+                (-9).ToNumber(),
+            };
+            // when
+            var result = MaximumFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(-6, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void PositiveAndNegativeYieldsMax()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                (-1).ToNumber(),
+                0.ToNumber(),
+                1.ToNumber(),
+            };
+            // when
+            var result = MaximumFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(1, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NotInOrderYieldsMax()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                5.ToNumber(),
+                9.ToNumber(),
+                1.ToNumber(),
+                3.ToNumber(),
+                2.ToNumber(),
+            };
+            // when
+            var result = MaximumFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(9, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void SingleArgumentYieldsMax()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                5.ToNumber(),
+            };
+            // when
+            var result = MaximumFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(5, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void ZeroArgumentsThrows()
+        {
+            // given
+            var args = new IMathObject[0];
+            // expect
+            var ex = Assert.Throws<ArgumentException>(
+                () => MaximumFunction.Value.Call(null, args));
+            // and
+            Assert.AreEqual("No arguments passed", ex.Message);
+        }
+
+        [Test]
+        public void NaNYieldsNaN()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                1.ToNumber(),
+                2.ToNumber(),
+                float.NaN.ToNumber(),
+                4.ToNumber(),
+                5.ToNumber(),
+            };
+            // when
+            var result = MaximumFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(float.NaN, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void PositiveInfinityYieldsPositiveInfinity()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                1.ToNumber(),
+                2.ToNumber(),
+                float.PositiveInfinity.ToNumber(),
+                4.ToNumber(),
+                5.ToNumber(),
+            };
+            // when
+            var result = MaximumFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(float.PositiveInfinity, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NegativeInfinityIsIgnored()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                1.ToNumber(),
+                2.ToNumber(),
+                float.NegativeInfinity.ToNumber(),
+                4.ToNumber(),
+                5.ToNumber(),
+            };
+            // when
+            var result = MaximumFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(5, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void InfinitiesAndNanYieldNan()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                float.PositiveInfinity.ToNumber(),
+                float.NegativeInfinity.ToNumber(),
+                float.NaN.ToNumber(),
+            };
+            // when
+            var result = MaximumFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(float.NaN, result.ToNumber().Value);
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/MinimumFiniteFunctionT/MinimumFiniteFunctionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/MinimumFiniteFunctionT/MinimumFiniteFunctionTest.cs
@@ -1,0 +1,278 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2021 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using System;
+using MetaphysicsIndustries.Solus.Functions;
+using MetaphysicsIndustries.Solus.Values;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.MinimumFiniteFunctionT
+{
+    [TestFixture]
+    public class MinimumFiniteFunctionTest
+    {
+        [Test]
+        public void AscendingYieldsMin()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                1.ToNumber(),
+                2.ToNumber(),
+                3.ToNumber(),
+                4.ToNumber(),
+                5.ToNumber(),
+            };
+            // when
+            var result = MinimumFiniteFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(1, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void DescendingYieldsMin()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                9.ToNumber(),
+                8.ToNumber(),
+                7.ToNumber(),
+                6.ToNumber(),
+            };
+            // when
+            var result = MinimumFiniteFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(6, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NegativeAscendingYieldsMin()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                (-5).ToNumber(),
+                (-4).ToNumber(),
+                (-3).ToNumber(),
+                (-2).ToNumber(),
+                (-1).ToNumber(),
+            };
+            // when
+            var result = MinimumFiniteFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(-5, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NegativeDescendingYieldsMin()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                (-6).ToNumber(),
+                (-7).ToNumber(),
+                (-8).ToNumber(),
+                (-9).ToNumber(),
+            };
+            // when
+            var result = MinimumFiniteFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(-9, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void PositiveAndNegativeYieldsMin()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                (-1).ToNumber(),
+                0.ToNumber(),
+                1.ToNumber(),
+            };
+            // when
+            var result = MinimumFiniteFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(-1, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NotInOrderYieldsMin()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                5.ToNumber(),
+                9.ToNumber(),
+                1.ToNumber(),
+                3.ToNumber(),
+                2.ToNumber(),
+            };
+            // when
+            var result = MinimumFiniteFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(1, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void SingleArgumentYieldsMin()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                5.ToNumber(),
+            };
+            // when
+            var result = MinimumFiniteFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(5, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void ZeroArgumentsThrows()
+        {
+            // given
+            var args = new IMathObject[0];
+            // expect
+            var ex = Assert.Throws<ArgumentException>(
+                () => MinimumFiniteFunction.Value.Call(null, args));
+            // and
+            Assert.AreEqual("No arguments passed", ex.Message);
+        }
+
+        [Test]
+        public void NaNIsIgnored()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                1.ToNumber(),
+                2.ToNumber(),
+                float.NaN.ToNumber(),
+                4.ToNumber(),
+                5.ToNumber(),
+            };
+            // when
+            var result = MinimumFiniteFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(1, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void PositiveInfinityIsIgnored()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                1.ToNumber(),
+                2.ToNumber(),
+                float.PositiveInfinity.ToNumber(),
+                4.ToNumber(),
+                5.ToNumber(),
+            };
+            // when
+            var result = MinimumFiniteFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(1, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NegativeInfinityIsIgnored()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                1.ToNumber(),
+                2.ToNumber(),
+                float.NegativeInfinity.ToNumber(),
+                4.ToNumber(),
+                5.ToNumber(),
+            };
+            // when
+            var result = MinimumFiniteFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(1, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void InfinitiesAndNanYieldMin()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                float.PositiveInfinity.ToNumber(),
+                float.NegativeInfinity.ToNumber(),
+                float.NaN.ToNumber(),
+                1.ToNumber(),
+            };
+            // when
+            var result = MinimumFiniteFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(1, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NoFiniteNumbersYieldsNaN1()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                float.PositiveInfinity.ToNumber(),
+                float.NegativeInfinity.ToNumber(),
+                float.NaN.ToNumber(),
+            };
+            // when
+            var result = MinimumFiniteFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(float.NaN, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NoFiniteNumbersYieldsNaN2()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                float.PositiveInfinity.ToNumber(),
+                float.NegativeInfinity.ToNumber(),
+            };
+            // when
+            var result = MinimumFiniteFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(float.NaN, result.ToNumber().Value);
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/MinimumFunctionT/MinimumFunctionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/MinimumFunctionT/MinimumFunctionTest.cs
@@ -1,0 +1,244 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2021 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using System;
+using MetaphysicsIndustries.Solus.Functions;
+using MetaphysicsIndustries.Solus.Values;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.MinimumFunctionT
+{
+    [TestFixture]
+    public class MinimumFunctionTest
+    {
+        [Test]
+        public void AscendingYieldsMin()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                1.ToNumber(),
+                2.ToNumber(),
+                3.ToNumber(),
+                4.ToNumber(),
+                5.ToNumber(),
+            };
+            // when
+            var result = MinimumFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(1, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void DescendingYieldsMin()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                9.ToNumber(),
+                8.ToNumber(),
+                7.ToNumber(),
+                6.ToNumber(),
+            };
+            // when
+            var result = MinimumFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(6, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NegativeAscendingYieldsMin()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                (-5).ToNumber(),
+                (-4).ToNumber(),
+                (-3).ToNumber(),
+                (-2).ToNumber(),
+                (-1).ToNumber(),
+            };
+            // when
+            var result = MinimumFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(-5, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NegativeDescendingYieldsMin()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                (-6).ToNumber(),
+                (-7).ToNumber(),
+                (-8).ToNumber(),
+                (-9).ToNumber(),
+            };
+            // when
+            var result = MinimumFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(-9, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void PositiveAndNegativeYieldsMin()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                (-1).ToNumber(),
+                0.ToNumber(),
+                1.ToNumber(),
+            };
+            // when
+            var result = MinimumFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(-1, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NotInOrderYieldsMin()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                5.ToNumber(),
+                9.ToNumber(),
+                1.ToNumber(),
+                3.ToNumber(),
+                2.ToNumber(),
+            };
+            // when
+            var result = MinimumFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(1, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void SingleArgumentYieldsMin()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                5.ToNumber(),
+            };
+            // when
+            var result = MinimumFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(5, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void ZeroArgumentsThrows()
+        {
+            // given
+            var args = new IMathObject[0];
+            // expect
+            var ex = Assert.Throws<ArgumentException>(
+                () => MinimumFunction.Value.Call(null, args));
+            // and
+            Assert.AreEqual("No arguments passed", ex.Message);
+        }
+
+        [Test]
+        public void NaNYieldsNaN()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                1.ToNumber(),
+                2.ToNumber(),
+                float.NaN.ToNumber(),
+                4.ToNumber(),
+                5.ToNumber(),
+            };
+            // when
+            var result = MinimumFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(float.NaN, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void PositiveInfinityIsIgnored()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                1.ToNumber(),
+                2.ToNumber(),
+                float.PositiveInfinity.ToNumber(),
+                4.ToNumber(),
+                5.ToNumber(),
+            };
+            // when
+            var result = MinimumFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(1, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NegativeInfinityYieldsNegativeInfinity()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                1.ToNumber(),
+                2.ToNumber(),
+                float.NegativeInfinity.ToNumber(),
+                4.ToNumber(),
+                5.ToNumber(),
+            };
+            // when
+            var result = MinimumFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(float.NegativeInfinity, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void InfinitiesAndNanYieldNan()
+        {
+            // given
+            var args = new IMathObject[]
+            {
+                float.PositiveInfinity.ToNumber(),
+                float.NegativeInfinity.ToNumber(),
+                float.NaN.ToNumber(),
+            };
+            // when
+            var result = MinimumFunction.Value.Call(null, args);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(float.NaN, result.ToNumber().Value);
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/MetaphysicsIndustries.Solus.Test.csproj
+++ b/MetaphysicsIndustries.Solus.Test/MetaphysicsIndustries.Solus.Test.csproj
@@ -175,6 +175,8 @@
     <Compile Include="ValuesT\NumberT\NumberTest.cs" />
     <Compile Include="ValuesT\StringValueT\StringValueTest.cs" />
     <Compile Include="ValuesT\VarIntervalT\VarIntervalTest.cs" />
+    <Compile Include="ValuesT\Vector2T\Vector2Test.cs" />
+    <Compile Include="ValuesT\Vector3T\Vector3Test.cs" />
     <Compile Include="ValuesT\VectorT\VectorTest.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/MetaphysicsIndustries.Solus.Test/MetaphysicsIndustries.Solus.Test.csproj
+++ b/MetaphysicsIndustries.Solus.Test/MetaphysicsIndustries.Solus.Test.csproj
@@ -133,6 +133,10 @@
     <Compile Include="FunctionsT\LogicalAndOperationT\LogicalAndOperationTest.cs" />
     <Compile Include="FunctionsT\LogicalOrOperationT\GetResultTest.cs" />
     <Compile Include="FunctionsT\LogicalOrOperationT\LogicalOrOperationTest.cs" />
+    <Compile Include="FunctionsT\MaximumFiniteFunctionT\MaximumFiniteFunctionTest.cs" />
+    <Compile Include="FunctionsT\MaximumFunctionT\MaximumFunctionTest.cs" />
+    <Compile Include="FunctionsT\MinimumFiniteFunctionT\MinimumFiniteFunctionTest.cs" />
+    <Compile Include="FunctionsT\MinimumFunctionT\MinimumFunctionTest.cs" />
     <Compile Include="FunctionsT\ModularDivisionT\GetResultTest.cs" />
     <Compile Include="FunctionsT\ModularDivisionT\ModularDivisionTest.cs" />
     <Compile Include="FunctionsT\MultiplicationOperationT\GetResultTest.cs" />

--- a/MetaphysicsIndustries.Solus.Test/SolusParserT/SolusParserTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/SolusParserT/SolusParserTest.cs
@@ -1226,7 +1226,6 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
         }
 
         [Test]
-        [Ignore("Recursive is broken")]
         public void ParseRecursiveUserDefinedFunction()
         {
             // given
@@ -1248,9 +1247,65 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             Assert.AreEqual("f", udf.Name);
             Assert.AreEqual(1, udf.Argnames.Length);
             Assert.AreEqual("x", udf.Argnames[0]);
-            // Assert.IsInstanceOf<VariableAccess>(udf.Expression);
-            // var va = (VariableAccess)udf.Expression;
-            // Assert.AreEqual("x", va.VariableName);
+            Assert.IsInstanceOf<FunctionCall>(udf.Expression);
+            var call = (FunctionCall)udf.Expression;
+            Assert.IsInstanceOf<VariableAccess>(call.Function);
+            Assert.AreEqual("if",
+                ((VariableAccess)call.Function).VariableName);
+            Assert.AreEqual(3, call.Arguments.Count);
+
+            Assert.IsInstanceOf<FunctionCall>(call.Arguments[0]);
+            var call2 = (FunctionCall)call.Arguments[0];
+            Assert.IsInstanceOf<Literal>(call2.Function);
+            Assert.AreSame(EqualComparisonOperation.Value,
+                ((Literal)call2.Function).Value);
+            Assert.IsInstanceOf<VariableAccess>(call2.Arguments[0]);
+            Assert.AreEqual("x",
+                ((VariableAccess)call2.Arguments[0]).VariableName);
+            Assert.IsInstanceOf<Literal>(call2.Arguments[1]);
+            Assert.AreEqual(0,
+                ((Literal)call2.Arguments[1]).Value.ToNumber().Value);
+
+            Assert.IsInstanceOf<Literal>(call.Arguments[1]);
+            Assert.AreEqual(0,
+                ((Literal)call.Arguments[1]).Value.ToNumber().Value);
+
+            Assert.IsInstanceOf<FunctionCall>(call.Arguments[2]);
+            call2 = (FunctionCall)call.Arguments[2];
+            Assert.IsInstanceOf<Literal>(call2.Function);
+            Assert.AreSame(AdditionOperation.Value,
+                ((Literal)call2.Function).Value);
+            Assert.AreEqual(2, call2.Arguments.Count);
+            Assert.IsInstanceOf<Literal>(call2.Arguments[0]);
+            Assert.AreEqual(1,
+                ((Literal)call2.Arguments[0]).Value.ToNumber().Value);
+            Assert.IsInstanceOf<FunctionCall>(call2.Arguments[1]);
+
+            var call3 = (FunctionCall)call2.Arguments[1];
+            Assert.IsInstanceOf<VariableAccess>(call3.Function);
+            Assert.AreEqual("f",
+                ((VariableAccess)call3.Function).VariableName);
+            Assert.AreEqual(1, call3.Arguments.Count);
+            Assert.IsInstanceOf<FunctionCall>(call3.Arguments[0]);
+
+            var call4 = (FunctionCall)call3.Arguments[0];
+            Assert.IsInstanceOf<VariableAccess>(call4.Function);
+            Assert.AreEqual("floor",
+                ((VariableAccess)call4.Function).VariableName);
+            Assert.AreEqual(1, call4.Arguments.Count);
+            Assert.IsInstanceOf<FunctionCall>(call4.Arguments[0]);
+
+            var call5 = (FunctionCall)call4.Arguments[0];
+            Assert.IsInstanceOf<Literal>(call5.Function);
+            Assert.AreSame(DivisionOperation.Value,
+                ((Literal)call5.Function).Value);
+            Assert.AreEqual(2, call5.Arguments.Count);
+            Assert.IsInstanceOf<VariableAccess>(call5.Arguments[0]);
+            Assert.AreEqual("x",
+                ((VariableAccess)call5.Arguments[0]).VariableName);
+            Assert.IsInstanceOf<Literal>(call5.Arguments[1]);
+            Assert.AreEqual(10,
+                ((Literal)call5.Arguments[1]).Value.ToNumber().Value);
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/ValuesT/Vector2T/Vector2Test.cs
+++ b/MetaphysicsIndustries.Solus.Test/ValuesT/Vector2T/Vector2Test.cs
@@ -1,0 +1,177 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2021 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Values;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.ValuesT.Vector2T
+{
+    [TestFixture]
+    public class Vector2Test
+    {
+        [Test]
+        public void CreateSetsElements()
+        {
+            // when
+            var result = new Vector2(1, 2);
+            // then
+            Assert.AreEqual(1, result.X);
+            Assert.AreEqual(2, result.Y);
+            // and
+            Assert.IsFalse(result.IsScalar(null));
+            Assert.IsTrue(result.IsVector(null));
+            Assert.IsFalse(result.IsMatrix(null));
+            Assert.AreEqual(1, result.GetTensorRank(null));
+            Assert.IsFalse(result.IsString(null));
+            Assert.IsNull(result.GetDimension(null, -1));
+            Assert.AreEqual(2, result.GetDimension(null, 0));
+            Assert.IsNull(result.GetDimension(null, 1));
+            Assert.AreEqual(new int[1] { 2 }, result.GetDimensions(null));
+            Assert.AreEqual(2, result.GetVectorLength(null));
+            Assert.IsFalse(result.IsInterval(null));
+            Assert.IsFalse(result.IsFunction(null));
+            Assert.IsFalse(result.IsExpression(null));
+            Assert.IsTrue(result.IsConcrete);
+            Assert.AreEqual("", result.DocString);
+        }
+
+        [Test]
+        public void NegateYieldsOppositeValues()
+        {
+            // given
+            var v = new Vector2(1, 2);
+            // when
+            var result = -v;
+            // then
+            Assert.AreEqual(-1, result.X);
+            Assert.AreEqual(-2, result.Y);
+        }
+
+        [Test]
+        public void MinusYieldsDifference()
+        {
+            // given
+            var v = new Vector2(1, 2);
+            var u = new Vector2(4, 6);
+            // when
+            var result = u - v;
+            // then
+            Assert.AreEqual(3, result.X);
+            Assert.AreEqual(4, result.Y);
+        }
+
+        [Test]
+        public void PlusYieldsSum()
+        {
+            // given
+            var v = new Vector2(1, 2);
+            var u = new Vector2(4, 6);
+            // when
+            var result = u + v;
+            // then
+            Assert.AreEqual(5, result.X);
+            Assert.AreEqual(8, result.Y);
+        }
+
+        [Test]
+        public void ScalarMultiplicationYieldsScaledVector1()
+        {
+            // given
+            var v = new Vector2(1, 2);
+            // when
+            var result = v * 2;
+            // then
+            Assert.AreEqual(2, result.X);
+            Assert.AreEqual(4, result.Y);
+        }
+
+        [Test]
+        public void ScalarMultiplicationYieldsScaledVector2()
+        {
+            // given
+            var v = new Vector2(1, 2);
+            // when
+            var result = 2 * v;
+            // then
+            Assert.AreEqual(2, result.X);
+            Assert.AreEqual(4, result.Y);
+        }
+
+        [Test]
+        public void ScalarDivisionYieldsScaledVector()
+        {
+            // given
+            var v = new Vector2(1, 2);
+            // when
+            var result = v / 2;
+            // then
+            Assert.AreEqual(0.5f, result.X);
+            Assert.AreEqual(1, result.Y);
+        }
+
+        [Test]
+        public void SameVectorsEqualsYieldsTrue()
+        {
+            // given
+            var v = new Vector2(1, 2);
+            var u = new Vector2(1, 2);
+            // when
+            var result = u == v;
+            // then
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void DifferentVectorEqualsYieldsFalse()
+        {
+            // given
+            var v = new Vector2(1, 2);
+            // expect
+            Assert.IsFalse(v == new Vector2(1, 3));
+            Assert.IsFalse(v == new Vector2(2, 2));
+            Assert.IsFalse(v == new Vector2(2, 3));
+        }
+
+        [Test]
+        public void SameVectorsNotEqualsYieldsFalse()
+        {
+            // given
+            var v = new Vector2(1, 2);
+            var u = new Vector2(1, 2);
+            // when
+            var result = u != v;
+            // then
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void DifferentVectorNotEqualsYieldsTrue()
+        {
+            // given
+            var v = new Vector2(1, 2);
+            // expect
+            Assert.IsTrue(v != new Vector2(1, 3));
+            Assert.IsTrue(v != new Vector2(2, 2));
+            Assert.IsTrue(v != new Vector2(2, 3));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/ValuesT/Vector3T/Vector3Test.cs
+++ b/MetaphysicsIndustries.Solus.Test/ValuesT/Vector3T/Vector3Test.cs
@@ -1,0 +1,184 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2021 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Values;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.ValuesT.Vector3T
+{
+    [TestFixture]
+    public class Vector3Test
+    {
+        [Test]
+        public void CreateSetsElements()
+        {
+            // when
+            var result = new Vector3(1, 2, 3);
+            // then
+            Assert.AreEqual(1, result.X);
+            Assert.AreEqual(2, result.Y);
+            Assert.AreEqual(3, result.Z);
+            // and
+            Assert.IsFalse(result.IsScalar(null));
+            Assert.IsTrue(result.IsVector(null));
+            Assert.IsFalse(result.IsMatrix(null));
+            Assert.AreEqual(1, result.GetTensorRank(null));
+            Assert.IsFalse(result.IsString(null));
+            Assert.IsNull(result.GetDimension(null, -1));
+            Assert.AreEqual(3, result.GetDimension(null, 0));
+            Assert.IsNull(result.GetDimension(null, 1));
+            Assert.AreEqual(new int[1] { 3 }, result.GetDimensions(null));
+            Assert.AreEqual(3, result.GetVectorLength(null));
+            Assert.IsFalse(result.IsInterval(null));
+            Assert.IsFalse(result.IsFunction(null));
+            Assert.IsFalse(result.IsExpression(null));
+            Assert.IsTrue(result.IsConcrete);
+            Assert.AreEqual("", result.DocString);
+        }
+
+        [Test]
+        public void NegateYieldsOppositeValues()
+        {
+            // given
+            var v = new Vector3(1, 2, 3);
+            // when
+            var result = -v;
+            // then
+            Assert.AreEqual(-1, result.X);
+            Assert.AreEqual(-2, result.Y);
+            Assert.AreEqual(-3, result.Z);
+        }
+
+        [Test]
+        public void MinusYieldsDifference()
+        {
+            // given
+            var v = new Vector3(1, 2, 3);
+            var u = new Vector3(4, 6, 8);
+            // when
+            var result = u - v;
+            // then
+            Assert.AreEqual(3, result.X);
+            Assert.AreEqual(4, result.Y);
+            Assert.AreEqual(5, result.Z);
+        }
+
+        [Test]
+        public void PlusYieldsSum()
+        {
+            // given
+            var v = new Vector3(1, 2, 3);
+            var u = new Vector3(4, 6, 8);
+            // when
+            var result = u + v;
+            // then
+            Assert.AreEqual(5, result.X);
+            Assert.AreEqual(8, result.Y);
+            Assert.AreEqual(11, result.Z);
+        }
+
+        [Test]
+        public void ScalarMultiplicationYieldsScaledVector1()
+        {
+            // given
+            var v = new Vector3(1, 2, 3);
+            // when
+            var result = v * 2;
+            // then
+            Assert.AreEqual(2, result.X);
+            Assert.AreEqual(4, result.Y);
+            Assert.AreEqual(6, result.Z);
+        }
+
+        [Test]
+        public void ScalarMultiplicationYieldsScaledVector2()
+        {
+            // given
+            var v = new Vector3(1, 2, 3);
+            // when
+            var result = 2 * v;
+            // then
+            Assert.AreEqual(2, result.X);
+            Assert.AreEqual(4, result.Y);
+            Assert.AreEqual(6, result.Z);
+        }
+
+        [Test]
+        public void ScalarDivisionYieldsScaledVector()
+        {
+            // given
+            var v = new Vector3(1, 2, 3);
+            // when
+            var result = v / 2;
+            // then
+            Assert.AreEqual(0.5f, result.X);
+            Assert.AreEqual(1, result.Y);
+            Assert.AreEqual(1.5f, result.Z);
+        }
+
+        [Test]
+        public void SameVectorsEqualsYieldsTrue()
+        {
+            // given
+            var v = new Vector3(1, 2, 3);
+            var u = new Vector3(1, 2, 3);
+            // when
+            var result = u == v;
+            // then
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void DifferentVectorEqualsYieldsFalse()
+        {
+            // given
+            var v = new Vector3(1, 2, 3);
+            // expect
+            Assert.IsFalse(v == new Vector3(1, 2, 2));
+            Assert.IsFalse(v == new Vector3(1, 4, 3));
+            Assert.IsFalse(v == new Vector3(2, 2, 3));
+        }
+
+        [Test]
+        public void SameVectorsNotEqualsYieldsFalse()
+        {
+            // given
+            var v = new Vector3(1, 2, 3);
+            var u = new Vector3(1, 2, 3);
+            // when
+            var result = u != v;
+            // then
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void DifferentVectorNotEqualsYieldsTrue()
+        {
+            // given
+            var v = new Vector3(1, 2, 3);
+            // expect
+            Assert.IsTrue(v != new Vector3(1, 2, 2));
+            Assert.IsTrue(v != new Vector3(1, 4, 3));
+            Assert.IsTrue(v != new Vector3(2, 2, 3));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.csproj
+++ b/MetaphysicsIndustries.Solus.csproj
@@ -179,6 +179,8 @@
     <Compile Include="Values\Types.cs" />
     <Compile Include="Values\VarInterval.cs" />
     <Compile Include="Values\Vector.cs" />
+    <Compile Include="Values\Vector2.cs" />
+    <Compile Include="Values\Vector3.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="ExGrammar.txt" />

--- a/MetaphysicsIndustries.Solus.csproj
+++ b/MetaphysicsIndustries.Solus.csproj
@@ -124,6 +124,10 @@
     <Compile Include="Functions\LogarithmFunction.cs" />
     <Compile Include="Functions\LogicalAndOperation.cs" />
     <Compile Include="Functions\LogicalOrOperation.cs" />
+    <Compile Include="Functions\MaximumFiniteFunction.cs" />
+    <Compile Include="Functions\MaximumFunction.cs" />
+    <Compile Include="Functions\MinimumFiniteFunction.cs" />
+    <Compile Include="Functions\MinimumFunction.cs" />
     <Compile Include="Functions\ModularDivision.cs" />
     <Compile Include="Functions\MultiplicationOperation.cs" />
     <Compile Include="Functions\NaturalLogarithmFunction.cs" />

--- a/Transformers/DerivativeTransformer.cs
+++ b/Transformers/DerivativeTransformer.cs
@@ -25,7 +25,6 @@ using System.Collections.Generic;
 using MetaphysicsIndustries.Solus.Exceptions;
 using MetaphysicsIndustries.Solus.Expressions;
 using MetaphysicsIndustries.Solus.Functions;
-using MetaphysicsIndustries.Solus.Values;
 
 namespace MetaphysicsIndustries.Solus.Transformers
 {
@@ -89,8 +88,16 @@ namespace MetaphysicsIndustries.Solus.Transformers
 
         protected Expression GetDerivativeOfFunctionCall(FunctionCall functionCall, string var)
         {
+            var expr = functionCall.Function;
+            if (!(expr is Literal literal))
+                throw new NotImplementedException(
+                    "Evaluated call target not yet implemented");
+            if (!literal.Value.IsIsFunction(null))
+                throw new OperandException(
+                    "Call target is not a function");
+            var function = (Function)literal.Value;
 
-            if (functionCall.Function is Operation)
+            if (function is Operation)
             {
                 return GetDerivativeOfOperation(functionCall, var);
             }
@@ -98,15 +105,6 @@ namespace MetaphysicsIndustries.Solus.Transformers
             {
                 Expression functionDerivative;
                 Expression argumentDerivative;
-
-                var expr = functionCall.Function;
-                if (!(expr is Literal literal))
-                    throw new NotImplementedException(
-                        "Evaluated call target not yet implemented");
-                if (!literal.Value.IsIsFunction(null))
-                    throw new OperandException(
-                        "Call target is not a function");
-                var function = (Function)literal.Value;
 
                 if (function == CosineFunction.Value)
                 {
@@ -148,13 +146,15 @@ namespace MetaphysicsIndustries.Solus.Transformers
 
         protected Expression GetDerivativeOfOperation(FunctionCall functionCall, string var)
         {
+            Function f = null;
+            if (functionCall.Function is Literal literal)
+                f = literal.Value as Function;
 
-
-            if (functionCall.Function is BinaryOperation)
+            if (f is BinaryOperation)
             {
                 return GetDerivativeOfBinaryOperation(functionCall, var);
             }
-            else if (functionCall.Function is AssociativeCommutativeOperation)
+            else if (f is AssociativeCommutativeOperation)
             {
                 return GetDerivativeOfAssociativeCommutativOperation(functionCall, var);
             }

--- a/Transformers/PolynomialSimplifier.cs
+++ b/Transformers/PolynomialSimplifier.cs
@@ -50,7 +50,11 @@ namespace MetaphysicsIndustries.Solus.Transformers
 
         private void TransformFunctionCall(FunctionCall fc)
         {
-            if (fc.Function is ExponentOperation)
+            Function f = null;
+            if (fc.Function is Literal literal0 &&
+                literal0.Value is Function f0)
+                f = f0;
+            if (f is ExponentOperation)
             {
                 var arg1 = fc.Arguments[1];
                 if (arg1 is Literal literal &&
@@ -58,8 +62,12 @@ namespace MetaphysicsIndustries.Solus.Transformers
                     fc.Arguments[0] is FunctionCall)
                 {
                     FunctionCall fcarg = (FunctionCall)fc.Arguments[0];
-                    if (fcarg.Function is AdditionOperation ||
-                        fcarg.Function is MultiplicationOperation)
+                    Function f2 = null;
+                    if (fcarg.Function is Literal literal2 &&
+                        literal2.Value is Function function)
+                        f2 = function;
+                    if (f2 is AdditionOperation ||
+                        f2 is MultiplicationOperation)
                     {
                         //this is all wrong
 

--- a/Values/Number.cs
+++ b/Values/Number.cs
@@ -55,5 +55,19 @@ namespace MetaphysicsIndustries.Solus.Values
                 return "π";
             return Value.ToString("G");
         }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Number number)
+                return Value.Equals(number.Value);
+            if (obj is float f)
+                return Value.Equals(f);
+            return base.Equals(obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return Value.GetHashCode();
+        }
     }
 }

--- a/Values/Vector2.cs
+++ b/Values/Vector2.cs
@@ -1,0 +1,203 @@
+﻿
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2021 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using System;
+
+namespace MetaphysicsIndustries.Solus.Values
+{
+    public readonly struct Vector2 : IMathObject
+    {
+        public Vector2(float x, float y)
+        {
+            X = x;
+            Y = y;
+        }
+
+        public readonly float X;
+        public readonly float Y;
+
+        public static readonly Vector2 Zero = new Vector2(0, 0);
+        public static readonly Vector2 One = new Vector2(1, 1);
+        public static readonly Vector2 UnitX = new Vector2(1, 0);
+        public static readonly Vector2 UnitY = new Vector2(0, 1);
+
+        public static Vector2 operator -(Vector2 v)
+        {
+            return new Vector2(-v.X, -v.Y);
+        }
+        public static Vector2 operator -(Vector2 x, Vector2 y)
+        {
+            return new Vector2(x.X - y.X, x.Y - y.Y);
+        }
+        public static Vector2 operator +(Vector2 x, Vector2 y)
+        {
+            return new Vector2(x.X + y.X, x.Y + y.Y);
+        }
+        public static Vector2 operator *(Vector2 v, float s)
+        {
+            return new Vector2(v.X * s, v.Y * s);
+        }
+        public static Vector2 operator *(float s, Vector2 v)
+        {
+            return new Vector2(v.X * s, v.Y * s);
+        }
+        public static Vector2 operator /(Vector2 v, float s)
+        {
+            return new Vector2(v.X / s, v.Y / s);
+        }
+        public static bool operator ==(Vector2 u, Vector2 v)
+        {
+            return u.Equals(v);
+        }
+        public static bool operator !=(Vector2 u, Vector2 v)
+        {
+            return !u.Equals(v);
+        }
+
+        public bool Equals(Vector2 other)
+        {
+            return (this.X == other.X &&
+                this.Y == other.Y);
+        }
+        public override bool Equals(object other)
+        {
+            if (other is Vector2)
+            {
+                return Equals((Vector2)other);
+            }
+            else
+            {
+                return false;
+            }
+        }
+        public override int GetHashCode()
+        {
+            var x = 101 * X.GetHashCode();
+            return x ^ Y.GetHashCode();
+        }
+
+        public float Length()
+        {
+            return (float)Math.Sqrt(this.LengthSquared());
+        }
+
+        public float LengthSquared()
+        {
+            return Vector2.Dot(this, this);
+        }
+
+        public static float Dot(Vector2 a, Vector2 b)
+        {
+            return a.X * b.X + a.Y * b.Y;
+        }
+
+        public float ToAngle()
+        {
+            if (this.LengthSquared() > 0)
+            {
+                return (float)Math.Atan2(this.Y, this.X);
+            }
+            else
+            {
+                return 0;
+            }
+        }
+        public static Vector2 FromAngle(float angle)
+        {
+            return FromAngle((double)angle);
+        }
+        public static Vector2 FromAngle(double angle)
+        {
+            return new Vector2((float)Math.Cos(angle), (float)Math.Sin(angle));
+        }
+
+        public Vector2 Normalized()
+        {
+            return Normalize(this);
+        }
+
+        public static Vector2 Normalize(Vector2 v)
+        {
+            if (v.LengthSquared() > 0)
+            {
+                return v / v.Length();
+            }
+            else
+            {
+                return Zero;
+            }
+        }
+
+        public static float Distance(Vector2 u, Vector2 v)
+        {
+            return (u - v).Length();
+        }
+
+        public static float DistanceSquared(Vector2 u, Vector2 v)
+        {
+            return (u - v).LengthSquared();
+        }
+
+        public static Vector2 Max(Vector2 u, Vector2 v)
+        {
+            return new Vector2(
+                Math.Max(u.X, v.X),
+                Math.Max(u.Y, v.Y));
+        }
+
+        public override string ToString()
+        {
+            return string.Format("{{X:{0} Y:{1}}}", X, Y);
+        }
+
+        public Vector2 AddX(float dx)
+        {
+            return new Vector2(X + dx, Y);
+        }
+        public Vector2 AddY(float dy)
+        {
+            return new Vector2(X, Y + dy);
+        }
+
+        public bool? IsScalar(SolusEnvironment env) => false;
+        public bool? IsVector(SolusEnvironment env) => true;
+        public bool? IsMatrix(SolusEnvironment env) => false;
+        public int? GetTensorRank(SolusEnvironment env) => 1;
+        public bool? IsString(SolusEnvironment env) => false;
+
+        public int? GetDimension(SolusEnvironment env, int index)
+        {
+            if (index == 0) return 2;
+            return null;
+        }
+
+        private static readonly int[] Dimensions = new int[1] { 2 };
+        public int[] GetDimensions(SolusEnvironment env) => Dimensions;
+        public int? GetVectorLength(SolusEnvironment env) => 2;
+        public bool? IsInterval(SolusEnvironment env) => false;
+        public bool? IsFunction(SolusEnvironment env) => false;
+        public bool? IsExpression(SolusEnvironment env) => false;
+        public bool IsConcrete => true;
+        public string DocString => "";
+    }
+}
+

--- a/Values/Vector3.cs
+++ b/Values/Vector3.cs
@@ -1,0 +1,203 @@
+﻿
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2021 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using System;
+
+namespace MetaphysicsIndustries.Solus.Values
+{
+    public readonly struct Vector3 : IMathObject
+    {
+        public Vector3(float x, float y, float z)
+        {
+            X = x;
+            Y = y;
+            Z = z;
+        }
+
+        public readonly float X;
+        public readonly float Y;
+        public readonly float Z;
+
+        public static readonly Vector3 Zero = new Vector3(0, 0, 0);
+        public static readonly Vector3 One = new Vector3(1, 1, 1);
+        public static readonly Vector3 UnitX = new Vector3(1, 0, 0);
+        public static readonly Vector3 UnitY = new Vector3(0, 1, 0);
+        public static readonly Vector3 UnitZ = new Vector3(0, 0, 1);
+
+        public static Vector3 operator -(Vector3 v)
+        {
+            return new Vector3(-v.X, -v.Y, -v.Z);
+        }
+
+        public static Vector3 operator -(Vector3 x, Vector3 y)
+        {
+            return new Vector3(x.X - y.X, x.Y - y.Y, x.Z - y.Z);
+        }
+
+        public static Vector3 operator +(Vector3 x, Vector3 y)
+        {
+            return new Vector3(x.X + y.X, x.Y + y.Y, x.Z + y.Z);
+        }
+
+        public static Vector3 operator *(Vector3 v, float s)
+        {
+            return new Vector3(v.X * s, v.Y * s, v.Z * s);
+        }
+
+        public static Vector3 operator *(float s, Vector3 v)
+        {
+            return new Vector3(v.X * s, v.Y * s, v.Z * s);
+        }
+
+        public static Vector3 operator /(Vector3 v, float s)
+        {
+            return new Vector3(v.X / s, v.Y / s, v.Z / s);
+        }
+
+        public static bool operator ==(Vector3 u, Vector3 v)
+        {
+            return u.Equals(v);
+        }
+
+        public static bool operator !=(Vector3 u, Vector3 v)
+        {
+            return !u.Equals(v);
+        }
+
+        public bool Equals(Vector3 other)
+        {
+            return (this.X == other.X &&
+                    this.Y == other.Y &&
+                    this.Z == other.Z);
+        }
+
+        public override bool Equals(object other)
+        {
+            if (other is Vector3)
+            {
+                return Equals((Vector3)other);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public override int GetHashCode()
+        {
+            var x = 113 * X.GetHashCode();
+            x ^= 127 * Y.GetHashCode();
+            return x ^ Z.GetHashCode();
+        }
+
+        public float Length()
+        {
+            return (float)Math.Sqrt(this.LengthSquared());
+        }
+
+        public float LengthSquared()
+        {
+            return Vector3.Dot(this, this);
+        }
+
+        public static float Dot(Vector3 a, Vector3 b)
+        {
+            return a.X * b.X + a.Y * b.Y + a.Z * b.Z;
+        }
+
+        public Vector3 Normalized()
+        {
+            return Normalize(this);
+        }
+
+        public static Vector3 Normalize(Vector3 v)
+        {
+            if (v.LengthSquared() > 0)
+            {
+                return v / v.Length();
+            }
+            else
+            {
+                return Zero;
+            }
+        }
+
+        public static float Distance(Vector3 u, Vector3 v)
+        {
+            return (u - v).Length();
+        }
+
+        public static float DistanceSquared(Vector3 u, Vector3 v)
+        {
+            return (u - v).LengthSquared();
+        }
+
+        public static Vector3 Max(Vector3 u, Vector3 v)
+        {
+            return new Vector3(
+                Math.Max(u.X, v.X),
+                Math.Max(u.Y, v.Y),
+                Math.Max(u.Z, v.Z));
+        }
+
+        public override string ToString()
+        {
+            return string.Format("{{X:{0} Y:{1} Z:{2}}}", X, Y, Z);
+        }
+
+        public Vector3 AddX(float dx)
+        {
+            return new Vector3(X + dx, Y, Z);
+        }
+
+        public Vector3 AddY(float dy)
+        {
+            return new Vector3(X, Y + dy, Z);
+        }
+
+        public Vector3 AddZ(float dz)
+        {
+            return new Vector3(X, Y, Z + dz);
+        }
+
+        public bool? IsScalar(SolusEnvironment env) => false;
+        public bool? IsVector(SolusEnvironment env) => true;
+        public bool? IsMatrix(SolusEnvironment env) => false;
+        public int? GetTensorRank(SolusEnvironment env) => 1;
+        public bool? IsString(SolusEnvironment env) => false;
+
+        public int? GetDimension(SolusEnvironment env, int index)
+        {
+            if (index == 0) return 3;
+            return null;
+        }
+
+        private static readonly int[] Dimensions = new int[1] { 3 };
+        public int[] GetDimensions(SolusEnvironment env) => Dimensions;
+        public int? GetVectorLength(SolusEnvironment env) => 3;
+        public bool? IsInterval(SolusEnvironment env) => false;
+        public bool? IsFunction(SolusEnvironment env) => false;
+        public bool? IsExpression(SolusEnvironment env) => false;
+        public bool IsConcrete => true;
+        public string DocString => "";
+    }
+}


### PR DESCRIPTION
This PR adds optional operations to the `EvalInterval` methods. Storing the result of the evaluation is now optional (`StoreOp`), and there is also the ability to pass each evaluation result to a function (`AggregateOp`).

This PR also adds the `Vector2` and `Vector3` value types, to represent fixed-length 2-vectors and 3-vectors. These complement the existing n-ary `Vector` type.

This PR also adds four new functions for finding the min and max of a collection of numbers. The `min` and `max` functions find the extrema of the arguments passed to them, taking infinities and `NaN` into account. The `minf` and `maxf` functions ignore infinities and `NaN`.