### PR TITLE
Evaluator 5: more storage and aggregate op improvements

### DIFF
--- a/Evaluator.cs
+++ b/Evaluator.cs
@@ -24,6 +24,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using MetaphysicsIndustries.Solus.Expressions;
+using MetaphysicsIndustries.Solus.Functions;
 using MetaphysicsIndustries.Solus.Transformers;
 using MetaphysicsIndustries.Solus.Values;
 
@@ -78,6 +79,28 @@ namespace MetaphysicsIndustries.Solus
             public override void Operate(IMathObject input)
             {
                 State = Function((TIn)input, State);
+            }
+        }
+
+        public class FunctionAggregateOp : AggregateOp
+        {
+            public FunctionAggregateOp(Function function,
+                IMathObject initialState)
+            {
+                Function = function;
+                State = initialState;
+            }
+
+            public IMathObject State;
+            public readonly Function Function;
+
+            private readonly IMathObject[] _args = new IMathObject[2];
+            public override void Operate(IMathObject input)
+            {
+                _args[0] = input;
+                _args[1] = State;
+                var result = Function.Call(null, _args);
+                State = result;
             }
         }
 

--- a/Evaluator.cs
+++ b/Evaluator.cs
@@ -68,7 +68,8 @@ namespace MetaphysicsIndustries.Solus
 
         public abstract class AggregateOp
         {
-            public abstract void Operate(IMathObject input);
+            public abstract void Operate(IMathObject input,
+                SolusEnvironment env);
         }
 
         public class AggregateOp<TIn, TOut> : AggregateOp
@@ -76,7 +77,8 @@ namespace MetaphysicsIndustries.Solus
             public TOut State;
             public Func<TIn, TOut, TOut> Function;
 
-            public override void Operate(IMathObject input)
+            public override void Operate(IMathObject input,
+                SolusEnvironment env)
             {
                 State = Function((TIn)input, State);
             }
@@ -95,11 +97,12 @@ namespace MetaphysicsIndustries.Solus
             public readonly Function Function;
 
             private readonly IMathObject[] _args = new IMathObject[2];
-            public override void Operate(IMathObject input)
+            public override void Operate(IMathObject input,
+                SolusEnvironment env)
             {
                 _args[0] = input;
                 _args[1] = State;
-                var result = Function.Call(null, _args);
+                var result = Function.Call(env, _args);
                 State = result;
             }
         }
@@ -130,7 +133,7 @@ namespace MetaphysicsIndustries.Solus
                     store.Store(i, v);
                 if (aggrs != null)
                     foreach (var aggr in aggrs)
-                        aggr?.Operate(v);
+                        aggr?.Operate(v, env2);
             }
         }
 
@@ -209,7 +212,7 @@ namespace MetaphysicsIndustries.Solus
                         store.Store(i, j, v);
                     if (aggrs != null)
                         foreach (var aggr in aggrs)
-                            aggr?.Operate(v);
+                            aggr?.Operate(v, env2);
                 }
             }
         }
@@ -305,7 +308,7 @@ namespace MetaphysicsIndustries.Solus
                             store.Store(i, j, k, v);
                         if (aggrs != null)
                             foreach (var aggr in aggrs)
-                                aggr?.Operate(v);
+                                aggr?.Operate(v, env2);
                     }
                 }
             }

--- a/Evaluator.cs
+++ b/Evaluator.cs
@@ -66,6 +66,30 @@ namespace MetaphysicsIndustries.Solus
             }
         }
 
