### PR TITLE
Eval to fixed length vector

### DIFF
--- a/Evaluator.Expressions.cs
+++ b/Evaluator.Expressions.cs
@@ -198,8 +198,38 @@ namespace MetaphysicsIndustries.Solus
 
         public IMathObject Eval(VectorExpression expr, SolusEnvironment env)
         {
+            var value0 = Eval(expr[0], env);
+            IMathObject value1 = null;
+            if (expr.Length > 1)
+                value1 = Eval(expr[1], env);
+            if (expr.Length == 2 &&
+                value0.IsConcrete &&
+                value0.IsIsScalar(null) &&
+                value1.IsConcrete &&
+                value1.IsIsScalar(null))
+                return new Vector2(
+                    value0.ToNumber().Value,
+                    value1.ToNumber().Value);
+            IMathObject value2 = null;
+            if (expr.Length > 2)
+                value2 = Eval(expr[2], env);
+            if (expr.Length == 3 &&
+                value0.IsConcrete &&
+                value0.IsIsScalar(null) &&
+                value1.IsConcrete &&
+                value1.IsIsScalar(null) &&
+                value2.IsConcrete &&
+                value2.IsIsScalar(null))
+                return new Vector3(
+                    value0.ToNumber().Value,
+                    ((Number)value1).Value,
+                    value2.ToNumber().Value);
+
             var values = new IMathObject[expr.Length];
-            for (int i = 0; i < expr.Length; i++)
+            values[0] = value0;
+            if (expr.Length > 1) values[1] = value1;
+            if (expr.Length > 2) values[2] = value2;
+            for (int i = 3; i < expr.Length; i++)
                 values[i] = Eval(expr[i], env);
             // Vector will take ownership of array
             return new Vector(values); // TODO: don't box here

--- a/Evaluator.Expressions.cs
+++ b/Evaluator.Expressions.cs
@@ -120,9 +120,6 @@ namespace MetaphysicsIndustries.Solus
             throw new NotImplementedException();
         }
 
-        private IMathObject[] _functionCallArgsCache = new IMathObject[0];
-
-        // Warning: Not thread-safe
         public IMathObject Eval(FunctionCall expr, SolusEnvironment env)
         {
             var f0 = Eval(expr.Function, env);
@@ -142,11 +139,10 @@ namespace MetaphysicsIndustries.Solus
 
             var f = (Function)f0;
 
-            if (_functionCallArgsCache.Length < expr.Arguments.Count)
-                _functionCallArgsCache = new IMathObject[expr.Arguments.Count];
+            var evaluatedArgs = new IMathObject[expr.Arguments.Count];
             for (i = 0; i < expr.Arguments.Count; i++)
-                _functionCallArgsCache[i] = Eval(expr.Arguments[i], env);
-            return Call(f, _functionCallArgsCache, env);
+                evaluatedArgs[i] = Eval(expr.Arguments[i], env);
+            return Call(f, evaluatedArgs, env);
         }
 
         public IMathObject Eval(IntervalExpression expr, SolusEnvironment env)

--- a/Expressions/MatrixExpression.cs
+++ b/Expressions/MatrixExpression.cs
@@ -134,6 +134,8 @@ namespace MetaphysicsIndustries.Solus.Expressions
 
         public IMathObject GetComponent(int row, int column) =>
             this[row, column];
