### PR TITLE
Evaluator 4: Duplicate the tests for the new functions.

### DIFF
--- a/MetaphysicsIndustries.Solus.Test/EvaluatorT/FunctionsT/MaximumFiniteFunctionT/EvalMaximumFiniteFunctionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorT/FunctionsT/MaximumFiniteFunctionT/EvalMaximumFiniteFunctionTest.cs
@@ -21,8 +21,6 @@
  */
 
 using System;
-using System.Linq;
-using MetaphysicsIndustries.Solus.Exceptions;
 using MetaphysicsIndustries.Solus.Expressions;
 using MetaphysicsIndustries.Solus.Functions;
 using MetaphysicsIndustries.Solus.Values;
@@ -34,5 +32,251 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorT.FunctionsT.
     [TestFixture]
     public class EvalMaximumFiniteFunctionTest
     {
+        [Test]
+        public void AscendingYieldsMax()
+        {
+            // given
+            var expr = new FunctionCall(
+                MaximumFiniteFunction.Value,
+                new Literal(1),
+                new Literal(2),
+                new Literal(3),
+                new Literal(4),
+                new Literal(5));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(5, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void DescendingYieldsMax()
+        {
+            // given
+            var expr = new FunctionCall(
+                MaximumFiniteFunction.Value,
+                new Literal(9),
+                new Literal(8),
+                new Literal(7),
+                new Literal(6));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(9, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NegativeAscendingYieldsMax()
+        {
+            // given
+            var expr = new FunctionCall(
+                MaximumFiniteFunction.Value,
+                new Literal(-5),
+                new Literal(-4),
+                new Literal(-3),
+                new Literal(-2),
+                new Literal(-1));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(-1, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NegativeDescendingYieldsMax()
+        {
+            // given
+            var expr = new FunctionCall(
+                MaximumFiniteFunction.Value,
+                new Literal(-6),
+                new Literal(-7),
+                new Literal(-8),
+                new Literal(-9));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(-6, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void PositiveAndNegativeYieldsMax()
+        {
+            // given
+            var expr = new FunctionCall(
+                MaximumFiniteFunction.Value,
+                new Literal(-1),
+                new Literal(0),
+                new Literal(1));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(1, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NotInOrderYieldsMax()
+        {
+            // given
+            var expr = new FunctionCall(
+                MaximumFiniteFunction.Value,
+                new Literal(5),
+                new Literal(9),
+                new Literal(1),
+                new Literal(3),
+                new Literal(2));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(9, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void SingleArgumentYieldsMax()
+        {
+            // given
+            var expr = new FunctionCall(
+                MaximumFiniteFunction.Value,
+                new Literal(5));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(5, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void ZeroArgumentsThrows()
+        {
+            // given
+            var expr = new FunctionCall(
+                MaximumFiniteFunction.Value);
+            var eval = new Evaluator();
+            // expect
+            var ex = Assert.Throws<ArgumentException>(
+                () => eval.Eval(expr, null));
+            // and
+            Assert.AreEqual("No arguments passed", ex.Message);
+        }
+
+        [Test]
+        public void NaNIsIgnored()
+        {
+            // given
+            var expr = new FunctionCall(
+                MaximumFiniteFunction.Value,
+                new Literal(1),
+                new Literal(2),
+                new Literal(float.NaN),
+                new Literal(4),
+                new Literal(5));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(5, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void PositiveInfinityIsIgnored()
+        {
+            // given
+            var expr = new FunctionCall(
+                MaximumFiniteFunction.Value,
+                new Literal(1),
+                new Literal(2),
+                new Literal(float.PositiveInfinity),
+                new Literal(4),
+                new Literal(5));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(5, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NegativeInfinityIsIgnored()
+        {
+            // given
+            var expr = new FunctionCall(
+                MaximumFiniteFunction.Value,
+                new Literal(1),
+                new Literal(2),
+                new Literal(float.NegativeInfinity),
+                new Literal(4),
+                new Literal(5));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(5, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void InfinitiesAndNanYieldMax()
+        {
+            // given
+            var expr = new FunctionCall(
+                MaximumFiniteFunction.Value,
+                new Literal(float.PositiveInfinity),
+                new Literal(float.NegativeInfinity),
+                new Literal(float.NaN),
+                new Literal(1));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(1, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NoFiniteNumbersYieldsNaN1()
+        {
+            // given
+            var expr = new FunctionCall(
+                MaximumFiniteFunction.Value,
+                new Literal(float.PositiveInfinity),
+                new Literal(float.NegativeInfinity),
+                new Literal(float.NaN));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(float.NaN, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NoFiniteNumbersYieldsNaN2()
+        {
+            // given
+            var expr = new FunctionCall(
+                MaximumFiniteFunction.Value,
+                new Literal(float.PositiveInfinity),
+                new Literal(float.NegativeInfinity));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(float.NaN, result.ToNumber().Value);
+        }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorT/FunctionsT/MaximumFunctionT/EvalMaximumFunctionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorT/FunctionsT/MaximumFunctionT/EvalMaximumFunctionTest.cs
@@ -21,8 +21,6 @@
  */
 
 using System;
-using System.Linq;
-using MetaphysicsIndustries.Solus.Exceptions;
 using MetaphysicsIndustries.Solus.Expressions;
 using MetaphysicsIndustries.Solus.Functions;
 using MetaphysicsIndustries.Solus.Values;
@@ -34,5 +32,217 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorT.FunctionsT.
     [TestFixture]
     public class EvalMaximumFunctionTest
     {
+        [Test]
+        public void AscendingYieldsMax()
+        {
+            // given
+            var expr = new FunctionCall(
+                MaximumFunction.Value,
+                new Literal(1),
+                new Literal(2),
+                new Literal(3),
+                new Literal(4),
+                new Literal(5));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(5, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void DescendingYieldsMax()
+        {
+            // given
+            var expr = new FunctionCall(
+                MaximumFunction.Value,
+                new Literal(9),
+                new Literal(8),
+                new Literal(7),
+                new Literal(6));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(9, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NegativeAscendingYieldsMax()
+        {
+            // given
+            var expr = new FunctionCall(
+                MaximumFunction.Value,
+                new Literal(-5),
+                new Literal(-4),
+                new Literal(-3),
+                new Literal(-2),
+                new Literal(-1));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(-1, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NegativeDescendingYieldsMax()
+        {
+            // given
+            var expr = new FunctionCall(
+                MaximumFunction.Value,
+                new Literal(-6),
+                new Literal(-7),
+                new Literal(-8),
+                new Literal(-9));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(-6, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void PositiveAndNegativeYieldsMax()
+        {
+            // given
+            var expr = new FunctionCall(
+                MaximumFunction.Value,
+                new Literal(-1),
+                new Literal(0),
+                new Literal(1));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(1, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NotInOrderYieldsMax()
+        {
+            // given
+            var expr = new FunctionCall(
+                MaximumFunction.Value,
+                new Literal(5),
+                new Literal(9),
+                new Literal(1),
+                new Literal(3),
+                new Literal(2));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(9, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void SingleArgumentYieldsMax()
+        {
+            // given
+            var expr = new FunctionCall(
+                MaximumFunction.Value,
+                new Literal(5));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(5, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void ZeroArgumentsThrows()
+        {
+            // given
+            var expr = new FunctionCall(
+                MaximumFunction.Value);
+            var eval = new Evaluator();
+            // expect
+            var ex = Assert.Throws<ArgumentException>(
+                () => eval.Eval(expr, null));
+            // and
+            Assert.AreEqual("No arguments passed", ex.Message);
+        }
+
+        [Test]
+        public void NaNYieldsNaN()
+        {
+            // given
+            var expr = new FunctionCall(
+                MaximumFunction.Value,
+                new Literal(1),
+                new Literal(2),
+                new Literal(float.NaN),
+                new Literal(4),
+                new Literal(5));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(float.NaN, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void PositiveInfinityYieldsPositiveInfinity()
+        {
+            // given
+            var expr = new FunctionCall(
+                MaximumFunction.Value,
+                new Literal(1),
+                new Literal(2),
+                new Literal(float.PositiveInfinity),
+                new Literal(4),
+                new Literal(5));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(float.PositiveInfinity, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NegativeInfinityIsIgnored()
+        {
+            // given
+            var expr = new FunctionCall(
+                MaximumFunction.Value,
+                new Literal(1),
+                new Literal(2),
+                new Literal(float.NegativeInfinity),
+                new Literal(4),
+                new Literal(5));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(5, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void InfinitiesAndNanYieldNan()
+        {
+            // given
+            var expr = new FunctionCall(
+                MaximumFunction.Value,
+                new Literal(float.PositiveInfinity),
+                new Literal(float.NegativeInfinity),
+                new Literal(float.NaN));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(float.NaN, result.ToNumber().Value);
+        }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorT/FunctionsT/MinimumFiniteFunctionT/EvalMinimumFiniteFunctionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorT/FunctionsT/MinimumFiniteFunctionT/EvalMinimumFiniteFunctionTest.cs
@@ -21,8 +21,6 @@
  */
 
 using System;
-using System.Linq;
-using MetaphysicsIndustries.Solus.Exceptions;
 using MetaphysicsIndustries.Solus.Expressions;
 using MetaphysicsIndustries.Solus.Functions;
 using MetaphysicsIndustries.Solus.Values;
@@ -34,5 +32,251 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorT.FunctionsT.
     [TestFixture]
     public class EvalMinimumFiniteFunctionTest
     {
+        [Test]
+        public void AscendingYieldsMin()
+        {
+            // given
+            var expr = new FunctionCall(
+                MinimumFiniteFunction.Value,
+                new Literal(1),
+                new Literal(2),
+                new Literal(3),
+                new Literal(4),
+                new Literal(5));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(1, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void DescendingYieldsMin()
+        {
+            // given
+            var expr = new FunctionCall(
+                MinimumFiniteFunction.Value,
+                new Literal(9),
+                new Literal(8),
+                new Literal(7),
+                new Literal(6));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(6, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NegativeAscendingYieldsMin()
+        {
+            // given
+            var expr = new FunctionCall(
+                MinimumFiniteFunction.Value,
+                new Literal(-5),
+                new Literal(-4),
+                new Literal(-3),
+                new Literal(-2),
+                new Literal(-1));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(-5, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NegativeDescendingYieldsMin()
+        {
+            // given
+            var expr = new FunctionCall(
+                MinimumFiniteFunction.Value,
+                new Literal(-6),
+                new Literal(-7),
+                new Literal(-8),
+                new Literal(-9));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(-9, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void PositiveAndNegativeYieldsMin()
+        {
+            // given
+            var expr = new FunctionCall(
+                MinimumFiniteFunction.Value,
+                new Literal(-1),
+                new Literal(0),
+                new Literal(1));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(-1, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NotInOrderYieldsMin()
+        {
+            // given
+            var expr = new FunctionCall(
+                MinimumFiniteFunction.Value,
+                new Literal(5),
+                new Literal(9),
+                new Literal(1),
+                new Literal(3),
+                new Literal(2));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(1, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void SingleArgumentYieldsMin()
+        {
+            // given
+            var expr = new FunctionCall(
+                MinimumFiniteFunction.Value,
+                new Literal(5));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(5, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void ZeroArgumentsThrows()
+        {
+            // given
+            var expr = new FunctionCall(
+                MinimumFiniteFunction.Value);
+            var eval = new Evaluator();
+            // expect
+            var ex = Assert.Throws<ArgumentException>(
+                () => eval.Eval(expr, null));
+            // and
+            Assert.AreEqual("No arguments passed", ex.Message);
+        }
+
+        [Test]
+        public void NaNIsIgnored()
+        {
+            // given
+            var expr = new FunctionCall(
+                MinimumFiniteFunction.Value,
+                new Literal(1),
+                new Literal(2),
+                new Literal(float.NaN),
+                new Literal(4),
+                new Literal(5));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(1, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void PositiveInfinityIsIgnored()
+        {
+            // given
+            var expr = new FunctionCall(
+                MinimumFiniteFunction.Value,
+                new Literal(1),
+                new Literal(2),
+                new Literal(float.PositiveInfinity),
+                new Literal(4),
+                new Literal(5));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(1, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NegativeInfinityIsIgnored()
+        {
+            // given
+            var expr = new FunctionCall(
+                MinimumFiniteFunction.Value,
+                new Literal(1),
+                new Literal(2),
+                new Literal(float.NegativeInfinity),
+                new Literal(4),
+                new Literal(5));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(1, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void InfinitiesAndNanYieldMin()
+        {
+            // given
+            var expr = new FunctionCall(
+                MinimumFiniteFunction.Value,
+                new Literal(float.PositiveInfinity),
+                new Literal(float.NegativeInfinity),
+                new Literal(float.NaN),
+                new Literal(1));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(1, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NoFiniteNumbersYieldsNaN1()
+        {
+            // given
+            var expr = new FunctionCall(
+                MinimumFiniteFunction.Value,
+                new Literal(float.PositiveInfinity),
+                new Literal(float.NegativeInfinity),
+                new Literal(float.NaN));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(float.NaN, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NoFiniteNumbersYieldsNaN2()
+        {
+            // given
+            var expr = new FunctionCall(
+                MinimumFiniteFunction.Value,
+                new Literal(float.PositiveInfinity),
+                new Literal(float.NegativeInfinity));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(float.NaN, result.ToNumber().Value);
+        }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorT/FunctionsT/MinimumFunctionT/EvalMinimumFunctionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorT/FunctionsT/MinimumFunctionT/EvalMinimumFunctionTest.cs
@@ -21,8 +21,6 @@
  */
 
 using System;
-using System.Linq;
-using MetaphysicsIndustries.Solus.Exceptions;
 using MetaphysicsIndustries.Solus.Expressions;
 using MetaphysicsIndustries.Solus.Functions;
 using MetaphysicsIndustries.Solus.Values;
@@ -34,5 +32,217 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorT.FunctionsT.
     [TestFixture]
     public class EvalMinimumFunctionTest
     {
+        [Test]
+        public void AscendingYieldsMin()
+        {
+            // given
+            var expr = new FunctionCall(
+                MinimumFunction.Value,
+                new Literal(1),
+                new Literal(2),
+                new Literal(3),
+                new Literal(4),
+                new Literal(5));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(1, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void DescendingYieldsMin()
+        {
+            // given
+            var expr = new FunctionCall(
+                MinimumFunction.Value,
+                new Literal(9),
+                new Literal(8),
+                new Literal(7),
+                new Literal(6));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(6, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NegativeAscendingYieldsMin()
+        {
+            // given
+            var expr = new FunctionCall(
+                MinimumFunction.Value,
+                new Literal(-5),
+                new Literal(-4),
+                new Literal(-3),
+                new Literal(-2),
+                new Literal(-1));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(-5, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NegativeDescendingYieldsMin()
+        {
+            // given
+            var expr = new FunctionCall(
+                MinimumFunction.Value,
+                new Literal(-6),
+                new Literal(-7),
+                new Literal(-8),
+                new Literal(-9));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(-9, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void PositiveAndNegativeYieldsMin()
+        {
+            // given
+            var expr = new FunctionCall(
+                MinimumFunction.Value,
+                new Literal(-1),
+                new Literal(0),
+                new Literal(1));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(-1, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NotInOrderYieldsMin()
+        {
+            // given
+            var expr = new FunctionCall(
+                MinimumFunction.Value,
+                new Literal(5),
+                new Literal(9),
+                new Literal(1),
+                new Literal(3),
+                new Literal(2));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(1, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void SingleArgumentYieldsMin()
+        {
+            // given
+            var expr = new FunctionCall(
+                MinimumFunction.Value,
+                new Literal(5));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(5, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void ZeroArgumentsThrows()
+        {
+            // given
+            var expr = new FunctionCall(
+                MinimumFunction.Value);
+            var eval = new Evaluator();
+            // expect
+            var ex = Assert.Throws<ArgumentException>(
+                () => eval.Eval(expr, null));
+            // and
+            Assert.AreEqual("No arguments passed", ex.Message);
+        }
+
+        [Test]
+        public void NaNYieldsNaN()
+        {
+            // given
+            var expr = new FunctionCall(
+                MinimumFunction.Value,
+                new Literal(1),
+                new Literal(2),
+                new Literal(float.NaN),
+                new Literal(4),
+                new Literal(5));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(float.NaN, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void PositiveInfinityIsIgnored()
+        {
+            // given
+            var expr = new FunctionCall(
+                MinimumFunction.Value,
+                new Literal(1),
+                new Literal(2),
+                new Literal(float.PositiveInfinity),
+                new Literal(4),
+                new Literal(5));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(1, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void NegativeInfinityYieldsNegativeInfinity()
+        {
+            // given
+            var expr = new FunctionCall(
+                MinimumFunction.Value,
+                new Literal(1),
+                new Literal(2),
+                new Literal(float.NegativeInfinity),
+                new Literal(4),
+                new Literal(5));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(float.NegativeInfinity, result.ToNumber().Value);
+        }
+
+        [Test]
+        public void InfinitiesAndNanYieldNan()
+        {
+            // given
+            var expr = new FunctionCall(
+                MinimumFunction.Value,
+                new Literal(float.PositiveInfinity),
+                new Literal(float.NegativeInfinity),
+                new Literal(float.NaN));
+            var eval = new Evaluator();
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.IsInstanceOf<Number>(result);
+            Assert.AreEqual(float.NaN, result.ToNumber().Value);
+        }
     }
 }


### PR DESCRIPTION
This PR duplicates the tests for the `min`, `minf`, `max`, and `maxf` functions. There are already tests for those functions that call the `Call` method directly. These new tests exercise the functions via the evaluator. This only affects test files. There is no change to the functionality of the library.