+        public class VectorStoreOp : StoreOp1
+        {
+            private IMathObject[] _values = null;
+            private Vector? _result = null;
+
+            public Vector GetResult()
+            {
+                if (!_result.HasValue)
+                    _result = new Vector(_values);
+                return _result.Value;
+            }
+
+            public override void Store(int index, IMathObject value)
+            {
+                _values[index] = value;
+            }
+
+            public override void SetMinArraySize(int length)
+            {
+                if (_values == null || _values.Length != length)
+                    _values = new IMathObject[length];
+            }
+        }
+
         public abstract class AggregateOp
         {
             public abstract void Operate(IMathObject input,
@@ -164,6 +188,33 @@ namespace MetaphysicsIndustries.Solus
                 {
                     Values = new T[length0, length1];
                 }
+            }
+        }
+
+        public class MatrixStoreOp : StoreOp2
+        {
+            private IMathObject[,] _values = null;
+            private Matrix? _result = null;
+
+            public Matrix GetResult()
+            {
+                if (!_result.HasValue)
+                    _result = new Matrix(_values);
+                return _result.Value;
+            }
+
+            public override void Store(int index0, int index1,
+                IMathObject value)
+            {
+                _values[index0, index1] = value;
+            }
+
+            public override void SetMinArraySize(int length0, int length1)
+            {
+                if (_values == null ||
+                    _values.GetLength(0) < length0 ||
+                    _values.GetLength(1) < length1)
+                    _values = new IMathObject[length0, length1];
             }
         }
 

--- a/Expressions/ComponentAccess.cs
+++ b/Expressions/ComponentAccess.cs
@@ -48,13 +48,22 @@ namespace MetaphysicsIndustries.Solus.Expressions
             return AccessComponent(value, evaledIndexes, env);
         }
 
+        private IMathObject[] _evaledIndexesCache;
         private IMathObject[] GetEvaledIndexes(SolusEnvironment env)
         {
-            // TODO: caching, eventually, so as to not repeat so much
-            // evaluation. But that is a non-starter at the moment, because
-            // the contents of the env can change at any time.
+            // TODO: proper caching of the results of evaluation, eventually,
+            // so as to not repeat so much evaluation. But that is a
+            // non-starter at the moment, because the contents of the env
+            // can change at any time.
 
-            return Indexes.Select(e => e.Eval(env)).ToArray();
+            if (_evaledIndexesCache == null ||
+                _evaledIndexesCache.Length < Indexes.Count)
+                _evaledIndexesCache = new IMathObject[Indexes.Count];
+            int i;
+            for (i = 0; i < Indexes.Count; i++)
+                _evaledIndexesCache[i] = Indexes[i].Eval(env);
+
+            return _evaledIndexesCache;
         }
 
         private static void CheckIndexes(IMathObject[] indexes,

--- a/Expressions/ComponentAccess.cs
+++ b/Expressions/ComponentAccess.cs
@@ -92,12 +92,16 @@ namespace MetaphysicsIndustries.Solus.Expressions
 
             // TODO: maybe pass the env, and then we don't have to eval the
             // indexes before-hand?
-            if (indexes.Any(i => !i.IsIsScalar(null)))
-                throw new IndexException(
-                    "Indexes must be scalar");
-            if (indexes.Any(i => i.ToNumber().Value < 0))
-                throw new IndexException(
-                    "Indexes must not be negative");
+            int i;
+            for (i = 0; i < indexes.Length; i++)
+            {
+                if (!indexes[i].IsIsScalar(null))
+                    throw new IndexException(
+                        "Indexes must be scalar");
+                if (indexes[i].ToNumber().Value < 0)
+                    throw new IndexException(
+                        "Indexes must not be negative");
+            }
 
             var index0 = (int) indexes[0].ToNumber().Value;
             if (exprIsVector.HasValue && exprIsVector.Value)

--- a/Functions/UserDefinedFunction.cs
+++ b/Functions/UserDefinedFunction.cs
@@ -20,6 +20,7 @@
  *
  */
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using MetaphysicsIndustries.Solus.Expressions;
@@ -39,6 +40,15 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public string[] Argnames;
         public Expression Expression;
+
+        public override void CheckArguments(IMathObject[] args)
+        {
+            if (args.Length != Argnames.Length)
+                throw new ArgumentException(
+                    $"Wrong number of arguments given to " +
+                    $"{DisplayName} (expected {Argnames.Length} but got " +
+                    $"{args.Length})");
+        }
 
         protected override IMathObject InternalCall(SolusEnvironment env,
             IMathObject[] args)

--- a/Functions/UserDefinedFunction.cs
+++ b/Functions/UserDefinedFunction.cs
@@ -53,7 +53,7 @@ namespace MetaphysicsIndustries.Solus.Functions
         protected override IMathObject InternalCall(SolusEnvironment env,
             IMathObject[] args)
         {
-            SolusEnvironment env2 = env.Clone();
+            SolusEnvironment env2 = env.CreateChildEnvironment();
 
             int i;
             for (i = 0; i < Argnames.Length; i++)

--- a/Functions/UserDefinedFunction.cs
+++ b/Functions/UserDefinedFunction.cs
@@ -66,7 +66,7 @@ namespace MetaphysicsIndustries.Solus.Functions
             int i;
             for (i = 0; i < Argnames.Length; i++)
             {
-                env2.SetVariable(Argnames[i], new Literal(args[i]));
+                env2.SetVariable(Argnames[i], args[i]);
             }
 
             return Expression.Eval(env2);

--- a/Functions/UserDefinedFunction.cs
+++ b/Functions/UserDefinedFunction.cs
@@ -50,10 +50,18 @@ namespace MetaphysicsIndustries.Solus.Functions
                     $"{args.Length})");
         }
 