+        IMathObject IMatrix.this[int row,int column] =>
+            GetComponent(row, column);
 
         public override Expression GetComponent(int[] indexes)
         {

--- a/Expressions/VectorExpression.cs
+++ b/Expressions/VectorExpression.cs
@@ -93,6 +93,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
         private Expression[] _array;
         public int Length => _array.Length;
         public IMathObject GetComponent(int index) => _array[index];
+        IMathObject IVector.this[int index] => GetComponent(index);
 
         public override Expression GetComponent(int[] indexes)
         {

--- a/IMathObject.cs
+++ b/IMathObject.cs
@@ -50,6 +50,7 @@ namespace MetaphysicsIndustries.Solus
     {
         int Length { get; }
         IMathObject GetComponent(int index);
+        IMathObject this[int index] { get; }
     }
 
     public interface IMatrix : ITensor
@@ -57,6 +58,7 @@ namespace MetaphysicsIndustries.Solus
         int RowCount { get; }
         int ColumnCount { get; }
         IMathObject GetComponent(int row, int column);
+        IMathObject this[int row,int column] { get; }
     }
 
     public class ScalarMathObject : IMathObject

--- a/MathObjectHelper.cs
+++ b/MathObjectHelper.cs
@@ -75,8 +75,8 @@ namespace MetaphysicsIndustries.Solus
         public static StringValue ToStringValue(this IMathObject mo) =>
             (StringValue) mo;
 
-        public static Vector ToVector(this IMathObject mo) => (Vector) mo;
-        public static Matrix ToMatrix(this IMathObject mo) => (Matrix) mo;
+        public static IVector ToVector(this IMathObject mo) => (IVector) mo;
+        public static IMatrix ToMatrix(this IMathObject mo) => (IMatrix) mo;
 
         public static Number ToNumber(this float value) => new Number(value);
         public static Number ToNumber(this int value) => new Number(value);

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorT/ExpressionsT/VectorExpressionT/EvalVectorExpressionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorT/ExpressionsT/VectorExpressionT/EvalVectorExpressionTest.cs
@@ -43,12 +43,12 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorT.ExpressionsT.
             // when
             var result = eval.Eval(expr, null);
             // then
-            Assert.IsInstanceOf<Vector>(result);
-            var vector = (Vector)result;
+            Assert.IsInstanceOf<IVector>(result);
+            var vector = (IVector)result;
             Assert.AreEqual(3, vector.Length);
-            Assert.AreEqual(1.ToNumber(), vector[0]);
-            Assert.AreEqual(2.ToNumber(), vector[1]);
-            Assert.AreEqual(3.ToNumber(), vector[2]);
+            Assert.AreEqual(1.ToNumber(), vector.GetComponent(0));
+            Assert.AreEqual(2.ToNumber(), vector.GetComponent(1));
+            Assert.AreEqual(3.ToNumber(), vector.GetComponent(2));
         }
 
         [Test]
@@ -82,12 +82,12 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorT.ExpressionsT.
             // when
             var result = eval.Eval(expr, env);
             // then
-            Assert.IsInstanceOf<Vector>(result);
-            var vector = (Vector)result;
+            Assert.IsInstanceOf<IVector>(result);
+            var vector = (IVector)result;
             Assert.AreEqual(3, vector.Length);
-            Assert.AreEqual(1.ToNumber(), vector[0]);
-            Assert.AreEqual(2.ToNumber(), vector[1]);
-            Assert.AreEqual(5.ToNumber(), vector[2]);
+            Assert.AreEqual(1.ToNumber(), vector.GetComponent(0));
+            Assert.AreEqual(2.ToNumber(), vector.GetComponent(1));
+            Assert.AreEqual(5.ToNumber(), vector.GetComponent(2));
         }
 
         [Test]
@@ -105,17 +105,17 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorT.ExpressionsT.
             // when
             var result = eval.Eval(expr, null);
             // then
-            Assert.IsInstanceOf<Vector>(result);
-            var vector = (Vector)result;
+            Assert.IsInstanceOf<IVector>(result);
+            var vector = (IVector)result;
             Assert.AreEqual(3, vector.Length);
-            Assert.AreEqual(1.ToNumber(), vector[0]);
-            Assert.AreEqual(2.ToNumber(), vector[1]);
-            Assert.IsInstanceOf<Vector>(vector[2]);
-            var vector2 = (Vector)vector[2];
+            Assert.AreEqual(1.ToNumber(), vector.GetComponent(0));
+            Assert.AreEqual(2.ToNumber(), vector.GetComponent(1));
+            Assert.IsInstanceOf<IVector>(vector.GetComponent(2));
+            var vector2 = (IVector)vector.GetComponent(2);
             Assert.AreEqual(3, vector2.Length);
-            Assert.AreEqual(3.ToNumber(), vector2[0]);
-            Assert.AreEqual(4.ToNumber(), vector2[1]);
-            Assert.AreEqual(5.ToNumber(), vector2[2]);
+            Assert.AreEqual(3.ToNumber(), vector2.GetComponent(0));
+            Assert.AreEqual(4.ToNumber(), vector2.GetComponent(1));
+            Assert.AreEqual(5.ToNumber(), vector2.GetComponent(2));
         }
     }
 }

--- a/Values/Vector2.cs
+++ b/Values/Vector2.cs
@@ -206,6 +206,8 @@ namespace MetaphysicsIndustries.Solus.Values
             if (index == 1) return Y.ToNumber();
             throw new IndexOutOfRangeException();
         }
+
+        public IMathObject this[int index] => GetComponent(index);
     }
 }
 

--- a/Values/Vector3.cs
+++ b/Values/Vector3.cs
@@ -208,5 +208,7 @@ namespace MetaphysicsIndustries.Solus.Values
             if (index == 2) return Z.ToNumber();
             throw new IndexOutOfRangeException();
         }
+
+        public IMathObject this[int index] => GetComponent(index);
     }
 }


### PR DESCRIPTION
This PR modifies `Eval(VectorExpression, SolusEnvironment)` to return fixed-length vector (types `Vector2` and `Vector3`) if the resulting value is small enough, thus preventing an array allocation.