+        private SolusEnvironment _parentCache;
+        private SolusEnvironment _childCache;
         protected override IMathObject InternalCall(SolusEnvironment env,
             IMathObject[] args)
         {
-            SolusEnvironment env2 = env.CreateChildEnvironment();
+            if (_childCache == null ||
+                env != _parentCache)
+            {
+                _childCache = env.CreateChildEnvironment();
+                _parentCache = env;
+            }
+            var env2 = _childCache;
 
             int i;
             for (i = 0; i < Argnames.Length; i++)

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorT/EvalIntervalTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorT/EvalIntervalTest.cs
@@ -56,6 +56,31 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorT
         }
 
         [Test]
+        public void StoreToVector()
+        {
+            // given
+            var eval = new Evaluator();
+            var expr = new FunctionCall(MultiplicationOperation.Value,
+                new VariableAccess("x"),
+                new VariableAccess("x"));
+            var env = new SolusEnvironment();
+            var interval = new VarInterval("x",
+                new Interval(2, false, 6, false, false));
+            var numSteps = 5;
+            var store = new Evaluator.VectorStoreOp();
+            // when
+            eval.EvalInterval(expr, env, interval, numSteps, store);
+            // then
+            var result = store.GetResult();
+            Assert.AreEqual(5, result.Length);
+            Assert.AreEqual(4, result[0].ToNumber().Value);
+            Assert.AreEqual(9, result[1].ToNumber().Value);
+            Assert.AreEqual(16, result[2].ToNumber().Value);
+            Assert.AreEqual(25, result[3].ToNumber().Value);
+            Assert.AreEqual(36, result[4].ToNumber().Value);
+        }
+
+        [Test]
         public void TwoIntervalEval()
         {
             // given
@@ -115,6 +140,68 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorT
             Assert.AreEqual(60, store.Values[4, 3].Value);
             Assert.AreEqual(66, store.Values[4, 4].Value);
             Assert.AreEqual(72, store.Values[4, 5].Value);
+        }
+
+        [Test]
+        public void StoreToMatrix()
+        {
+            // given
+            var eval = new Evaluator();
+            var expr = new FunctionCall(MultiplicationOperation.Value,
+                new VariableAccess("x"),
+                new VariableAccess("y"));
+            var env = new SolusEnvironment();
+            var interval1 = new VarInterval("x",
+                new Interval(2, false, 6, false, false));
+            var numSteps1 = 5;
+            var interval2 = new VarInterval("y",
+                new Interval(7, false, 12, false, false));
+            var numSteps2 = 6;
+            var store = new Evaluator.MatrixStoreOp();
+            // when
+            eval.EvalInterval(expr, env,
+                interval1, numSteps1,
+                interval2, numSteps2,
+                store);
+            // then
+            var result = store.GetResult();
+            Assert.AreEqual(5, result.RowCount);
+            Assert.AreEqual(6, result.ColumnCount);
+
+            Assert.AreEqual(14, result[0, 0].ToNumber().Value);
+            Assert.AreEqual(16, result[0, 1].ToNumber().Value);
+            Assert.AreEqual(18, result[0, 2].ToNumber().Value);
+            Assert.AreEqual(20, result[0, 3].ToNumber().Value);
+            Assert.AreEqual(22, result[0, 4].ToNumber().Value);
+            Assert.AreEqual(24, result[0, 5].ToNumber().Value);
+
+            Assert.AreEqual(21, result[1, 0].ToNumber().Value);
+            Assert.AreEqual(24, result[1, 1].ToNumber().Value);
+            Assert.AreEqual(27, result[1, 2].ToNumber().Value);
+            Assert.AreEqual(30, result[1, 3].ToNumber().Value);
+            Assert.AreEqual(33, result[1, 4].ToNumber().Value);
+            Assert.AreEqual(36, result[1, 5].ToNumber().Value);
+
+            Assert.AreEqual(28, result[2, 0].ToNumber().Value);
+            Assert.AreEqual(32, result[2, 1].ToNumber().Value);
+            Assert.AreEqual(36, result[2, 2].ToNumber().Value);
+            Assert.AreEqual(40, result[2, 3].ToNumber().Value);
+            Assert.AreEqual(44, result[2, 4].ToNumber().Value);
+            Assert.AreEqual(48, result[2, 5].ToNumber().Value);
+
+            Assert.AreEqual(35, result[3, 0].ToNumber().Value);
+            Assert.AreEqual(40, result[3, 1].ToNumber().Value);
+            Assert.AreEqual(45, result[3, 2].ToNumber().Value);
+            Assert.AreEqual(50, result[3, 3].ToNumber().Value);
+            Assert.AreEqual(55, result[3, 4].ToNumber().Value);
+            Assert.AreEqual(60, result[3, 5].ToNumber().Value);
+
+            Assert.AreEqual(42, result[4, 0].ToNumber().Value);
+            Assert.AreEqual(48, result[4, 1].ToNumber().Value);
+            Assert.AreEqual(54, result[4, 2].ToNumber().Value);
+            Assert.AreEqual(60, result[4, 3].ToNumber().Value);
+            Assert.AreEqual(66, result[4, 4].ToNumber().Value);
+            Assert.AreEqual(72, result[4, 5].ToNumber().Value);
         }
 
         [Test]

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorT/EvalIntervalTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorT/EvalIntervalTest.cs
@@ -349,5 +349,26 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorT
             Assert.AreEqual(7, aggrMax.State.Value);
             Assert.AreEqual(3, aggrMin.State.Value);
         }
+
+        [Test]
+        public void FunctionAggregateOpRunsOnEachValue()
+        {
+            // given
+            var expr = new FunctionCall(
+                MultiplicationOperation.Value,
+                new VariableAccess("x"),
+                new VariableAccess("x"));
+            var eval = new Evaluator();
+            var interval = new VarInterval("x", 1, 5);
+            var env = new SolusEnvironment();
+            var aggr = new Evaluator.FunctionAggregateOp(
+                MaximumFiniteFunction.Value, float.NaN.ToNumber());
+            // when
+            eval.EvalInterval(expr, env, interval, 5, null,
+                new Evaluator.AggregateOp[] { aggr });
+            // then
+            Assert.AreEqual(25, aggr.State.ToNumber().Value);
+        }
+
     }
 }


### PR DESCRIPTION
This PR adds the ability to specify a `Function` as an `AggregateOp`, and the ability to store evaluation result into a `Vector` or `Matrix` instead of an array. It also includes some small performance improvements, and allows `UserDefinedFunction` to take arguments that are not numbers.