### PR TITLE
Evaluator 13: Nascent Method

### DIFF
--- a/Compiler/ILCompiler.cs
+++ b/Compiler/ILCompiler.cs
@@ -34,9 +34,9 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public CompiledExpression Compile(Expression expr)
         {
-            var varmap = new VariableToArgumentNumberMapper();
-            var ilexpr = ConvertToIlExpression(expr, varmap);
-            var args = varmap.GetVariableNamesInIndexOrder();
+            var nm = new NascentMethod();
+            var ilexpr = ConvertToIlExpression(expr, nm);
+            var args = nm.GetVariableNamesInIndexOrder();
             var instructions = new List<Instruction>();
             ilexpr.GetInstructions(instructions);
 
@@ -143,24 +143,24 @@ namespace MetaphysicsIndustries.Solus.Compiler
         // compile expressions
 
         public IlExpression ConvertToIlExpression(
-            Expression expr, VariableToArgumentNumberMapper varmap)
+            Expression expr, NascentMethod nm)
         {
             if (expr is FunctionCall call)
-                return ConvertToIlExpression(call, varmap);
+                return ConvertToIlExpression(call, nm);
             if (expr is Literal lit)
-                return ConvertToIlExpression(lit, varmap);
+                return ConvertToIlExpression(lit, nm);
             if (expr is VariableAccess va)
-                return ConvertToIlExpression(va, varmap);
+                return ConvertToIlExpression(va, nm);
             throw new ArgumentException(
                 $"Unsupported expresssion type: \"{expr}\"", nameof(expr));
         }
 
         public IlExpression ConvertToIlExpression(
-             FunctionCall expr, VariableToArgumentNumberMapper varmap)
+            FunctionCall expr, NascentMethod nm)
         {
             if (expr.Function is Literal literal &&
                 literal.Value is Function f)
-                return ConvertToIlExpression(f, varmap, expr.Arguments);
+                return ConvertToIlExpression(f, nm, expr.Arguments);
 
             // TODO:
             throw new NotImplementedException(
@@ -169,7 +169,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
         }
 
         public IlExpression ConvertToIlExpression(
-            Literal expr, VariableToArgumentNumberMapper varmap)
+            Literal expr, NascentMethod nm)
         {
             if (expr.Value.IsIsScalar(null))
                 return new LoadConstantIlExpression(expr.Value.ToFloat());
@@ -178,110 +178,110 @@ namespace MetaphysicsIndustries.Solus.Compiler
         }
 
         public IlExpression ConvertToIlExpression(
-            VariableAccess expr, VariableToArgumentNumberMapper varmap)
+            VariableAccess expr, NascentMethod nm)
         {
-            return new LoadLocalIlExpression(varmap[expr.VariableName]);
+            return new LoadLocalIlExpression(nm[expr.VariableName]);
         }
 
         // compile functions
 
         public IlExpression ConvertToIlExpression(Function func,
-            VariableToArgumentNumberMapper varmap, List<Expression> arguments)
+            NascentMethod nm, List<Expression> arguments)
         {
             switch (func)
             {
                 case AbsoluteValueFunction ff:
-                    return ConvertToIlExpression(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, nm, arguments);
                 case AdditionOperation ao:
-                    return ConvertToIlExpression(ao, varmap, arguments);
+                    return ConvertToIlExpression(ao, nm, arguments);
                 case ArccosecantFunction ff:
-                    return ConvertToIlExpression(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, nm, arguments);
                 case ArccosineFunction ff:
-                    return ConvertToIlExpression(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, nm, arguments);
                 case ArccotangentFunction ff:
-                    return ConvertToIlExpression(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, nm, arguments);
                 case ArcsecantFunction ff:
-                    return ConvertToIlExpression(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, nm, arguments);
                 case ArcsineFunction ff:
-                    return ConvertToIlExpression(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, nm, arguments);
                 case Arctangent2Function ff:
-                    return ConvertToIlExpression(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, nm, arguments);
                 case ArctangentFunction ff:
-                    return ConvertToIlExpression(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, nm, arguments);
                 case BitwiseAndOperation ff:
-                    return ConvertToIlExpression(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, nm, arguments);
                 case BitwiseOrOperation ff:
-                    return ConvertToIlExpression(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, nm, arguments);
                 case CeilingFunction ff:
-                    return ConvertToIlExpression(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, nm, arguments);
                 case CosecantFunction ff:
-                    return ConvertToIlExpression(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, nm, arguments);
                 case CosineFunction c:
-                    return ConvertToIlExpression(c, varmap, arguments);
+                    return ConvertToIlExpression(c, nm, arguments);
                 case CotangentFunction ff:
-                    return ConvertToIlExpression(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, nm, arguments);
                 case DistFunction ff:
-                    return ConvertToIlExpression(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, nm, arguments);
                 case DistSqFunction ff:
-                    return ConvertToIlExpression(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, nm, arguments);
                 case DivisionOperation ff:
-                    return ConvertToIlExpression(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, nm, arguments);
                 case EqualComparisonOperation ff:
-                    return ConvertToIlExpression(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, nm, arguments);
                 case ExponentOperation eo:
-                    return ConvertToIlExpression(eo, varmap, arguments);
+                    return ConvertToIlExpression(eo, nm, arguments);
                 case FactorialFunction ff:
-                    return ConvertToIlExpression(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, nm, arguments);
                 case FloorFunction ff:
-                    return ConvertToIlExpression(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, nm, arguments);
                 case GreaterThanComparisonOperation ff:
-                    return ConvertToIlExpression(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, nm, arguments);
                 case GreaterThanOrEqualComparisonOperation ff:
-                    return ConvertToIlExpression(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, nm, arguments);
                 case LessThanComparisonOperation ff:
-                    return ConvertToIlExpression(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, nm, arguments);
                 case LessThanOrEqualComparisonOperation ff:
-                    return ConvertToIlExpression(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, nm, arguments);
                 case LoadImageFunction ff:
-                    return ConvertToIlExpression(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, nm, arguments);
                 case Log10Function ff:
-                    return ConvertToIlExpression(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, nm, arguments);
                 case Log2Function ff:
-                    return ConvertToIlExpression(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, nm, arguments);
                 case LogarithmFunction ff:
-                    return ConvertToIlExpression(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, nm, arguments);
                 case LogicalAndOperation ff:
-                    return ConvertToIlExpression(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, nm, arguments);
                 case LogicalOrOperation ff:
-                    return ConvertToIlExpression(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, nm, arguments);
                 case MaximumFiniteFunction ff:
-                    return ConvertToIlExpression(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, nm, arguments);
                 case MaximumFunction ff:
-                    return ConvertToIlExpression(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, nm, arguments);
                 case MinimumFiniteFunction ff:
-                    return ConvertToIlExpression(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, nm, arguments);
                 case MinimumFunction ff:
-                    return ConvertToIlExpression(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, nm, arguments);
                 case ModularDivision ff:
-                    return ConvertToIlExpression(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, nm, arguments);
                 case MultiplicationOperation mo:
-                    return ConvertToIlExpression(mo, varmap, arguments);
+                    return ConvertToIlExpression(mo, nm, arguments);
                 case NaturalLogarithmFunction ff:
-                    return ConvertToIlExpression(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, nm, arguments);
                 case NegationOperation no:
-                    return ConvertToIlExpression(no, varmap, arguments);
+                    return ConvertToIlExpression(no, nm, arguments);
                 case NotEqualComparisonOperation ff:
-                    return ConvertToIlExpression(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, nm, arguments);
                 case SecantFunction ff:
-                    return ConvertToIlExpression(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, nm, arguments);
                 case SineFunction s:
-                    return ConvertToIlExpression(s, varmap, arguments);
+                    return ConvertToIlExpression(s, nm, arguments);
                 case SizeFunction ff:
-                    return ConvertToIlExpression(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, nm, arguments);
                 case TangentFunction ff:
-                    return ConvertToIlExpression(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, nm, arguments);
                 case UnitStepFunction usf:
-                    return ConvertToIlExpression(usf, varmap, arguments);
+                    return ConvertToIlExpression(usf, nm, arguments);
                 default:
                     throw new ArgumentException(
                         $"Unsupported function type: \"{func}\"",
@@ -290,17 +290,17 @@ namespace MetaphysicsIndustries.Solus.Compiler
         }
 
         public IlExpression ConvertToIlExpression(
-            AbsoluteValueFunction func, VariableToArgumentNumberMapper varmap,
+            AbsoluteValueFunction func, NascentMethod nm,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
             return new CallIlExpression(
                 new Func<double, double>(Math.Abs),
-                ConvertToIlExpression(arguments[0], varmap));
+                ConvertToIlExpression(arguments[0], nm));
         }
 
         public IlExpression ConvertToIlExpression(
-            AdditionOperation func, VariableToArgumentNumberMapper varmap,
+            AdditionOperation func, NascentMethod nm,
             List<Expression> arguments)
         {
             IlExpression expr = new RawInstructions();
@@ -315,17 +315,15 @@ namespace MetaphysicsIndustries.Solus.Compiler
                     f == NegationOperation.Value)
                 {
                     expr = new SubIlExpression(expr,
-                            ConvertToIlExpression(
-                                call.Arguments[0], varmap));
+                        ConvertToIlExpression(call.Arguments[0], nm));
                 }
                 else
                 {
                     if (first)
-                        expr = ConvertToIlExpression(arg, varmap);
+                        expr = ConvertToIlExpression(arg, nm);
                     else
                         expr = new AddIlExpression(expr,
-                                ConvertToIlExpression(
-                                    arg, varmap));
+                            ConvertToIlExpression(arg, nm));
                     first = false;
                 }
             }
@@ -334,7 +332,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
         }
 
         public IlExpression ConvertToIlExpression(
-            ArccosecantFunction func, VariableToArgumentNumberMapper varmap,
+            ArccosecantFunction func, NascentMethod nm,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
@@ -343,39 +341,38 @@ namespace MetaphysicsIndustries.Solus.Compiler
                     "Asin", new [] { typeof(float) }),
                 new DivIlExpression(
                     new LoadConstantIlExpression(1f),
-                        ConvertToIlExpression(arguments[0],
-                            varmap)));
+                    ConvertToIlExpression(arguments[0], nm)));
             expr.GetInstructions(instructions);
             return expr;
         }
 
         public IlExpression ConvertToIlExpression(
-            ArccosineFunction func, VariableToArgumentNumberMapper varmap,
+            ArccosineFunction func, NascentMethod nm,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Acos),
-                    ConvertToIlExpression(arguments[0], varmap));
+                ConvertToIlExpression(arguments[0], nm));
             expr.GetInstructions(instructions);
             return expr;
         }
 
         public IlExpression ConvertToIlExpression(
-            ArccotangentFunction func, VariableToArgumentNumberMapper varmap,
+            ArccotangentFunction func, NascentMethod nm,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
             var expr = new CallIlExpression(
                 new Func<double, double, double>(Math.Atan2),
                 new LoadConstantIlExpression(1f),
-                    ConvertToIlExpression(arguments[0], varmap));
+                ConvertToIlExpression(arguments[0], nm));
             expr.GetInstructions(instructions);
             return expr;
         }
 
         public IlExpression ConvertToIlExpression(
-            ArcsecantFunction func, VariableToArgumentNumberMapper varmap,
+            ArcsecantFunction func, NascentMethod nm,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
@@ -383,97 +380,92 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 new Func<double, double>(Math.Acos),
                 new DivIlExpression(
                     new LoadConstantIlExpression(1f),
-                        ConvertToIlExpression(
-                            arguments[0], varmap)));
+                    ConvertToIlExpression(arguments[0], nm)));
             expr.GetInstructions(instructions);
             return expr;
         }
 
         public IlExpression ConvertToIlExpression(
-            ArcsineFunction func, VariableToArgumentNumberMapper varmap,
+            ArcsineFunction func, NascentMethod nm,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Asin),
-                    ConvertToIlExpression(arguments[0], varmap));
+                ConvertToIlExpression(arguments[0], nm));
             expr.GetInstructions(instructions);
             return expr;
         }
 
         public IlExpression ConvertToIlExpression(
-            Arctangent2Function func, VariableToArgumentNumberMapper varmap,
+            Arctangent2Function func, NascentMethod nm,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
             var expr = new CallIlExpression(
                 new Func<double, double, double>(Math.Atan2),
-                    ConvertToIlExpression(arguments[0], varmap),
-                    ConvertToIlExpression(arguments[1], varmap));
+                ConvertToIlExpression(arguments[0], nm),
+                ConvertToIlExpression(arguments[1], nm));
             expr.GetInstructions(instructions);
             return expr;
         }
 
         public IlExpression ConvertToIlExpression(
-            ArctangentFunction func, VariableToArgumentNumberMapper varmap,
+            ArctangentFunction func, NascentMethod nm,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Atan),
-                    ConvertToIlExpression(arguments[0], varmap));
+                ConvertToIlExpression(arguments[0], nm));
             expr.GetInstructions(instructions);
             return expr;
         }
 
         public IlExpression ConvertToIlExpression(
-            BitwiseAndOperation func, VariableToArgumentNumberMapper varmap,
+            BitwiseAndOperation func, NascentMethod nm,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
             var expr = new ConvertR4IlExpression(
                 new AndIlExpression(
                     new ConvertI4IlExpression(
-                            ConvertToIlExpression(
-                                arguments[0], varmap)),
+                        ConvertToIlExpression(arguments[0], nm)),
                     new ConvertI4IlExpression(
-                            ConvertToIlExpression(
-                                arguments[1], varmap))));
+                        ConvertToIlExpression(arguments[1], nm))));
             expr.GetInstructions(instructions);
             return expr;
         }
 
         public IlExpression ConvertToIlExpression(
-            BitwiseOrOperation func, VariableToArgumentNumberMapper varmap,
+            BitwiseOrOperation func, NascentMethod nm,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
             var expr = new ConvertR4IlExpression(
                 new OrIlExpression(
                     new ConvertI4IlExpression(
-                            ConvertToIlExpression(
-                                arguments[0], varmap)),
+                        ConvertToIlExpression(arguments[0], nm)),
                     new ConvertI4IlExpression(
-                            ConvertToIlExpression(
-                                arguments[1], varmap))));
+                        ConvertToIlExpression(arguments[1], nm))));
             expr.GetInstructions(instructions);
             return expr;
         }
 
         public IlExpression ConvertToIlExpression(
-            CeilingFunction func, VariableToArgumentNumberMapper varmap,
+            CeilingFunction func, NascentMethod nm,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Ceiling),
-                    ConvertToIlExpression(arguments[0], varmap));
+                ConvertToIlExpression(arguments[0], nm));
             expr.GetInstructions(instructions);
             return expr;
         }
 
         public IlExpression ConvertToIlExpression(
-            CosecantFunction func, VariableToArgumentNumberMapper varmap,
+            CosecantFunction func, NascentMethod nm,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
@@ -481,26 +473,25 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 new LoadConstantIlExpression(1f),
                 new CallIlExpression(
                     new Func<double, double>(Math.Sin),
-                        ConvertToIlExpression(
-                            arguments[0], varmap)));
+                    ConvertToIlExpression(arguments[0], nm)));
             expr.GetInstructions(instructions);
             return expr;
         }
 
         public IlExpression ConvertToIlExpression(
-            CosineFunction func, VariableToArgumentNumberMapper varmap,
+            CosineFunction func, NascentMethod nm,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Cos),
-                    ConvertToIlExpression(arguments[0], varmap));
+                ConvertToIlExpression(arguments[0], nm));
             expr.GetInstructions(instructions);
             return expr;
         }
 
         public IlExpression ConvertToIlExpression(
-            CotangentFunction func, VariableToArgumentNumberMapper varmap,
+            CotangentFunction func, NascentMethod nm,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
@@ -508,18 +499,17 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 new LoadConstantIlExpression(1f),
                 new CallIlExpression(
                     new Func<double, double>(Math.Tan),
-                        ConvertToIlExpression(
-                            arguments[0], varmap)));
+                    ConvertToIlExpression(arguments[0], nm)));
             expr.GetInstructions(instructions);
             return expr;
         }
 
         public IlExpression ConvertToIlExpression(
-            DistFunction func, VariableToArgumentNumberMapper varmap,
+            DistFunction func, NascentMethod nm,
             List<Expression> arguments)
         {
-            var x = ConvertToIlExpression(arguments[0], varmap);
-            var y = ConvertToIlExpression(arguments[1], varmap);
+            var x = ConvertToIlExpression(arguments[0], nm);
+            var y = ConvertToIlExpression(arguments[1], nm);
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Sqrt),
                 new AddIlExpression(
@@ -533,11 +523,11 @@ namespace MetaphysicsIndustries.Solus.Compiler
         }
 
         public IlExpression ConvertToIlExpression(
-            DistSqFunction func, VariableToArgumentNumberMapper varmap,
+            DistSqFunction func, NascentMethod nm,
             List<Expression> arguments)
         {
-            var x = ConvertToIlExpression(arguments[0], varmap);
-            var y = ConvertToIlExpression(arguments[1], varmap);
+            var x = ConvertToIlExpression(arguments[0], nm);
+            var y = ConvertToIlExpression(arguments[1], nm);
             var expr = new AddIlExpression(
                 new MulIlExpression(
                     x,
@@ -549,81 +539,77 @@ namespace MetaphysicsIndustries.Solus.Compiler
         }
 
         public IlExpression ConvertToIlExpression(
-            DivisionOperation func, VariableToArgumentNumberMapper varmap,
+            DivisionOperation func, NascentMethod nm,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
             var expr = new DivIlExpression(
-                    ConvertToIlExpression(arguments[0], varmap),
-                    ConvertToIlExpression(arguments[1], varmap));
+                ConvertToIlExpression(arguments[0], nm),
+                ConvertToIlExpression(arguments[1], nm));
             expr.GetInstructions(instructions);
             return expr;
         }
 
         public IlExpression ConvertToIlExpression(
             EqualComparisonOperation func,
-            VariableToArgumentNumberMapper varmap,
+            NascentMethod nm,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
             var expr = new ConvertR4IlExpression(
                 new CompareEqualIlExpression(
-                        ConvertToIlExpression(arguments[0],
-                            varmap),
-                        ConvertToIlExpression(arguments[1],
-                            varmap)));
+                    ConvertToIlExpression(arguments[0], nm),
+                    ConvertToIlExpression(arguments[1], nm)));
             expr.GetInstructions(instructions);
             return expr;
         }
 
         public IlExpression ConvertToIlExpression(
-            ExponentOperation func, VariableToArgumentNumberMapper varmap,
+            ExponentOperation func, NascentMethod nm,
             List<Expression> arguments)
         {
             return new CallIlExpression(
                 new Func<double, double, double>(Math.Pow),
-                ConvertToIlExpression(arguments[0], varmap),
-                ConvertToIlExpression(arguments[1], varmap));
+                ConvertToIlExpression(arguments[0], nm),
+                ConvertToIlExpression(arguments[1], nm));
         }
 
         public IlExpression ConvertToIlExpression(
-            FactorialFunction func, VariableToArgumentNumberMapper varmap,
+            FactorialFunction func, NascentMethod nm,
             List<Expression> arguments)
         {
             throw new NotImplementedException();
         }
 
         public IlExpression ConvertToIlExpression(
-            FloorFunction func, VariableToArgumentNumberMapper varmap,
+            FloorFunction func, NascentMethod nm,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Floor),
-                    ConvertToIlExpression(arguments[0], varmap));
+                ConvertToIlExpression(arguments[0], nm));
             expr.GetInstructions(instructions);
             return expr;
         }
 
         public IlExpression ConvertToIlExpression(
             GreaterThanComparisonOperation func,
-            VariableToArgumentNumberMapper varmap,
+            NascentMethod nm,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
             var expr = new ConvertR4IlExpression(
                 new CompareGreaterThanIlExpression(
-                        ConvertToIlExpression(arguments[0],
-                            varmap),
-                        ConvertToIlExpression(arguments[1],
-                            varmap)));
+                    ConvertToIlExpression(arguments[0], nm),
+                    ConvertToIlExpression(arguments[1], nm)));
             expr.GetInstructions(instructions);
             return expr;
         }
 
         public IlExpression ConvertToIlExpression(
             GreaterThanOrEqualComparisonOperation func,
-            VariableToArgumentNumberMapper varmap,
+            NascentMethod nm,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
@@ -631,33 +617,29 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 new CompareEqualIlExpression(
                     new LoadConstantIlExpression(0),
                     new CompareLessThanIlExpression(
-                            ConvertToIlExpression(arguments[0],
-                                varmap),
-                            ConvertToIlExpression(arguments[1],
-                                varmap))));
+                        ConvertToIlExpression(arguments[0], nm),
+                        ConvertToIlExpression(arguments[1], nm))));
             expr.GetInstructions(instructions);
             return expr;
         }
 
         public IlExpression ConvertToIlExpression(
             LessThanComparisonOperation func,
-            VariableToArgumentNumberMapper varmap,
+            NascentMethod nm,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
             var expr = new ConvertR4IlExpression(
                 new CompareLessThanIlExpression(
-                        ConvertToIlExpression(arguments[0],
-                            varmap),
-                        ConvertToIlExpression(arguments[1],
-                            varmap)));
+                    ConvertToIlExpression(arguments[0], nm),
+                    ConvertToIlExpression(arguments[1], nm)));
             expr.GetInstructions(instructions);
             return expr;
         }
 
         public IlExpression ConvertToIlExpression(
             LessThanOrEqualComparisonOperation func,
-            VariableToArgumentNumberMapper varmap,
+            NascentMethod nm,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
@@ -665,61 +647,59 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 new CompareEqualIlExpression(
                     new LoadConstantIlExpression(0),
                     new CompareGreaterThanIlExpression(
-                            ConvertToIlExpression(arguments[0],
-                                varmap),
-                            ConvertToIlExpression(arguments[1],
-                                varmap))));
+                        ConvertToIlExpression(arguments[0], nm),
+                        ConvertToIlExpression(arguments[1], nm))));
             expr.GetInstructions(instructions);
             return expr;
         }
 
         public IlExpression ConvertToIlExpression(
-            LoadImageFunction func, VariableToArgumentNumberMapper varmap,
+            LoadImageFunction func, NascentMethod nm,
             List<Expression> arguments)
         {
             throw new NotImplementedException();
         }
 
         public IlExpression ConvertToIlExpression(
-            Log10Function func, VariableToArgumentNumberMapper varmap,
+            Log10Function func, NascentMethod nm,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Log10),
-                    ConvertToIlExpression(arguments[0], varmap));
+                ConvertToIlExpression(arguments[0], nm));
             expr.GetInstructions(instructions);
             return expr;
         }
 
         public IlExpression ConvertToIlExpression(
-            Log2Function func, VariableToArgumentNumberMapper varmap,
+            Log2Function func, NascentMethod nm,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
             var expr = new CallIlExpression(
                 new Func<double, double, double>(Math.Log),
-                    ConvertToIlExpression(arguments[0], varmap),
+                ConvertToIlExpression(arguments[0], nm),
                 new LoadConstantIlExpression(2f));
             expr.GetInstructions(instructions);
             return expr;
         }
 
         public IlExpression ConvertToIlExpression(
-            LogarithmFunction func, VariableToArgumentNumberMapper varmap,
+            LogarithmFunction func, NascentMethod nm,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
             var expr = new CallIlExpression(
                 new Func<double, double, double>(Math.Log),
-                    ConvertToIlExpression(arguments[0], varmap),
-                    ConvertToIlExpression(arguments[1], varmap));
+                ConvertToIlExpression(arguments[0], nm),
+                ConvertToIlExpression(arguments[1], nm));
             expr.GetInstructions(instructions);
             return expr;
         }
 
         public IlExpression ConvertToIlExpression(
-            LogicalAndOperation func, VariableToArgumentNumberMapper varmap,
+            LogicalAndOperation func, NascentMethod nm,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
@@ -730,19 +710,17 @@ namespace MetaphysicsIndustries.Solus.Compiler
                         new CompareEqualIlExpression(
                             new LoadConstantIlExpression(0),
                             new ConvertI4IlExpression(
-                                    ConvertToIlExpression(arguments[0],
-                                        varmap))),
+                                ConvertToIlExpression(arguments[0], nm))),
                         new CompareEqualIlExpression(
                             new LoadConstantIlExpression(0),
                             new ConvertI4IlExpression(
-                                    ConvertToIlExpression(arguments[1],
-                                        varmap))))));
+                                ConvertToIlExpression(arguments[1], nm))))));
             expr.GetInstructions(instructions);
             return expr;
         }
 
         public IlExpression ConvertToIlExpression(
-            LogicalOrOperation func, VariableToArgumentNumberMapper varmap,
+            LogicalOrOperation func, NascentMethod nm,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
@@ -752,126 +730,121 @@ namespace MetaphysicsIndustries.Solus.Compiler
                         new CompareEqualIlExpression(
                             new LoadConstantIlExpression(0),
                             new ConvertI4IlExpression(
-                                    ConvertToIlExpression(arguments[0],
-                                        varmap))),
+                                ConvertToIlExpression(arguments[0], nm))),
                         new CompareEqualIlExpression(
                             new LoadConstantIlExpression(0),
                             new ConvertI4IlExpression(
-                                    ConvertToIlExpression(arguments[1],
-                                        varmap)))),
+                                ConvertToIlExpression(arguments[1], nm)))),
                     new LoadConstantIlExpression(2)));
             expr.GetInstructions(instructions);
             return expr;
         }
 
         public IlExpression ConvertToIlExpression(
-            MaximumFiniteFunction func, VariableToArgumentNumberMapper varmap,
+            MaximumFiniteFunction func, NascentMethod nm,
             List<Expression> arguments)
         {
             throw new NotImplementedException();
         }
 
         public IlExpression ConvertToIlExpression(
-            MaximumFunction func, VariableToArgumentNumberMapper varmap,
+            MaximumFunction func, NascentMethod nm,
             List<Expression> arguments)
         {
-            var expr = ConvertToIlExpression(arguments[0], varmap);
+            var expr = ConvertToIlExpression(arguments[0], nm);
             int i;
             for (i = 1; i < arguments.Count; i++)
             {
                 expr = new CallIlExpression(
                     new Func<float, float, float>(Math.Max),
                     expr,
-                    ConvertToIlExpression(arguments[i], varmap));
+                    ConvertToIlExpression(arguments[i], nm));
             }
 
             return expr;
         }
 
         public IlExpression ConvertToIlExpression(
-            MinimumFiniteFunction func, VariableToArgumentNumberMapper varmap,
+            MinimumFiniteFunction func, NascentMethod nm,
             List<Expression> arguments)
         {
             throw new NotImplementedException();
         }
 
         public IlExpression ConvertToIlExpression(
-            MinimumFunction func, VariableToArgumentNumberMapper varmap,
+            MinimumFunction func, NascentMethod nm,
             List<Expression> arguments)
         {
-            var expr = ConvertToIlExpression(arguments[0], varmap);
+            var expr = ConvertToIlExpression(arguments[0], nm);
             int i;
             for (i = 1; i < arguments.Count; i++)
             {
                 expr = new CallIlExpression(
                     new Func<float, float, float>(Math.Min),
                     expr,
-                    ConvertToIlExpression(arguments[i], varmap));
+                    ConvertToIlExpression(arguments[i], nm));
             }
 
             return expr;
         }
 
         public IlExpression ConvertToIlExpression(
-            ModularDivision func, VariableToArgumentNumberMapper varmap,
+            ModularDivision func, NascentMethod nm,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
             var expr = new ConvertR4IlExpression(
                 new RemIlExpression(
                     new ConvertI4IlExpression(
-                            ConvertToIlExpression(arguments[0],
-                                varmap)),
+                        ConvertToIlExpression(arguments[0], nm)),
                     new ConvertI4IlExpression(
-                            ConvertToIlExpression(arguments[1],
-                                varmap))));
+                        ConvertToIlExpression(arguments[1], nm))));
             expr.GetInstructions(instructions);
             return expr;
         }
 
         public IlExpression ConvertToIlExpression(
             MultiplicationOperation func,
-            VariableToArgumentNumberMapper varmap, List<Expression> arguments)
+            NascentMethod nm, List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
-            var expr = ConvertToIlExpression(arguments[0], varmap);
+            var expr = ConvertToIlExpression(arguments[0], nm);
             int i;
             for (i = 1; i < arguments.Count; i++)
                 expr = new MulIlExpression(
                     expr,
-                        ConvertToIlExpression(arguments[i],
-                            varmap));
+                    ConvertToIlExpression(arguments[i], nm));
             expr.GetInstructions(instructions);
             return expr;
         }
 
         public IlExpression ConvertToIlExpression(
             NaturalLogarithmFunction func,
-            VariableToArgumentNumberMapper varmap,
+            NascentMethod nm,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Log),
-                    ConvertToIlExpression(arguments[0], varmap));
+                ConvertToIlExpression(arguments[0], nm));
             expr.GetInstructions(instructions);
             return expr;
         }
 
         public IlExpression ConvertToIlExpression(
-            NegationOperation func, VariableToArgumentNumberMapper varmap,
+            NegationOperation func, NascentMethod nm,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
             var expr = new NegIlExpression(
-                    ConvertToIlExpression(arguments[0], varmap));
+                ConvertToIlExpression(arguments[0], nm));
             expr.GetInstructions(instructions);
             return expr;
         }
 
         public IlExpression ConvertToIlExpression(
             NotEqualComparisonOperation func,
-            VariableToArgumentNumberMapper varmap,
+            NascentMethod nm,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
@@ -879,16 +852,14 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 new CompareEqualIlExpression(
                     new LoadConstantIlExpression(0),
                     new CompareEqualIlExpression(
-                            ConvertToIlExpression(
-                                arguments[0], varmap),
-                            ConvertToIlExpression(
-                                arguments[1], varmap))));
+                        ConvertToIlExpression(arguments[0], nm),
+                        ConvertToIlExpression(arguments[1], nm))));
             expr.GetInstructions(instructions);
             return expr;
         }
 
         public IlExpression ConvertToIlExpression(
-            SecantFunction func, VariableToArgumentNumberMapper varmap,
+            SecantFunction func, NascentMethod nm,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
@@ -896,57 +867,53 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 new LoadConstantIlExpression(1f),
                 new CallIlExpression(
                     new Func<double, double>(Math.Cos),
-                        ConvertToIlExpression(
-                            arguments[0], varmap)));
+                    ConvertToIlExpression(arguments[0], nm)));
             expr.GetInstructions(instructions);
             return expr;
         }
 
         public IlExpression ConvertToIlExpression(
-            SineFunction func, VariableToArgumentNumberMapper varmap,
+            SineFunction func, NascentMethod nm,
             List<Expression> arguments)
         {
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Sin),
-                ConvertToIlExpression(
-                    arguments[0], varmap));
+                ConvertToIlExpression(arguments[0], nm));
             return expr;
         }
 
         public IlExpression ConvertToIlExpression(
-            SizeFunction func, VariableToArgumentNumberMapper varmap,
+            SizeFunction func, NascentMethod nm,
             List<Expression> arguments)
         {
             throw new NotImplementedException();
         }
 
         public IlExpression ConvertToIlExpression(
-            TangentFunction func, VariableToArgumentNumberMapper varmap,
+            TangentFunction func, NascentMethod nm,
             List<Expression> arguments)
         {
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Tan),
-                ConvertToIlExpression(
-                    arguments[0], varmap));
+                ConvertToIlExpression(arguments[0], nm));
             return expr;
         }
 
         public IlExpression ConvertToIlExpression(
-            UnitStepFunction func, VariableToArgumentNumberMapper varmap,
+            UnitStepFunction func, NascentMethod nm,
             List<Expression> arguments)
         {
             var expr = new ConvertR4IlExpression(
                 new CompareLessThanIlExpression(
                     new CompareLessThanIlExpression(
-                        ConvertToIlExpression(
-                            arguments[0], varmap),
+                        ConvertToIlExpression(arguments[0], nm),
                         new LoadConstantIlExpression(0f)),
                     new LoadConstantIlExpression(1)));
             return expr;
         }
 
         public IlExpression ConvertToIlExpression(
-            UserDefinedFunction func, VariableToArgumentNumberMapper varmap,
+            UserDefinedFunction func, NascentMethod nm,
             List<Expression> arguments)
         {
             throw new NotImplementedException();

--- a/Compiler/ILCompiler.cs
+++ b/Compiler/ILCompiler.cs
@@ -180,8 +180,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
         public IlExpression ConvertToIlExpression(
             VariableAccess expr, VariableToArgumentNumberMapper varmap)
         {
-            return new RawInstructions(
-                Instruction.LoadLocalVariable(varmap[expr.VariableName]));
+            return new LoadLocalIlExpression(varmap[expr.VariableName]);
         }
 
         // compile functions

--- a/Compiler/ILCompiler.cs
+++ b/Compiler/ILCompiler.cs
@@ -519,23 +519,17 @@ namespace MetaphysicsIndustries.Solus.Compiler
             DistFunction func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
-            var instructions = new List<Instruction>();
+            var x = ConvertToIlExpression(arguments[0], varmap);
+            var y = ConvertToIlExpression(arguments[1], varmap);
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Sqrt),
                 new AddIlExpression(
-                    new IlExpressionSequence(
-                        ConvertToIlExpression(arguments[0],
-                            varmap),
-                        new RawInstructions(
-                            Instruction.Dup(),
-                            Instruction.Mul())),
-                    new IlExpressionSequence(
-                        ConvertToIlExpression(arguments[1],
-                            varmap),
-                        new RawInstructions(
-                            Instruction.Dup(),
-                            Instruction.Mul()))));
-            expr.GetInstructions(instructions);
+                    new MulIlExpression(
+                        x,
+                        new DupIlExpression(x)),
+                    new MulIlExpression(
+                        y,
+                        new DupIlExpression(y))));
             return expr;
         }
 
@@ -543,20 +537,15 @@ namespace MetaphysicsIndustries.Solus.Compiler
             DistSqFunction func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
-            var instructions = new List<Instruction>();
+            var x = ConvertToIlExpression(arguments[0], varmap);
+            var y = ConvertToIlExpression(arguments[1], varmap);
             var expr = new AddIlExpression(
-                new IlExpressionSequence(
-                    ConvertToIlExpression(arguments[0],
-                        varmap),
-                    new RawInstructions(
-                        Instruction.Dup(),
-                        Instruction.Mul())),
-                new IlExpressionSequence(
-                    ConvertToIlExpression(arguments[1],
-                        varmap),
-                    new RawInstructions(
-                        Instruction.Dup(),
-                        Instruction.Mul())));
+                new MulIlExpression(
+                    x,
+                    new DupIlExpression(x)),
+                new MulIlExpression(
+                    y,
+                    new DupIlExpression(y)));
             return expr;
         }
 

--- a/Compiler/ILCompiler.cs
+++ b/Compiler/ILCompiler.cs
@@ -775,7 +775,17 @@ namespace MetaphysicsIndustries.Solus.Compiler
             MaximumFunction func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
-            throw new NotImplementedException();
+            var expr = ConvertToIlExpression(arguments[0], varmap);
+            int i;
+            for (i = 1; i < arguments.Count; i++)
+            {
+                expr = new CallIlExpression(
+                    new Func<float, float, float>(Math.Max),
+                    expr,
+                    ConvertToIlExpression(arguments[i], varmap));
+            }
+
+            return expr;
         }
 
         public IlExpression ConvertToIlExpression(
@@ -789,7 +799,17 @@ namespace MetaphysicsIndustries.Solus.Compiler
             MinimumFunction func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
-            throw new NotImplementedException();
+            var expr = ConvertToIlExpression(arguments[0], varmap);
+            int i;
+            for (i = 1; i < arguments.Count; i++)
+            {
+                expr = new CallIlExpression(
+                    new Func<float, float, float>(Math.Min),
+                    expr,
+                    ConvertToIlExpression(arguments[i], varmap));
+            }
+
+            return expr;
         }
 
         public IlExpression ConvertToIlExpression(

--- a/Compiler/ILCompiler.cs
+++ b/Compiler/ILCompiler.cs
@@ -22,7 +22,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection.Emit;
 using MetaphysicsIndustries.Solus.Compiler.IlExpressions;
 using MetaphysicsIndustries.Solus.Evaluators;
@@ -36,8 +35,10 @@ namespace MetaphysicsIndustries.Solus.Compiler
         public CompiledExpression Compile(Expression expr)
         {
             var varmap = new VariableToArgumentNumberMapper();
-            var instructions = ConvertToInstructions(expr, varmap);
+            var ilexpr = ConvertToIlExpression(expr, varmap);
             var args = varmap.GetVariableNamesInIndexOrder();
+            var instructions = new List<Instruction>();
+            ilexpr.GetInstructions(instructions);
 
             DynamicMethod method =
                 new DynamicMethod(
@@ -141,151 +142,147 @@ namespace MetaphysicsIndustries.Solus.Compiler
 
         // compile expressions
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             Expression expr, VariableToArgumentNumberMapper varmap)
         {
             if (expr is FunctionCall call)
-                return ConvertToInstructions(call, varmap);
+                return ConvertToIlExpression(call, varmap);
             if (expr is Literal lit)
-                return ConvertToInstructions(lit, varmap);
+                return ConvertToIlExpression(lit, varmap);
             if (expr is VariableAccess va)
-                return ConvertToInstructions(va, varmap);
+                return ConvertToIlExpression(va, varmap);
             throw new ArgumentException(
                 $"Unsupported expresssion type: \"{expr}\"", nameof(expr));
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
              FunctionCall expr, VariableToArgumentNumberMapper varmap)
         {
             if (expr.Function is Literal literal &&
                 literal.Value is Function f)
-                return ConvertToInstructions(f, varmap, expr.Arguments);
+                return ConvertToIlExpression(f, varmap, expr.Arguments);
+
             // TODO:
             throw new NotImplementedException(
                 "What should be done? Should the expression be " +
                 "evaluated? Compiled?");
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             Literal expr, VariableToArgumentNumberMapper varmap)
         {
             if (expr.Value.IsIsScalar(null))
-                return new []
-                {
-                    Instruction.LoadConstant(expr.Value.ToFloat())
-                };
+                return new LoadConstantIlExpression(expr.Value.ToFloat());
             throw new NotImplementedException(
                 "currently only implemented for numbers.");
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             VariableAccess expr, VariableToArgumentNumberMapper varmap)
         {
-            return new []
-            {
-                Instruction.LoadLocalVariable(varmap[expr.VariableName])
-            };
+            return new RawInstructions(
+                Instruction.LoadLocalVariable(varmap[expr.VariableName]));
         }
 
         // compile functions
 
-        public IEnumerable<Instruction> ConvertToInstructions(Function func,
+        public IlExpression ConvertToIlExpression(Function func,
             VariableToArgumentNumberMapper varmap, List<Expression> arguments)
         {
             switch (func)
             {
                 case AbsoluteValueFunction ff:
-                    return ConvertToInstructions(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, varmap, arguments);
                 case AdditionOperation ao:
-                    return ConvertToInstructions(ao, varmap, arguments);
+                    return ConvertToIlExpression(ao, varmap, arguments);
                 case ArccosecantFunction ff:
-                    return ConvertToInstructions(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, varmap, arguments);
                 case ArccosineFunction ff:
-                    return ConvertToInstructions(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, varmap, arguments);
                 case ArccotangentFunction ff:
-                    return ConvertToInstructions(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, varmap, arguments);
                 case ArcsecantFunction ff:
-                    return ConvertToInstructions(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, varmap, arguments);
                 case ArcsineFunction ff:
-                    return ConvertToInstructions(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, varmap, arguments);
                 case Arctangent2Function ff:
-                    return ConvertToInstructions(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, varmap, arguments);
                 case ArctangentFunction ff:
-                    return ConvertToInstructions(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, varmap, arguments);
                 case BitwiseAndOperation ff:
-                    return ConvertToInstructions(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, varmap, arguments);
                 case BitwiseOrOperation ff:
-                    return ConvertToInstructions(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, varmap, arguments);
                 case CeilingFunction ff:
-                    return ConvertToInstructions(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, varmap, arguments);
                 case CosecantFunction ff:
-                    return ConvertToInstructions(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, varmap, arguments);
                 case CosineFunction c:
-                    return ConvertToInstructions(c, varmap, arguments);
+                    return ConvertToIlExpression(c, varmap, arguments);
                 case CotangentFunction ff:
-                    return ConvertToInstructions(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, varmap, arguments);
                 case DistFunction ff:
-                    return ConvertToInstructions(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, varmap, arguments);
                 case DistSqFunction ff:
-                    return ConvertToInstructions(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, varmap, arguments);
                 case DivisionOperation ff:
-                    return ConvertToInstructions(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, varmap, arguments);
                 case EqualComparisonOperation ff:
-                    return ConvertToInstructions(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, varmap, arguments);
                 case ExponentOperation eo:
-                    return ConvertToInstructions(eo, varmap, arguments);
+                    return ConvertToIlExpression(eo, varmap, arguments);
                 case FactorialFunction ff:
-                    return ConvertToInstructions(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, varmap, arguments);
                 case FloorFunction ff:
-                    return ConvertToInstructions(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, varmap, arguments);
                 case GreaterThanComparisonOperation ff:
-                    return ConvertToInstructions(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, varmap, arguments);
                 case GreaterThanOrEqualComparisonOperation ff:
-                    return ConvertToInstructions(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, varmap, arguments);
                 case LessThanComparisonOperation ff:
-                    return ConvertToInstructions(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, varmap, arguments);
                 case LessThanOrEqualComparisonOperation ff:
-                    return ConvertToInstructions(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, varmap, arguments);
                 case LoadImageFunction ff:
-                    return ConvertToInstructions(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, varmap, arguments);
                 case Log10Function ff:
-                    return ConvertToInstructions(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, varmap, arguments);
                 case Log2Function ff:
-                    return ConvertToInstructions(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, varmap, arguments);
                 case LogarithmFunction ff:
-                    return ConvertToInstructions(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, varmap, arguments);
                 case LogicalAndOperation ff:
-                    return ConvertToInstructions(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, varmap, arguments);
                 case LogicalOrOperation ff:
-                    return ConvertToInstructions(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, varmap, arguments);
                 case MaximumFiniteFunction ff:
-                    return ConvertToInstructions(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, varmap, arguments);
                 case MaximumFunction ff:
-                    return ConvertToInstructions(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, varmap, arguments);
                 case MinimumFiniteFunction ff:
-                    return ConvertToInstructions(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, varmap, arguments);
                 case MinimumFunction ff:
-                    return ConvertToInstructions(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, varmap, arguments);
                 case ModularDivision ff:
-                    return ConvertToInstructions(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, varmap, arguments);
                 case MultiplicationOperation mo:
-                    return ConvertToInstructions(mo, varmap, arguments);
+                    return ConvertToIlExpression(mo, varmap, arguments);
                 case NaturalLogarithmFunction ff:
-                    return ConvertToInstructions(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, varmap, arguments);
                 case NegationOperation no:
-                    return ConvertToInstructions(no, varmap, arguments);
+                    return ConvertToIlExpression(no, varmap, arguments);
                 case NotEqualComparisonOperation ff:
-                    return ConvertToInstructions(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, varmap, arguments);
                 case SecantFunction ff:
-                    return ConvertToInstructions(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, varmap, arguments);
                 case SineFunction s:
-                    return ConvertToInstructions(s, varmap, arguments);
+                    return ConvertToIlExpression(s, varmap, arguments);
                 case SizeFunction ff:
-                    return ConvertToInstructions(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, varmap, arguments);
                 case TangentFunction ff:
-                    return ConvertToInstructions(ff, varmap, arguments);
+                    return ConvertToIlExpression(ff, varmap, arguments);
                 case UnitStepFunction usf:
-                    return ConvertToInstructions(usf, varmap, arguments);
+                    return ConvertToIlExpression(usf, varmap, arguments);
                 default:
                     throw new ArgumentException(
                         $"Unsupported function type: \"{func}\"",
@@ -293,24 +290,20 @@ namespace MetaphysicsIndustries.Solus.Compiler
             }
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             AbsoluteValueFunction func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
-            var expr = new CallIlExpression(
+            return new CallIlExpression(
                 new Func<double, double>(Math.Abs),
-                new RawInstructions(
-                    ConvertToInstructions(arguments[0], varmap).ToArray()));
-            expr.GetInstructions(instructions);
-            return instructions;
+                ConvertToIlExpression(arguments[0], varmap));
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             AdditionOperation func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
-            var instructions = new List<Instruction>();
             IlExpression expr = new RawInstructions();
 
             bool first = true;
@@ -323,29 +316,25 @@ namespace MetaphysicsIndustries.Solus.Compiler
                     f == NegationOperation.Value)
                 {
                     expr = new SubIlExpression(expr,
-                        new RawInstructions(
-                            ConvertToInstructions(
-                                call.Arguments[0], varmap).ToArray()));
+                            ConvertToIlExpression(
+                                call.Arguments[0], varmap));
                 }
                 else
                 {
                     if (first)
-                        expr = new RawInstructions(
-                            ConvertToInstructions(arg, varmap).ToArray());
+                        expr = ConvertToIlExpression(arg, varmap);
                     else
                         expr = new AddIlExpression(expr,
-                            new RawInstructions(
-                                ConvertToInstructions(
-                                    arg, varmap).ToArray()));
+                                ConvertToIlExpression(
+                                    arg, varmap));
                     first = false;
                 }
             }
 
-            expr.GetInstructions(instructions);
-            return instructions;
+            return expr;
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             ArccosecantFunction func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
@@ -355,27 +344,25 @@ namespace MetaphysicsIndustries.Solus.Compiler
                     "Asin", new [] { typeof(float) }),
                 new DivIlExpression(
                     new LoadConstantIlExpression(1f),
-                    new RawInstructions(
-                        ConvertToInstructions(arguments[0],
-                            varmap).ToArray())));
+                        ConvertToIlExpression(arguments[0],
+                            varmap)));
             expr.GetInstructions(instructions);
-            return instructions;
+            return expr;
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             ArccosineFunction func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Acos),
-                new RawInstructions(
-                    ConvertToInstructions(arguments[0], varmap).ToArray()));
+                    ConvertToIlExpression(arguments[0], varmap));
             expr.GetInstructions(instructions);
-            return instructions;
+            return expr;
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             ArccotangentFunction func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
@@ -383,13 +370,12 @@ namespace MetaphysicsIndustries.Solus.Compiler
             var expr = new CallIlExpression(
                 new Func<double, double, double>(Math.Atan2),
                 new LoadConstantIlExpression(1f),
-                new RawInstructions(
-                    ConvertToInstructions(arguments[0], varmap).ToArray()));
+                    ConvertToIlExpression(arguments[0], varmap));
             expr.GetInstructions(instructions);
-            return instructions;
+            return expr;
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             ArcsecantFunction func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
@@ -398,55 +384,50 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 new Func<double, double>(Math.Acos),
                 new DivIlExpression(
                     new LoadConstantIlExpression(1f),
-                    new RawInstructions(
-                        ConvertToInstructions(
-                            arguments[0], varmap).ToArray())));
+                        ConvertToIlExpression(
+                            arguments[0], varmap)));
             expr.GetInstructions(instructions);
-            return instructions;
+            return expr;
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             ArcsineFunction func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Asin),
-                new RawInstructions(
-                    ConvertToInstructions(arguments[0], varmap).ToArray()));
+                    ConvertToIlExpression(arguments[0], varmap));
             expr.GetInstructions(instructions);
-            return instructions;
+            return expr;
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             Arctangent2Function func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
             var expr = new CallIlExpression(
                 new Func<double, double, double>(Math.Atan2),
-                new RawInstructions(
-                    ConvertToInstructions(arguments[0], varmap).ToArray()),
-                new RawInstructions(
-                    ConvertToInstructions(arguments[1], varmap).ToArray()));
+                    ConvertToIlExpression(arguments[0], varmap),
+                    ConvertToIlExpression(arguments[1], varmap));
             expr.GetInstructions(instructions);
-            return instructions;
+            return expr;
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             ArctangentFunction func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Atan),
-                new RawInstructions(
-                    ConvertToInstructions(arguments[0], varmap).ToArray()));
+                    ConvertToIlExpression(arguments[0], varmap));
             expr.GetInstructions(instructions);
-            return instructions;
+            return expr;
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             BitwiseAndOperation func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
@@ -454,18 +435,16 @@ namespace MetaphysicsIndustries.Solus.Compiler
             var expr = new ConvertR4IlExpression(
                 new AndIlExpression(
                     new ConvertI4IlExpression(
-                        new RawInstructions(
-                            ConvertToInstructions(
-                                arguments[0], varmap).ToArray())),
+                            ConvertToIlExpression(
+                                arguments[0], varmap)),
                     new ConvertI4IlExpression(
-                        new RawInstructions(
-                            ConvertToInstructions(
-                                arguments[1], varmap).ToArray()))));
+                            ConvertToIlExpression(
+                                arguments[1], varmap))));
             expr.GetInstructions(instructions);
-            return instructions;
+            return expr;
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             BitwiseOrOperation func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
@@ -473,31 +452,28 @@ namespace MetaphysicsIndustries.Solus.Compiler
             var expr = new ConvertR4IlExpression(
                 new OrIlExpression(
                     new ConvertI4IlExpression(
-                        new RawInstructions(
-                            ConvertToInstructions(
-                                arguments[0], varmap).ToArray())),
+                            ConvertToIlExpression(
+                                arguments[0], varmap)),
                     new ConvertI4IlExpression(
-                        new RawInstructions(
-                            ConvertToInstructions(
-                                arguments[1], varmap).ToArray()))));
+                            ConvertToIlExpression(
+                                arguments[1], varmap))));
             expr.GetInstructions(instructions);
-            return instructions;
+            return expr;
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             CeilingFunction func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Ceiling),
-                new RawInstructions(
-                    ConvertToInstructions(arguments[0], varmap).ToArray()));
+                    ConvertToIlExpression(arguments[0], varmap));
             expr.GetInstructions(instructions);
-            return instructions;
+            return expr;
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             CosecantFunction func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
@@ -506,27 +482,25 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 new LoadConstantIlExpression(1f),
                 new CallIlExpression(
                     new Func<double, double>(Math.Sin),
-                    new RawInstructions(
-                        ConvertToInstructions(
-                            arguments[0], varmap).ToArray())));
+                        ConvertToIlExpression(
+                            arguments[0], varmap)));
             expr.GetInstructions(instructions);
-            return instructions;
+            return expr;
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             CosineFunction func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Cos),
-                new RawInstructions(
-                    ConvertToInstructions(arguments[0], varmap).ToArray()));
+                    ConvertToIlExpression(arguments[0], varmap));
             expr.GetInstructions(instructions);
-            return instructions;
+            return expr;
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             CotangentFunction func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
@@ -535,14 +509,13 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 new LoadConstantIlExpression(1f),
                 new CallIlExpression(
                     new Func<double, double>(Math.Tan),
-                    new RawInstructions(
-                        ConvertToInstructions(
-                            arguments[0], varmap).ToArray())));
+                        ConvertToIlExpression(
+                            arguments[0], varmap)));
             expr.GetInstructions(instructions);
-            return instructions;
+            return expr;
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             DistFunction func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
@@ -551,62 +524,55 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 new Func<double, double>(Math.Sqrt),
                 new AddIlExpression(
                     new IlExpressionSequence(
-                        new RawInstructions(
-                            ConvertToInstructions(arguments[0],
-                                varmap).ToArray()),
+                        ConvertToIlExpression(arguments[0],
+                            varmap),
                         new RawInstructions(
                             Instruction.Dup(),
                             Instruction.Mul())),
                     new IlExpressionSequence(
-                        new RawInstructions(
-                            ConvertToInstructions(arguments[1],
-                                varmap).ToArray()),
+                        ConvertToIlExpression(arguments[1],
+                            varmap),
                         new RawInstructions(
                             Instruction.Dup(),
                             Instruction.Mul()))));
             expr.GetInstructions(instructions);
-            return instructions;
+            return expr;
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             DistSqFunction func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
             var expr = new AddIlExpression(
                 new IlExpressionSequence(
-                    new RawInstructions(
-                        ConvertToInstructions(arguments[0],
-                            varmap).ToArray()),
+                    ConvertToIlExpression(arguments[0],
+                        varmap),
                     new RawInstructions(
                         Instruction.Dup(),
                         Instruction.Mul())),
                 new IlExpressionSequence(
-                    new RawInstructions(
-                        ConvertToInstructions(arguments[1],
-                            varmap).ToArray()),
+                    ConvertToIlExpression(arguments[1],
+                        varmap),
                     new RawInstructions(
                         Instruction.Dup(),
                         Instruction.Mul())));
-            expr.GetInstructions(instructions);
-            return instructions;
+            return expr;
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             DivisionOperation func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
             var expr = new DivIlExpression(
-                new RawInstructions(
-                    ConvertToInstructions(arguments[0], varmap).ToArray()),
-                new RawInstructions(
-                    ConvertToInstructions(arguments[1], varmap).ToArray()));
+                    ConvertToIlExpression(arguments[0], varmap),
+                    ConvertToIlExpression(arguments[1], varmap));
             expr.GetInstructions(instructions);
-            return instructions;
+            return expr;
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             EqualComparisonOperation func,
             VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
@@ -614,88 +580,44 @@ namespace MetaphysicsIndustries.Solus.Compiler
             var instructions = new List<Instruction>();
             var expr = new ConvertR4IlExpression(
                 new CompareEqualIlExpression(
-                    new RawInstructions(
-                        ConvertToInstructions(arguments[0],
-                            varmap).ToArray()),
-                    new RawInstructions(
-                        ConvertToInstructions(arguments[1],
-                            varmap).ToArray())));
+                        ConvertToIlExpression(arguments[0],
+                            varmap),
+                        ConvertToIlExpression(arguments[1],
+                            varmap)));
             expr.GetInstructions(instructions);
-            return instructions;
+            return expr;
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             ExponentOperation func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
-            List<Instruction> instructions = new List<Instruction>();
-
-            instructions.AddRange(
-                ConvertToInstructions(arguments[0], varmap));
-
-            if (arguments[1] is Literal lit)
-            {
-                var value = lit.Value.ToFloat();
-
-                if (value == 1f)
-                {
-                    return instructions;
-                }
-                if (value == value.Round() &&
-                    value > 1 &&
-                    value < 16)
-                {
-                    int i;
-                    for (i = 1; i < value; i++)
-                    {
-                        instructions.Add(Instruction.Dup());
-                    }
-                    for (i = 1; i < value; i++)
-                    {
-                        instructions.Add(Instruction.Mul());
-                    }
-                    return instructions;
-                }
-                if (value == 1 / 2.0f)
-                {
-                    instructions.Add(
-                        Instruction.Call(
-                            typeof(System.Math).GetMethod(
-                                "Sqrt", new Type[] { typeof(float) })));
-
-                    return instructions;
-                }
-            }
-
-            instructions.AddRange(
-                ConvertToInstructions(arguments[1], varmap));
-            instructions.Add(
-                Instruction.Call(
-                    typeof(System.Math).GetMethod("Pow")));
-            return instructions;
+            return new CallIlExpression(
+                new Func<double, double, double>(Math.Pow),
+                ConvertToIlExpression(arguments[0], varmap),
+                ConvertToIlExpression(arguments[1], varmap));
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             FactorialFunction func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
             throw new NotImplementedException();
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             FloorFunction func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Floor),
-                new RawInstructions(
-                    ConvertToInstructions(arguments[0], varmap).ToArray()));
+                    ConvertToIlExpression(arguments[0], varmap));
             expr.GetInstructions(instructions);
-            return instructions;
+            return expr;
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             GreaterThanComparisonOperation func,
             VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
@@ -703,17 +625,15 @@ namespace MetaphysicsIndustries.Solus.Compiler
             var instructions = new List<Instruction>();
             var expr = new ConvertR4IlExpression(
                 new CompareGreaterThanIlExpression(
-                    new RawInstructions(
-                        ConvertToInstructions(arguments[0],
-                            varmap).ToArray()),
-                    new RawInstructions(
-                        ConvertToInstructions(arguments[1],
-                            varmap).ToArray())));
+                        ConvertToIlExpression(arguments[0],
+                            varmap),
+                        ConvertToIlExpression(arguments[1],
+                            varmap)));
             expr.GetInstructions(instructions);
-            return instructions;
+            return expr;
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             GreaterThanOrEqualComparisonOperation func,
             VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
@@ -723,17 +643,15 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 new CompareEqualIlExpression(
                     new LoadConstantIlExpression(0),
                     new CompareLessThanIlExpression(
-                        new RawInstructions(
-                            ConvertToInstructions(arguments[0],
-                                varmap).ToArray()),
-                        new RawInstructions(
-                            ConvertToInstructions(arguments[1],
-                                varmap).ToArray()))));
+                            ConvertToIlExpression(arguments[0],
+                                varmap),
+                            ConvertToIlExpression(arguments[1],
+                                varmap))));
             expr.GetInstructions(instructions);
-            return instructions;
+            return expr;
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             LessThanComparisonOperation func,
             VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
@@ -741,17 +659,15 @@ namespace MetaphysicsIndustries.Solus.Compiler
             var instructions = new List<Instruction>();
             var expr = new ConvertR4IlExpression(
                 new CompareLessThanIlExpression(
-                    new RawInstructions(
-                        ConvertToInstructions(arguments[0],
-                            varmap).ToArray()),
-                    new RawInstructions(
-                        ConvertToInstructions(arguments[1],
-                            varmap).ToArray())));
+                        ConvertToIlExpression(arguments[0],
+                            varmap),
+                        ConvertToIlExpression(arguments[1],
+                            varmap)));
             expr.GetInstructions(instructions);
-            return instructions;
+            return expr;
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             LessThanOrEqualComparisonOperation func,
             VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
@@ -761,66 +677,60 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 new CompareEqualIlExpression(
                     new LoadConstantIlExpression(0),
                     new CompareGreaterThanIlExpression(
-                        new RawInstructions(
-                            ConvertToInstructions(arguments[0],
-                                varmap).ToArray()),
-                        new RawInstructions(
-                            ConvertToInstructions(arguments[1],
-                                varmap).ToArray()))));
+                            ConvertToIlExpression(arguments[0],
+                                varmap),
+                            ConvertToIlExpression(arguments[1],
+                                varmap))));
             expr.GetInstructions(instructions);
-            return instructions;
+            return expr;
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             LoadImageFunction func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
             throw new NotImplementedException();
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             Log10Function func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Log10),
-                new RawInstructions(
-                    ConvertToInstructions(arguments[0], varmap).ToArray()));
+                    ConvertToIlExpression(arguments[0], varmap));
             expr.GetInstructions(instructions);
-            return instructions;
+            return expr;
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             Log2Function func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
             var expr = new CallIlExpression(
                 new Func<double, double, double>(Math.Log),
-                new RawInstructions(
-                    ConvertToInstructions(arguments[0], varmap).ToArray()),
+                    ConvertToIlExpression(arguments[0], varmap),
                 new LoadConstantIlExpression(2f));
             expr.GetInstructions(instructions);
-            return instructions;
+            return expr;
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             LogarithmFunction func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
             var expr = new CallIlExpression(
                 new Func<double, double, double>(Math.Log),
-                new RawInstructions(
-                    ConvertToInstructions(arguments[0], varmap).ToArray()),
-                new RawInstructions(
-                    ConvertToInstructions(arguments[1], varmap).ToArray()));
+                    ConvertToIlExpression(arguments[0], varmap),
+                    ConvertToIlExpression(arguments[1], varmap));
             expr.GetInstructions(instructions);
-            return instructions;
+            return expr;
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             LogicalAndOperation func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
@@ -832,20 +742,18 @@ namespace MetaphysicsIndustries.Solus.Compiler
                         new CompareEqualIlExpression(
                             new LoadConstantIlExpression(0),
                             new ConvertI4IlExpression(
-                                new RawInstructions(
-                                    ConvertToInstructions(arguments[0],
-                                        varmap).ToArray()))),
+                                    ConvertToIlExpression(arguments[0],
+                                        varmap))),
                         new CompareEqualIlExpression(
                             new LoadConstantIlExpression(0),
                             new ConvertI4IlExpression(
-                                new RawInstructions(
-                                    ConvertToInstructions(arguments[1],
-                                        varmap).ToArray()))))));
+                                    ConvertToIlExpression(arguments[1],
+                                        varmap))))));
             expr.GetInstructions(instructions);
-            return instructions;
+            return expr;
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             LogicalOrOperation func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
@@ -856,49 +764,47 @@ namespace MetaphysicsIndustries.Solus.Compiler
                         new CompareEqualIlExpression(
                             new LoadConstantIlExpression(0),
                             new ConvertI4IlExpression(
-                                new RawInstructions(
-                                    ConvertToInstructions(arguments[0],
-                                        varmap).ToArray()))),
+                                    ConvertToIlExpression(arguments[0],
+                                        varmap))),
                         new CompareEqualIlExpression(
                             new LoadConstantIlExpression(0),
                             new ConvertI4IlExpression(
-                                new RawInstructions(
-                                    ConvertToInstructions(arguments[1],
-                                        varmap).ToArray())))),
+                                    ConvertToIlExpression(arguments[1],
+                                        varmap)))),
                     new LoadConstantIlExpression(2)));
             expr.GetInstructions(instructions);
-            return instructions;
+            return expr;
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             MaximumFiniteFunction func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
             throw new NotImplementedException();
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             MaximumFunction func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
             throw new NotImplementedException();
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             MinimumFiniteFunction func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
             throw new NotImplementedException();
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             MinimumFunction func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
             throw new NotImplementedException();
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             ModularDivision func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
@@ -906,36 +812,32 @@ namespace MetaphysicsIndustries.Solus.Compiler
             var expr = new ConvertR4IlExpression(
                 new RemIlExpression(
                     new ConvertI4IlExpression(
-                        new RawInstructions(
-                            ConvertToInstructions(arguments[0],
-                                varmap).ToArray())),
+                            ConvertToIlExpression(arguments[0],
+                                varmap)),
                     new ConvertI4IlExpression(
-                        new RawInstructions(
-                            ConvertToInstructions(arguments[1],
-                                varmap).ToArray()))));
+                            ConvertToIlExpression(arguments[1],
+                                varmap))));
             expr.GetInstructions(instructions);
-            return instructions;
+            return expr;
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             MultiplicationOperation func,
             VariableToArgumentNumberMapper varmap, List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
-            IlExpression expr = new RawInstructions(
-                ConvertToInstructions(arguments[0], varmap).ToArray());
+            var expr = ConvertToIlExpression(arguments[0], varmap);
             int i;
             for (i = 1; i < arguments.Count; i++)
                 expr = new MulIlExpression(
                     expr,
-                    new RawInstructions(
-                        ConvertToInstructions(arguments[i],
-                            varmap).ToArray()));
+                        ConvertToIlExpression(arguments[i],
+                            varmap));
             expr.GetInstructions(instructions);
-            return instructions;
+            return expr;
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             NaturalLogarithmFunction func,
             VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
@@ -943,25 +845,23 @@ namespace MetaphysicsIndustries.Solus.Compiler
             var instructions = new List<Instruction>();
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Log),
-                new RawInstructions(
-                    ConvertToInstructions(arguments[0], varmap).ToArray()));
+                    ConvertToIlExpression(arguments[0], varmap));
             expr.GetInstructions(instructions);
-            return instructions;
+            return expr;
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             NegationOperation func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
             var instructions = new List<Instruction>();
             var expr = new NegIlExpression(
-                new RawInstructions(
-                    ConvertToInstructions(arguments[0], varmap).ToArray()));
+                    ConvertToIlExpression(arguments[0], varmap));
             expr.GetInstructions(instructions);
-            return instructions;
+            return expr;
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             NotEqualComparisonOperation func,
             VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
@@ -971,17 +871,15 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 new CompareEqualIlExpression(
                     new LoadConstantIlExpression(0),
                     new CompareEqualIlExpression(
-                        new RawInstructions(
-                            ConvertToInstructions(
-                                arguments[0], varmap).ToArray()),
-                        new RawInstructions(
-                            ConvertToInstructions(
-                                arguments[1], varmap).ToArray()))));
+                            ConvertToIlExpression(
+                                arguments[0], varmap),
+                            ConvertToIlExpression(
+                                arguments[1], varmap))));
             expr.GetInstructions(instructions);
-            return instructions;
+            return expr;
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             SecantFunction func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
@@ -990,66 +888,56 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 new LoadConstantIlExpression(1f),
                 new CallIlExpression(
                     new Func<double, double>(Math.Cos),
-                    new RawInstructions(
-                        ConvertToInstructions(
-                            arguments[0], varmap).ToArray())));
+                        ConvertToIlExpression(
+                            arguments[0], varmap)));
             expr.GetInstructions(instructions);
-            return instructions;
+            return expr;
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             SineFunction func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
-            var instructions = new List<Instruction>();
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Sin),
-                new RawInstructions(
-                    ConvertToInstructions(
-                        arguments[0], varmap).ToArray()));
-            expr.GetInstructions(instructions);
-            return instructions;
+                ConvertToIlExpression(
+                    arguments[0], varmap));
+            return expr;
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             SizeFunction func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
             throw new NotImplementedException();
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             TangentFunction func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
-            var instructions = new List<Instruction>();
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Tan),
-                new RawInstructions(
-                    ConvertToInstructions(
-                        arguments[0], varmap).ToArray()));
-            expr.GetInstructions(instructions);
-            return instructions;
+                ConvertToIlExpression(
+                    arguments[0], varmap));
+            return expr;
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             UnitStepFunction func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {
-            var instructions = new List<Instruction>();
             var expr = new ConvertR4IlExpression(
                 new CompareLessThanIlExpression(
                     new CompareLessThanIlExpression(
-                        new RawInstructions(
-                            ConvertToInstructions(
-                                arguments[0], varmap).ToArray()),
+                        ConvertToIlExpression(
+                            arguments[0], varmap),
                         new LoadConstantIlExpression(0f)),
                     new LoadConstantIlExpression(1)));
-            expr.GetInstructions(instructions);
-            return instructions;
+            return expr;
         }
 
-        public IEnumerable<Instruction> ConvertToInstructions(
+        public IlExpression ConvertToIlExpression(
             UserDefinedFunction func, VariableToArgumentNumberMapper varmap,
             List<Expression> arguments)
         {

--- a/Compiler/ILCompiler.cs
+++ b/Compiler/ILCompiler.cs
@@ -38,7 +38,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
             var ilexpr = ConvertToIlExpression(expr, nm);
             var args = nm.GetVariableNamesInIndexOrder();
             var instructions = new List<Instruction>();
-            ilexpr.GetInstructions(instructions);
+            ilexpr.GetInstructions(nm);
 
             DynamicMethod method =
                 new DynamicMethod(
@@ -342,7 +342,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 new DivIlExpression(
                     new LoadConstantIlExpression(1f),
                     ConvertToIlExpression(arguments[0], nm)));
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             return expr;
         }
 
@@ -354,7 +354,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Acos),
                 ConvertToIlExpression(arguments[0], nm));
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             return expr;
         }
 
@@ -367,7 +367,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 new Func<double, double, double>(Math.Atan2),
                 new LoadConstantIlExpression(1f),
                 ConvertToIlExpression(arguments[0], nm));
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             return expr;
         }
 
@@ -381,7 +381,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 new DivIlExpression(
                     new LoadConstantIlExpression(1f),
                     ConvertToIlExpression(arguments[0], nm)));
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             return expr;
         }
 
@@ -393,7 +393,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Asin),
                 ConvertToIlExpression(arguments[0], nm));
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             return expr;
         }
 
@@ -406,7 +406,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 new Func<double, double, double>(Math.Atan2),
                 ConvertToIlExpression(arguments[0], nm),
                 ConvertToIlExpression(arguments[1], nm));
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             return expr;
         }
 
@@ -418,7 +418,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Atan),
                 ConvertToIlExpression(arguments[0], nm));
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             return expr;
         }
 
@@ -433,7 +433,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
                         ConvertToIlExpression(arguments[0], nm)),
                     new ConvertI4IlExpression(
                         ConvertToIlExpression(arguments[1], nm))));
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             return expr;
         }
 
@@ -448,7 +448,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
                         ConvertToIlExpression(arguments[0], nm)),
                     new ConvertI4IlExpression(
                         ConvertToIlExpression(arguments[1], nm))));
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             return expr;
         }
 
@@ -460,7 +460,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Ceiling),
                 ConvertToIlExpression(arguments[0], nm));
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             return expr;
         }
 
@@ -474,7 +474,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 new CallIlExpression(
                     new Func<double, double>(Math.Sin),
                     ConvertToIlExpression(arguments[0], nm)));
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             return expr;
         }
 
@@ -486,7 +486,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Cos),
                 ConvertToIlExpression(arguments[0], nm));
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             return expr;
         }
 
@@ -500,7 +500,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 new CallIlExpression(
                     new Func<double, double>(Math.Tan),
                     ConvertToIlExpression(arguments[0], nm)));
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             return expr;
         }
 
@@ -546,7 +546,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
             var expr = new DivIlExpression(
                 ConvertToIlExpression(arguments[0], nm),
                 ConvertToIlExpression(arguments[1], nm));
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             return expr;
         }
 
@@ -560,7 +560,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 new CompareEqualIlExpression(
                     ConvertToIlExpression(arguments[0], nm),
                     ConvertToIlExpression(arguments[1], nm)));
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             return expr;
         }
 
@@ -589,7 +589,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Floor),
                 ConvertToIlExpression(arguments[0], nm));
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             return expr;
         }
 
@@ -603,7 +603,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 new CompareGreaterThanIlExpression(
                     ConvertToIlExpression(arguments[0], nm),
                     ConvertToIlExpression(arguments[1], nm)));
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             return expr;
         }
 
@@ -619,7 +619,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
                     new CompareLessThanIlExpression(
                         ConvertToIlExpression(arguments[0], nm),
                         ConvertToIlExpression(arguments[1], nm))));
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             return expr;
         }
 
@@ -633,7 +633,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 new CompareLessThanIlExpression(
                     ConvertToIlExpression(arguments[0], nm),
                     ConvertToIlExpression(arguments[1], nm)));
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             return expr;
         }
 
@@ -649,7 +649,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
                     new CompareGreaterThanIlExpression(
                         ConvertToIlExpression(arguments[0], nm),
                         ConvertToIlExpression(arguments[1], nm))));
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             return expr;
         }
 
@@ -668,7 +668,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Log10),
                 ConvertToIlExpression(arguments[0], nm));
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             return expr;
         }
 
@@ -681,7 +681,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 new Func<double, double, double>(Math.Log),
                 ConvertToIlExpression(arguments[0], nm),
                 new LoadConstantIlExpression(2f));
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             return expr;
         }
 
@@ -694,7 +694,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 new Func<double, double, double>(Math.Log),
                 ConvertToIlExpression(arguments[0], nm),
                 ConvertToIlExpression(arguments[1], nm));
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             return expr;
         }
 
@@ -715,7 +715,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
                             new LoadConstantIlExpression(0),
                             new ConvertI4IlExpression(
                                 ConvertToIlExpression(arguments[1], nm))))));
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             return expr;
         }
 
@@ -736,7 +736,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
                             new ConvertI4IlExpression(
                                 ConvertToIlExpression(arguments[1], nm)))),
                     new LoadConstantIlExpression(2)));
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             return expr;
         }
 
@@ -799,7 +799,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
                         ConvertToIlExpression(arguments[0], nm)),
                     new ConvertI4IlExpression(
                         ConvertToIlExpression(arguments[1], nm))));
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             return expr;
         }
 
@@ -814,7 +814,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 expr = new MulIlExpression(
                     expr,
                     ConvertToIlExpression(arguments[i], nm));
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             return expr;
         }
 
@@ -827,7 +827,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Log),
                 ConvertToIlExpression(arguments[0], nm));
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             return expr;
         }
 
@@ -838,7 +838,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
             var instructions = new List<Instruction>();
             var expr = new NegIlExpression(
                 ConvertToIlExpression(arguments[0], nm));
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             return expr;
         }
 
@@ -854,7 +854,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
                     new CompareEqualIlExpression(
                         ConvertToIlExpression(arguments[0], nm),
                         ConvertToIlExpression(arguments[1], nm))));
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             return expr;
         }
 
@@ -868,7 +868,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 new CallIlExpression(
                     new Func<double, double>(Math.Cos),
                     ConvertToIlExpression(arguments[0], nm)));
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             return expr;
         }
 

--- a/Compiler/IlExpressions/AddIlExpression.cs
+++ b/Compiler/IlExpressions/AddIlExpression.cs
@@ -36,11 +36,11 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
         public IlExpression Left { get; }
         public IlExpression Right { get; }
 
-        public override void GetInstructions(IList<Instruction> instructions)
+        public override void GetInstructions(NascentMethod nm)
         {
-            Left.GetInstructions(instructions);
-            Right.GetInstructions(instructions);
-            instructions.Add(Instruction.Add());
+            Left.GetInstructions(nm);
+            Right.GetInstructions(nm);
+            nm.Instructions.Add(Instruction.Add());
         }
     }
 }

--- a/Compiler/IlExpressions/AddIlExpression.cs
+++ b/Compiler/IlExpressions/AddIlExpression.cs
@@ -21,7 +21,6 @@
  */
 
 using System;
-using System.Collections.Generic;
 
 namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 {

--- a/Compiler/IlExpressions/AndIlExpression.cs
+++ b/Compiler/IlExpressions/AndIlExpression.cs
@@ -36,11 +36,11 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
         public IlExpression Left { get; }
         public IlExpression Right { get; }
 
-        public override void GetInstructions(IList<Instruction> instructions)
+        public override void GetInstructions(NascentMethod nm)
         {
-            Left.GetInstructions(instructions);
-            Right.GetInstructions(instructions);
-            instructions.Add(Instruction.And());
+            Left.GetInstructions(nm);
+            Right.GetInstructions(nm);
+            nm.Instructions.Add(Instruction.And());
         }
     }
 }

--- a/Compiler/IlExpressions/AndIlExpression.cs
+++ b/Compiler/IlExpressions/AndIlExpression.cs
@@ -21,7 +21,6 @@
  */
 
 using System;
-using System.Collections.Generic;
 
 namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 {

--- a/Compiler/IlExpressions/CallIlExpression.cs
+++ b/Compiler/IlExpressions/CallIlExpression.cs
@@ -21,7 +21,6 @@
  */
 
 using System;
-using System.Collections.Generic;
 using System.Reflection;
 
 namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions

--- a/Compiler/IlExpressions/CallIlExpression.cs
+++ b/Compiler/IlExpressions/CallIlExpression.cs
@@ -43,13 +43,13 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
         public MethodInfo Method { get; }
         public IlExpression[] Args { get; }
 
-        public override void GetInstructions(IList<Instruction> instructions)
+        public override void GetInstructions(NascentMethod nm)
         {
             // TODO: check args against method signature?
             int i;
             for (i = 0; i < Args.Length; i++)
-                Args[i].GetInstructions(instructions);
-            instructions.Add(Instruction.Call(Method));
+                Args[i].GetInstructions(nm);
+            nm.Instructions.Add(Instruction.Call(Method));
         }
     }
 }

--- a/Compiler/IlExpressions/CompareEqualIlExpression.cs
+++ b/Compiler/IlExpressions/CompareEqualIlExpression.cs
@@ -37,11 +37,11 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
         public IlExpression Left { get; }
         public IlExpression Right { get; }
 
-        public override void GetInstructions(IList<Instruction> instructions)
+        public override void GetInstructions(NascentMethod nm)
         {
-            Left.GetInstructions(instructions);
-            Right.GetInstructions(instructions);
-            instructions.Add(Instruction.CompareEqual());
+            Left.GetInstructions(nm);
+            Right.GetInstructions(nm);
+            nm.Instructions.Add(Instruction.CompareEqual());
         }
     }
 }

--- a/Compiler/IlExpressions/CompareEqualIlExpression.cs
+++ b/Compiler/IlExpressions/CompareEqualIlExpression.cs
@@ -21,7 +21,6 @@
  */
 
 using System;
-using System.Collections.Generic;
 
 namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 {

--- a/Compiler/IlExpressions/CompareGreaterThanIlExpression.cs
+++ b/Compiler/IlExpressions/CompareGreaterThanIlExpression.cs
@@ -37,11 +37,11 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
         public IlExpression Left { get; }
         public IlExpression Right { get; }
 
-        public override void GetInstructions(IList<Instruction> instructions)
+        public override void GetInstructions(NascentMethod nm)
         {
-            Left.GetInstructions(instructions);
-            Right.GetInstructions(instructions);
-            instructions.Add(Instruction.CompareGreaterThan());
+            Left.GetInstructions(nm);
+            Right.GetInstructions(nm);
+            nm.Instructions.Add(Instruction.CompareGreaterThan());
         }
     }
 }

--- a/Compiler/IlExpressions/CompareGreaterThanIlExpression.cs
+++ b/Compiler/IlExpressions/CompareGreaterThanIlExpression.cs
@@ -21,7 +21,6 @@
  */
 
 using System;
-using System.Collections.Generic;
 
 namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 {

--- a/Compiler/IlExpressions/CompareLessThanIlExpression.cs
+++ b/Compiler/IlExpressions/CompareLessThanIlExpression.cs
@@ -21,7 +21,6 @@
  */
 
 using System;
-using System.Collections.Generic;
 
 namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 {

--- a/Compiler/IlExpressions/CompareLessThanIlExpression.cs
+++ b/Compiler/IlExpressions/CompareLessThanIlExpression.cs
@@ -37,11 +37,11 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
         public IlExpression Left { get; }
         public IlExpression Right { get; }
 
-        public override void GetInstructions(IList<Instruction> instructions)
+        public override void GetInstructions(NascentMethod nm)
         {
-            Left.GetInstructions(instructions);
-            Right.GetInstructions(instructions);
-            instructions.Add(Instruction.CompareLessThan());
+            Left.GetInstructions(nm);
+            Right.GetInstructions(nm);
+            nm.Instructions.Add(Instruction.CompareLessThan());
         }
     }
 }

--- a/Compiler/IlExpressions/ConvertI4IlExpression.cs
+++ b/Compiler/IlExpressions/ConvertI4IlExpression.cs
@@ -21,7 +21,6 @@
  */
 
 using System;
-using System.Collections.Generic;
 
 namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 {

--- a/Compiler/IlExpressions/ConvertI4IlExpression.cs
+++ b/Compiler/IlExpressions/ConvertI4IlExpression.cs
@@ -35,10 +35,10 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 
         public IlExpression Argument { get; }
 
-        public override void GetInstructions(IList<Instruction> instructions)
+        public override void GetInstructions(NascentMethod nm)
         {
-            Argument.GetInstructions(instructions);
-            instructions.Add(Instruction.ConvertI4());
+            Argument.GetInstructions(nm);
+            nm.Instructions.Add(Instruction.ConvertI4());
         }
     }
 }

--- a/Compiler/IlExpressions/ConvertR4IlExpression.cs
+++ b/Compiler/IlExpressions/ConvertR4IlExpression.cs
@@ -21,7 +21,6 @@
  */
 
 using System;
-using System.Collections.Generic;
 
 namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 {

--- a/Compiler/IlExpressions/ConvertR4IlExpression.cs
+++ b/Compiler/IlExpressions/ConvertR4IlExpression.cs
@@ -35,10 +35,10 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 
         public IlExpression Argument { get; }
 
-        public override void GetInstructions(IList<Instruction> instructions)
+        public override void GetInstructions(NascentMethod nm)
         {
-            Argument.GetInstructions(instructions);
-            instructions.Add(Instruction.ConvertR4());
+            Argument.GetInstructions(nm);
+            nm.Instructions.Add(Instruction.ConvertR4());
         }
     }
 }

--- a/Compiler/IlExpressions/DivIlExpression.cs
+++ b/Compiler/IlExpressions/DivIlExpression.cs
@@ -38,11 +38,11 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
         public IlExpression Dividend { get; }
         public IlExpression Divisor { get; }
 
-        public override void GetInstructions(IList<Instruction> instructions)
+        public override void GetInstructions(NascentMethod nm)
         {
-            Dividend.GetInstructions(instructions);
-            Divisor.GetInstructions(instructions);
-            instructions.Add(Instruction.Div());
+            Dividend.GetInstructions(nm);
+            Divisor.GetInstructions(nm);
+            nm.Instructions.Add(Instruction.Div());
         }
     }
 }

--- a/Compiler/IlExpressions/DivIlExpression.cs
+++ b/Compiler/IlExpressions/DivIlExpression.cs
@@ -21,7 +21,6 @@
  */
 
 using System;
-using System.Collections.Generic;
 
 namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 {

--- a/Compiler/IlExpressions/DupIlExpression.cs
+++ b/Compiler/IlExpressions/DupIlExpression.cs
@@ -35,9 +35,9 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 
         public IlExpression Target { get; }
 
-        public override void GetInstructions(IList<Instruction> instructions)
+        public override void GetInstructions(NascentMethod nm)
         {
-            instructions.Add(Instruction.Dup());
+            nm.Instructions.Add(Instruction.Dup());
         }
     }
 }

--- a/Compiler/IlExpressions/DupIlExpression.cs
+++ b/Compiler/IlExpressions/DupIlExpression.cs
@@ -1,0 +1,43 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2021 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using System;
+using System.Collections.Generic;
+
+namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
+{
+    public class DupIlExpression : IlExpression
+    {
+        public DupIlExpression(IlExpression target)
+        {
+            Target = target ??
+                       throw new ArgumentNullException(nameof(target));
+        }
+
+        public IlExpression Target { get; }
+
+        public override void GetInstructions(IList<Instruction> instructions)
+        {
+            instructions.Add(Instruction.Dup());
+        }
+    }
+}

--- a/Compiler/IlExpressions/DupIlExpression.cs
+++ b/Compiler/IlExpressions/DupIlExpression.cs
@@ -21,7 +21,6 @@
  */
 
 using System;
-using System.Collections.Generic;
 
 namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 {

--- a/Compiler/IlExpressions/IlExpression.cs
+++ b/Compiler/IlExpressions/IlExpression.cs
@@ -20,8 +20,6 @@
  *
  */
 
-using System.Collections.Generic;
-
 namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 {
     public abstract class IlExpression

--- a/Compiler/IlExpressions/IlExpression.cs
+++ b/Compiler/IlExpressions/IlExpression.cs
@@ -26,6 +26,6 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 {
     public abstract class IlExpression
     {
-        public abstract void GetInstructions(IList<Instruction> instructions);
+        public abstract void GetInstructions(NascentMethod nm);
     }
 }

--- a/Compiler/IlExpressions/IlExpressionSequence.cs
+++ b/Compiler/IlExpressions/IlExpressionSequence.cs
@@ -20,8 +20,6 @@
  *
  */
 
-using System.Collections.Generic;
-
 namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 {
     public class IlExpressionSequence : IlExpression

--- a/Compiler/IlExpressions/IlExpressionSequence.cs
+++ b/Compiler/IlExpressions/IlExpressionSequence.cs
@@ -33,10 +33,10 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 
         public IlExpression[] Expressions;
 
-        public override void GetInstructions(IList<Instruction> instructions)
+        public override void GetInstructions(NascentMethod nm)
         {
             foreach (var expr in Expressions)
-                expr.GetInstructions(instructions);
+                expr.GetInstructions(nm);
         }
     }
 }

--- a/Compiler/IlExpressions/LoadConstantIlExpression.cs
+++ b/Compiler/IlExpressions/LoadConstantIlExpression.cs
@@ -20,8 +20,6 @@
  *
  */
 
-using System.Collections.Generic;
-
 namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 {
     public class LoadConstantIlExpression : IlExpression

--- a/Compiler/IlExpressions/LoadConstantIlExpression.cs
+++ b/Compiler/IlExpressions/LoadConstantIlExpression.cs
@@ -35,9 +35,9 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 
         public Instruction Instruction { get; }
 
-        public override void GetInstructions(IList<Instruction> instructions)
+        public override void GetInstructions(NascentMethod nm)
         {
-            instructions.Add(Instruction);
+            nm.Instructions.Add(Instruction);
         }
     }
 }

--- a/Compiler/IlExpressions/LoadLocalIlExpression.cs
+++ b/Compiler/IlExpressions/LoadLocalIlExpression.cs
@@ -1,3 +1,25 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2021 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
 using System.Collections.Generic;
 
 namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions

--- a/Compiler/IlExpressions/LoadLocalIlExpression.cs
+++ b/Compiler/IlExpressions/LoadLocalIlExpression.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+
+namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
+{
+    public class LoadLocalIlExpression : IlExpression
+    {
+        public LoadLocalIlExpression(ushort varNumber)
+        {
+            VarNumber = varNumber;
+        }
+
+        public ushort VarNumber { get; }
+        
+        public override void GetInstructions(IList<Instruction> instructions)
+        {
+            instructions.Add(Instruction.LoadLocalVariable(VarNumber));
+        }
+    }
+}

--- a/Compiler/IlExpressions/LoadLocalIlExpression.cs
+++ b/Compiler/IlExpressions/LoadLocalIlExpression.cs
@@ -11,9 +11,9 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 
         public ushort VarNumber { get; }
         
-        public override void GetInstructions(IList<Instruction> instructions)
+        public override void GetInstructions(NascentMethod nm)
         {
-            instructions.Add(Instruction.LoadLocalVariable(VarNumber));
+            nm.Instructions.Add(Instruction.LoadLocalVariable(VarNumber));
         }
     }
 }

--- a/Compiler/IlExpressions/LoadLocalIlExpression.cs
+++ b/Compiler/IlExpressions/LoadLocalIlExpression.cs
@@ -20,8 +20,6 @@
  *
  */
 
-using System.Collections.Generic;
-
 namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 {
     public class LoadLocalIlExpression : IlExpression

--- a/Compiler/IlExpressions/MulIlExpression.cs
+++ b/Compiler/IlExpressions/MulIlExpression.cs
@@ -36,11 +36,11 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
         public IlExpression Left { get; }
         public IlExpression Right { get; }
 
-        public override void GetInstructions(IList<Instruction> instructions)
+        public override void GetInstructions(NascentMethod nm)
         {
-            Left.GetInstructions(instructions);
-            Right.GetInstructions(instructions);
-            instructions.Add(Instruction.Mul());
+            Left.GetInstructions(nm);
+            Right.GetInstructions(nm);
+            nm.Instructions.Add(Instruction.Mul());
         }
     }
 }

--- a/Compiler/IlExpressions/MulIlExpression.cs
+++ b/Compiler/IlExpressions/MulIlExpression.cs
@@ -21,7 +21,6 @@
  */
 
 using System;
-using System.Collections.Generic;
 
 namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 {

--- a/Compiler/IlExpressions/NegIlExpression.cs
+++ b/Compiler/IlExpressions/NegIlExpression.cs
@@ -21,7 +21,6 @@
  */
 
 using System;
-using System.Collections.Generic;
 
 namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 {

--- a/Compiler/IlExpressions/NegIlExpression.cs
+++ b/Compiler/IlExpressions/NegIlExpression.cs
@@ -35,10 +35,10 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 
         public IlExpression Argument { get; }
 
-        public override void GetInstructions(IList<Instruction> instructions)
+        public override void GetInstructions(NascentMethod nm)
         {
-            Argument.GetInstructions(instructions);
-            instructions.Add(Instruction.Neg());
+            Argument.GetInstructions(nm);
+            nm.Instructions.Add(Instruction.Neg());
         }
     }
 }

--- a/Compiler/IlExpressions/OrIlExpression.cs
+++ b/Compiler/IlExpressions/OrIlExpression.cs
@@ -21,7 +21,6 @@
  */
 
 using System;
-using System.Collections.Generic;
 
 namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 {

--- a/Compiler/IlExpressions/OrIlExpression.cs
+++ b/Compiler/IlExpressions/OrIlExpression.cs
@@ -36,11 +36,11 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
         public IlExpression Left { get; }
         public IlExpression Right { get; }
 
-        public override void GetInstructions(IList<Instruction> instructions)
+        public override void GetInstructions(NascentMethod nm)
         {
-            Left.GetInstructions(instructions);
-            Right.GetInstructions(instructions);
-            instructions.Add(Instruction.Or());
+            Left.GetInstructions(nm);
+            Right.GetInstructions(nm);
+            nm.Instructions.Add(Instruction.Or());
         }
     }
 }

--- a/Compiler/IlExpressions/RawInstructions.cs
+++ b/Compiler/IlExpressions/RawInstructions.cs
@@ -33,11 +33,11 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 
         public Instruction[] Instructions { get; }
 
-        public override void GetInstructions(IList<Instruction> instructions)
+        public override void GetInstructions(NascentMethod nm)
         {
             int i;
             for (i = 0; i < Instructions.Length; i++)
-                instructions.Add(Instructions[i]);
+                nm.Instructions.Add(Instructions[i]);
         }
     }
 }

--- a/Compiler/IlExpressions/RawInstructions.cs
+++ b/Compiler/IlExpressions/RawInstructions.cs
@@ -20,8 +20,6 @@
  *
  */
 
-using System.Collections.Generic;
-
 namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 {
     public class RawInstructions:IlExpression

--- a/Compiler/IlExpressions/RemIlExpression.cs
+++ b/Compiler/IlExpressions/RemIlExpression.cs
@@ -21,7 +21,6 @@
  */
 
 using System;
-using System.Collections.Generic;
 
 namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 {

--- a/Compiler/IlExpressions/RemIlExpression.cs
+++ b/Compiler/IlExpressions/RemIlExpression.cs
@@ -38,11 +38,11 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
         public IlExpression Dividend { get; }
         public IlExpression Divisor { get; }
 
-        public override void GetInstructions(IList<Instruction> instructions)
+        public override void GetInstructions(NascentMethod nm)
         {
-            Dividend.GetInstructions(instructions);
-            Divisor.GetInstructions(instructions);
-            instructions.Add(Instruction.Rem());
+            Dividend.GetInstructions(nm);
+            Divisor.GetInstructions(nm);
+            nm.Instructions.Add(Instruction.Rem());
         }
     }
 }

--- a/Compiler/IlExpressions/SubIlExpression.cs
+++ b/Compiler/IlExpressions/SubIlExpression.cs
@@ -36,11 +36,11 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
         public IlExpression Left { get; }
         public IlExpression Right { get; }
 
-        public override void GetInstructions(IList<Instruction> instructions)
+        public override void GetInstructions(NascentMethod nm)
         {
-            Left.GetInstructions(instructions);
-            Right.GetInstructions(instructions);
-            instructions.Add(Instruction.Sub());
+            Left.GetInstructions(nm);
+            Right.GetInstructions(nm);
+            nm.Instructions.Add(Instruction.Sub());
         }
     }
 }

--- a/Compiler/IlExpressions/SubIlExpression.cs
+++ b/Compiler/IlExpressions/SubIlExpression.cs
@@ -21,7 +21,6 @@
  */
 
 using System;
-using System.Collections.Generic;
 
 namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 {

--- a/Compiler/NascentMethod.cs
+++ b/Compiler/NascentMethod.cs
@@ -57,6 +57,9 @@ namespace MetaphysicsIndustries.Solus.Compiler
         {
             _dictionary.Clear();
         }
+
+        public readonly List<Instruction> Instructions =
+            new List<Instruction>();
     }
 }
 

--- a/Compiler/NascentMethod.cs
+++ b/Compiler/NascentMethod.cs
@@ -24,7 +24,7 @@ using System.Collections.Generic;
 
 namespace MetaphysicsIndustries.Solus.Compiler
 {
-    public class VariableToArgumentNumberMapper
+    public class NascentMethod
     {
         readonly Dictionary<string, byte> _dictionary = new Dictionary<string, byte>();
 

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/AddIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/AddIlExpressionT/GetInstructionsTest.cs
@@ -40,16 +40,16 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var expr = new AddIlExpression(
                 new MockIlExpression(il => il.Add(i1)),
                 new MockIlExpression(il => il.Add(i2)));
-            var instructions = new List<Instruction>();
+            var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, instructions.Count);
+            Assert.AreEqual(0, nm.Instructions.Count);
             // when
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(3, instructions.Count);
-            Assert.AreEqual(i1, instructions[0]);
-            Assert.AreEqual(i2, instructions[1]);
-            Assert.AreEqual(Instruction.Add(), instructions[2]);
+            Assert.AreEqual(3, nm.Instructions.Count);
+            Assert.AreEqual(i1, nm.Instructions[0]);
+            Assert.AreEqual(i2, nm.Instructions[1]);
+            Assert.AreEqual(Instruction.Add(), nm.Instructions[2]);
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/AndIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/AndIlExpressionT/GetInstructionsTest.cs
@@ -39,16 +39,16 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.AndIlExpress
             var expr = new AndIlExpression(
                 new MockIlExpression(il => il.Add(i1)),
                 new MockIlExpression(il => il.Add(i2)));
-            var instructions = new List<Instruction>();
+            var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, instructions.Count);
+            Assert.AreEqual(0, nm.Instructions.Count);
             // when
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(3, instructions.Count);
-            Assert.AreEqual(i1, instructions[0]);
-            Assert.AreEqual(i2, instructions[1]);
-            Assert.AreEqual(Instruction.And(), instructions[2]);
+            Assert.AreEqual(3, nm.Instructions.Count);
+            Assert.AreEqual(i1, nm.Instructions[0]);
+            Assert.AreEqual(i2, nm.Instructions[1]);
+            Assert.AreEqual(Instruction.And(), nm.Instructions[2]);
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/CallIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/CallIlExpressionT/GetInstructionsTest.cs
@@ -44,17 +44,17 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var method = new Action<int, float, bool>(DummyMethod);
             var args = new IlExpression[0];
             var expr = new CallIlExpression(method, args);
-            var instructions = new List<Instruction>();
+            var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, instructions.Count);
+            Assert.AreEqual(0, nm.Instructions.Count);
             // when
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(1, instructions.Count);
+            Assert.AreEqual(1, nm.Instructions.Count);
             Assert.AreEqual(Instruction.ArgumentType.Method,
-                instructions[0].ArgType);
-            Assert.AreEqual(method.Method, instructions[0].MethodArg);
-            Assert.AreEqual(OpCodes.Call, instructions[0].OpCode);
+                nm.Instructions[0].ArgType);
+            Assert.AreEqual(method.Method, nm.Instructions[0].MethodArg);
+            Assert.AreEqual(OpCodes.Call, nm.Instructions[0].OpCode);
         }
 
         [Test]
@@ -69,20 +69,20 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
                 new LoadConstantIlExpression(3)
             };
             var expr = new CallIlExpression(method, args);
-            var instructions = new List<Instruction>();
+            var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, instructions.Count);
+            Assert.AreEqual(0, nm.Instructions.Count);
             // when
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(4, instructions.Count);
-            Assert.AreEqual(Instruction.LoadConstant(1), instructions[0]);
-            Assert.AreEqual(Instruction.LoadConstant(2), instructions[1]);
-            Assert.AreEqual(Instruction.LoadConstant(3), instructions[2]);
+            Assert.AreEqual(4, nm.Instructions.Count);
+            Assert.AreEqual(Instruction.LoadConstant(1), nm.Instructions[0]);
+            Assert.AreEqual(Instruction.LoadConstant(2), nm.Instructions[1]);
+            Assert.AreEqual(Instruction.LoadConstant(3), nm.Instructions[2]);
             Assert.AreEqual(Instruction.ArgumentType.Method,
-                instructions[3].ArgType);
-            Assert.AreEqual(method.Method, instructions[3].MethodArg);
-            Assert.AreEqual(OpCodes.Call, instructions[3].OpCode);
+                nm.Instructions[3].ArgType);
+            Assert.AreEqual(method.Method, nm.Instructions[3].MethodArg);
+            Assert.AreEqual(OpCodes.Call, nm.Instructions[3].OpCode);
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/CompareEqualIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/CompareEqualIlExpressionT/GetInstructionsTest.cs
@@ -40,17 +40,17 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var expr = new CompareEqualIlExpression(
                 new MockIlExpression(il => il.Add(i1)),
                 new MockIlExpression(il => il.Add(i2)));
-            var instructions = new List<Instruction>();
+            var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, instructions.Count);
+            Assert.AreEqual(0, nm.Instructions.Count);
             // when
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(3, instructions.Count);
-            Assert.AreEqual(i1, instructions[0]);
-            Assert.AreEqual(i2, instructions[1]);
+            Assert.AreEqual(3, nm.Instructions.Count);
+            Assert.AreEqual(i1, nm.Instructions[0]);
+            Assert.AreEqual(i2, nm.Instructions[1]);
             Assert.AreEqual(Instruction.CompareEqual(),
-                instructions[2]);
+                nm.Instructions[2]);
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/CompareGreaterThanIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/CompareGreaterThanIlExpressionT/GetInstructionsTest.cs
@@ -40,17 +40,17 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var expr = new CompareGreaterThanIlExpression(
                 new MockIlExpression(il => il.Add(i1)),
                 new MockIlExpression(il => il.Add(i2)));
-            var instructions = new List<Instruction>();
+            var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, instructions.Count);
+            Assert.AreEqual(0, nm.Instructions.Count);
             // when
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(3, instructions.Count);
-            Assert.AreEqual(i1, instructions[0]);
-            Assert.AreEqual(i2, instructions[1]);
+            Assert.AreEqual(3, nm.Instructions.Count);
+            Assert.AreEqual(i1, nm.Instructions[0]);
+            Assert.AreEqual(i2, nm.Instructions[1]);
             Assert.AreEqual(Instruction.CompareGreaterThan(),
-                instructions[2]);
+                nm.Instructions[2]);
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/CompareLessThanIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/CompareLessThanIlExpressionT/GetInstructionsTest.cs
@@ -40,17 +40,17 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var expr = new CompareLessThanIlExpression(
                 new MockIlExpression(il => il.Add(i1)),
                 new MockIlExpression(il => il.Add(i2)));
-            var instructions = new List<Instruction>();
+            var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, instructions.Count);
+            Assert.AreEqual(0, nm.Instructions.Count);
             // when
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(3, instructions.Count);
-            Assert.AreEqual(i1, instructions[0]);
-            Assert.AreEqual(i2, instructions[1]);
+            Assert.AreEqual(3, nm.Instructions.Count);
+            Assert.AreEqual(i1, nm.Instructions[0]);
+            Assert.AreEqual(i2, nm.Instructions[1]);
             Assert.AreEqual(Instruction.CompareLessThan(),
-                instructions[2]);
+                nm.Instructions[2]);
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/ConvertI4IlExpressionT/ConvertI4IlExpressionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/ConvertI4IlExpressionT/ConvertI4IlExpressionTest.cs
@@ -43,7 +43,7 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.ConvertI4IlE
         }
 
         [Test]
-        public void ConstructorNullArgumenttThrows()
+        public void ConstructorNullArgumentThrows()
         {
             // expect
             var ex = Assert.Throws<ArgumentNullException>(

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/ConvertI4IlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/ConvertI4IlExpressionT/GetInstructionsTest.cs
@@ -37,15 +37,15 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.ConvertI4IlE
             var i1 = Instruction.LoadConstant(1f);
             var expr = new ConvertI4IlExpression(
                 new MockIlExpression(il => il.Add(i1)));
-            var instructions = new List<Instruction>();
+            var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, instructions.Count);
+            Assert.AreEqual(0, nm.Instructions.Count);
             // when
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(2, instructions.Count);
-            Assert.AreEqual(i1, instructions[0]);
-            Assert.AreEqual(Instruction.ConvertI4(), instructions[1]);
+            Assert.AreEqual(2, nm.Instructions.Count);
+            Assert.AreEqual(i1, nm.Instructions[0]);
+            Assert.AreEqual(Instruction.ConvertI4(), nm.Instructions[1]);
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/ConvertR4IlExpressionT/ConvertR4IlExpressionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/ConvertR4IlExpressionT/ConvertR4IlExpressionTest.cs
@@ -43,7 +43,7 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.ConvertR4IlE
         }
 
         [Test]
-        public void ConstructorNullArgumenttThrows()
+        public void ConstructorNullArgumentThrows()
         {
             // expect
             var ex = Assert.Throws<ArgumentNullException>(

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/ConvertR4IlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/ConvertR4IlExpressionT/GetInstructionsTest.cs
@@ -37,15 +37,15 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.ConvertR4IlE
             var i1 = Instruction.LoadConstant(1f);
             var expr = new ConvertR4IlExpression(
                 new MockIlExpression(il => il.Add(i1)));
-            var instructions = new List<Instruction>();
+            var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, instructions.Count);
+            Assert.AreEqual(0, nm.Instructions.Count);
             // when
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(2, instructions.Count);
-            Assert.AreEqual(i1, instructions[0]);
-            Assert.AreEqual(Instruction.ConvertR4(), instructions[1]);
+            Assert.AreEqual(2, nm.Instructions.Count);
+            Assert.AreEqual(i1, nm.Instructions[0]);
+            Assert.AreEqual(Instruction.ConvertR4(), nm.Instructions[1]);
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/DivIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/DivIlExpressionT/GetInstructionsTest.cs
@@ -39,16 +39,16 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.DivIlExpress
             var expr = new DivIlExpression(
                 new MockIlExpression(il => il.Add(i1)),
                 new MockIlExpression(il => il.Add(i2)));
-            var instructions = new List<Instruction>();
+            var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, instructions.Count);
+            Assert.AreEqual(0, nm.Instructions.Count);
             // when
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(3, instructions.Count);
-            Assert.AreEqual(i1, instructions[0]);
-            Assert.AreEqual(i2, instructions[1]);
-            Assert.AreEqual(Instruction.Div(), instructions[2]);
+            Assert.AreEqual(3, nm.Instructions.Count);
+            Assert.AreEqual(i1, nm.Instructions[0]);
+            Assert.AreEqual(i2, nm.Instructions[1]);
+            Assert.AreEqual(Instruction.Div(), nm.Instructions[2]);
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/DupIlExpressionT/DupIlExpressionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/DupIlExpressionT/DupIlExpressionTest.cs
@@ -1,0 +1,57 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2021 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using System;
+using MetaphysicsIndustries.Solus.Compiler.IlExpressions;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.DupIlExpressionT
+{
+    [TestFixture]
+    public class DupIlExpressionTest
+    {
+        [Test]
+        public void ConstructorCreatesInstance()
+        {
+            // given
+            var target = new MockIlExpression();
+            // when
+            var result = new DupIlExpression(target);
+            // then
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOf<DupIlExpression>(result);
+            Assert.AreSame(target, result.Target);
+        }
+
+        [Test]
+        public void ConstructorNullTargettThrows()
+        {
+            // expect
+            var ex = Assert.Throws<ArgumentNullException>(
+                () => new DupIlExpression(null));
+            // and
+            Assert.AreEqual(
+                "Value cannot be null.\nParameter name: target",
+                ex.Message);
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/DupIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/DupIlExpressionT/GetInstructionsTest.cs
@@ -38,14 +38,14 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var i1 = Instruction.LoadConstant(1);
             var expr = new DupIlExpression(
                 new MockIlExpression(il => il.Add(i1)));
-            var instructions = new List<Instruction>();
+            var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, instructions.Count);
+            Assert.AreEqual(0, nm.Instructions.Count);
             // when
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(1, instructions.Count);
-            Assert.AreEqual(Instruction.Dup(), instructions[0]);
+            Assert.AreEqual(1, nm.Instructions.Count);
+            Assert.AreEqual(Instruction.Dup(), nm.Instructions[0]);
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/DupIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/DupIlExpressionT/GetInstructionsTest.cs
@@ -1,0 +1,51 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2021 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using System.Collections.Generic;
+using MetaphysicsIndustries.Solus.Compiler;
+using MetaphysicsIndustries.Solus.Compiler.IlExpressions;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
+    DupIlExpressionT
+{
+    [TestFixture]
+    public class GetInstructionsTest
+    {
+        [Test]
+        public void GetInstructionsAddsToList()
+        {
+            // given
+            var i1 = Instruction.LoadConstant(1);
+            var expr = new DupIlExpression(
+                new MockIlExpression(il => il.Add(i1)));
+            var instructions = new List<Instruction>();
+            // precondition
+            Assert.AreEqual(0, instructions.Count);
+            // when
+            expr.GetInstructions(instructions);
+            // then
+            Assert.AreEqual(1, instructions.Count);
+            Assert.AreEqual(Instruction.Dup(), instructions[0]);
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/IlExpressionSequenceT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/IlExpressionSequenceT/GetInstructionsTest.cs
@@ -40,13 +40,13 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
                     il => il.Add(Instruction.Add())),
                 new MockIlExpression(
                     il => il.Add(Instruction.Div())));
-            var instructions = new List<Instruction>();
+            var nm = new NascentMethod();
             // when
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(2, instructions.Count);
-            Assert.AreEqual(Instruction.Add(), instructions[0]);
-            Assert.AreEqual(Instruction.Div(), instructions[1]);
+            Assert.AreEqual(2, nm.Instructions.Count);
+            Assert.AreEqual(Instruction.Add(), nm.Instructions[0]);
+            Assert.AreEqual(Instruction.Div(), nm.Instructions[1]);
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/LoadConstantIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/LoadConstantIlExpressionT/GetInstructionsTest.cs
@@ -36,17 +36,17 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.LoadConstant
         {
             // given
             var expr = new LoadConstantIlExpression(1.0d);
-            var instructions = new List<Instruction>();
+            var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, instructions.Count);
+            Assert.AreEqual(0, nm.Instructions.Count);
             // when
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(1, instructions.Count);
+            Assert.AreEqual(1, nm.Instructions.Count);
             Assert.AreEqual(Instruction.LoadConstant(1.0d),
-                instructions[0]);
-            Assert.AreEqual(expr.Instruction, instructions[0]);
-            Assert.AreEqual(OpCodes.Ldc_R8, instructions[0].OpCode);
+                nm.Instructions[0]);
+            Assert.AreEqual(expr.Instruction, nm.Instructions[0]);
+            Assert.AreEqual(OpCodes.Ldc_R8, nm.Instructions[0].OpCode);
         }
 
         [Test]
@@ -54,17 +54,17 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.LoadConstant
         {
             // given
             var expr = new LoadConstantIlExpression(1.0f);
-            var instructions = new List<Instruction>();
+            var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, instructions.Count);
+            Assert.AreEqual(0, nm.Instructions.Count);
             // when
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(1, instructions.Count);
+            Assert.AreEqual(1, nm.Instructions.Count);
             Assert.AreEqual(Instruction.LoadConstant(1.0f),
-                instructions[0]);
-            Assert.AreEqual(expr.Instruction, instructions[0]);
-            Assert.AreEqual(OpCodes.Ldc_R4, instructions[0].OpCode);
+                nm.Instructions[0]);
+            Assert.AreEqual(expr.Instruction, nm.Instructions[0]);
+            Assert.AreEqual(OpCodes.Ldc_R4, nm.Instructions[0].OpCode);
         }
 
         [Test]
@@ -72,17 +72,17 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.LoadConstant
         {
             // given
             var expr = new LoadConstantIlExpression(129);
-            var instructions = new List<Instruction>();
+            var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, instructions.Count);
+            Assert.AreEqual(0, nm.Instructions.Count);
             // when
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(1, instructions.Count);
+            Assert.AreEqual(1, nm.Instructions.Count);
             Assert.AreEqual(Instruction.LoadConstant(129),
-                instructions[0]);
-            Assert.AreEqual(expr.Instruction, instructions[0]);
-            Assert.AreEqual(OpCodes.Ldc_I4, instructions[0].OpCode);
+                nm.Instructions[0]);
+            Assert.AreEqual(expr.Instruction, nm.Instructions[0]);
+            Assert.AreEqual(OpCodes.Ldc_I4, nm.Instructions[0].OpCode);
         }
 
         [Test]
@@ -90,17 +90,17 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.LoadConstant
         {
             // given
             var expr = new LoadConstantIlExpression(0);
-            var instructions = new List<Instruction>();
+            var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, instructions.Count);
+            Assert.AreEqual(0, nm.Instructions.Count);
             // when
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(1, instructions.Count);
+            Assert.AreEqual(1, nm.Instructions.Count);
             Assert.AreEqual(Instruction.LoadConstant(0),
-                instructions[0]);
-            Assert.AreEqual(expr.Instruction, instructions[0]);
-            Assert.AreEqual(OpCodes.Ldc_I4_0, instructions[0].OpCode);
+                nm.Instructions[0]);
+            Assert.AreEqual(expr.Instruction, nm.Instructions[0]);
+            Assert.AreEqual(OpCodes.Ldc_I4_0, nm.Instructions[0].OpCode);
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/LoadLocalIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/LoadLocalIlExpressionT/GetInstructionsTest.cs
@@ -1,0 +1,102 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2021 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using System.Collections.Generic;
+using System.Reflection.Emit;
+using MetaphysicsIndustries.Solus.Compiler;
+using MetaphysicsIndustries.Solus.Compiler.IlExpressions;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.LoadLocalIlExpressionT
+{
+    [TestFixture]
+    public class GetInstructionsTest
+    {
+        private static readonly OpCode[] OpCodeValues =
+        {
+            OpCodes.Ldloc_0,
+            OpCodes.Ldloc_1,
+            OpCodes.Ldloc_2,
+            OpCodes.Ldloc_3,
+        };
+
+        [Test]
+        [TestCase(0)]
+        [TestCase(1)]
+        [TestCase(2)]
+        [TestCase(3)]
+        public void SmallNumberYieldsSpecialOpCode(byte arg)
+        {
+            // given
+            var expr = new LoadLocalIlExpression(arg);
+            var instructions = new List<Instruction>();
+            var opcode = OpCodeValues[arg];
+            // precondition
+            Assert.AreEqual(0, instructions.Count);
+            // when
+            expr.GetInstructions(instructions);
+            // then
+            Assert.AreEqual(1, instructions.Count);
+            Assert.AreEqual(Instruction.LoadLocalVariable(arg),
+                instructions[0]);
+            Assert.AreEqual(opcode, instructions[0].OpCode);
+        }
+
+        [Test]
+        [TestCase((ushort)4)]
+        [TestCase((ushort)255)]
+        public void ShortNumberYieldsShortOpCode(ushort arg)
+        {
+            // given
+            var expr = new LoadLocalIlExpression(arg);
+            var instructions = new List<Instruction>();
+            // precondition
+            Assert.AreEqual(0, instructions.Count);
+            // when
+            expr.GetInstructions(instructions);
+            // then
+            Assert.AreEqual(1, instructions.Count);
+            Assert.AreEqual(Instruction.LoadLocalVariable(arg),
+                instructions[0]);
+            Assert.AreEqual(OpCodes.Ldloc_S, instructions[0].OpCode);
+        }
+
+        [Test]
+        [TestCase((ushort)256)]
+        [TestCase((ushort)65535)]
+        public void NormalNumberYieldsNormalOpCode(ushort arg)
+        {
+            // given
+            var expr = new LoadLocalIlExpression(arg);
+            var instructions = new List<Instruction>();
+            // precondition
+            Assert.AreEqual(0, instructions.Count);
+            // when
+            expr.GetInstructions(instructions);
+            // then
+            Assert.AreEqual(1, instructions.Count);
+            Assert.AreEqual(Instruction.LoadLocalVariable(arg),
+                instructions[0]);
+            Assert.AreEqual(OpCodes.Ldloc, instructions[0].OpCode);
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/LoadLocalIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/LoadLocalIlExpressionT/GetInstructionsTest.cs
@@ -48,17 +48,17 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.LoadLocalIlE
         {
             // given
             var expr = new LoadLocalIlExpression(arg);
-            var instructions = new List<Instruction>();
+            var nm = new NascentMethod();
             var opcode = OpCodeValues[arg];
             // precondition
-            Assert.AreEqual(0, instructions.Count);
+            Assert.AreEqual(0, nm.Instructions.Count);
             // when
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(1, instructions.Count);
+            Assert.AreEqual(1, nm.Instructions.Count);
             Assert.AreEqual(Instruction.LoadLocalVariable(arg),
-                instructions[0]);
-            Assert.AreEqual(opcode, instructions[0].OpCode);
+                nm.Instructions[0]);
+            Assert.AreEqual(opcode, nm.Instructions[0].OpCode);
         }
 
         [Test]
@@ -68,16 +68,16 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.LoadLocalIlE
         {
             // given
             var expr = new LoadLocalIlExpression(arg);
-            var instructions = new List<Instruction>();
+            var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, instructions.Count);
+            Assert.AreEqual(0, nm.Instructions.Count);
             // when
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(1, instructions.Count);
+            Assert.AreEqual(1, nm.Instructions.Count);
             Assert.AreEqual(Instruction.LoadLocalVariable(arg),
-                instructions[0]);
-            Assert.AreEqual(OpCodes.Ldloc_S, instructions[0].OpCode);
+                nm.Instructions[0]);
+            Assert.AreEqual(OpCodes.Ldloc_S, nm.Instructions[0].OpCode);
         }
 
         [Test]
@@ -87,16 +87,16 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.LoadLocalIlE
         {
             // given
             var expr = new LoadLocalIlExpression(arg);
-            var instructions = new List<Instruction>();
+            var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, instructions.Count);
+            Assert.AreEqual(0, nm.Instructions.Count);
             // when
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(1, instructions.Count);
+            Assert.AreEqual(1, nm.Instructions.Count);
             Assert.AreEqual(Instruction.LoadLocalVariable(arg),
-                instructions[0]);
-            Assert.AreEqual(OpCodes.Ldloc, instructions[0].OpCode);
+                nm.Instructions[0]);
+            Assert.AreEqual(OpCodes.Ldloc, nm.Instructions[0].OpCode);
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/LoadLocalIlExpressionT/LoadLocalIlExpressionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/LoadLocalIlExpressionT/LoadLocalIlExpressionTest.cs
@@ -1,0 +1,42 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2021 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using System.Reflection.Emit;
+using MetaphysicsIndustries.Solus.Compiler.IlExpressions;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.LoadLocalIlExpressionT
+{
+    [TestFixture]
+    public class LoadLocalIlExpressionTest
+    {
+        [Test]
+        public void ConstructorCreatesInstance()
+        {
+            // when
+            var result = new LoadLocalIlExpression(23);
+            // then
+            Assert.IsNotNull(result);
+            Assert.AreEqual(23, result.VarNumber);
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/MockIlExpression.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/MockIlExpression.cs
@@ -36,9 +36,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT
         }
 
         public Action<IList<Instruction>> GetInstructionsF;
-        public override void GetInstructions(IList<Instruction> instructions)
+        public override void GetInstructions(NascentMethod nm)
         {
-            GetInstructionsF?.Invoke(instructions);
+            GetInstructionsF?.Invoke(nm.Instructions);
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/MulIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/MulIlExpressionT/GetInstructionsTest.cs
@@ -39,16 +39,16 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.MulIlExpress
             var expr = new MulIlExpression(
                 new MockIlExpression(il => il.Add(i1)),
                 new MockIlExpression(il => il.Add(i2)));
-            var instructions = new List<Instruction>();
+            var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, instructions.Count);
+            Assert.AreEqual(0, nm.Instructions.Count);
             // when
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(3, instructions.Count);
-            Assert.AreEqual(i1, instructions[0]);
-            Assert.AreEqual(i2, instructions[1]);
-            Assert.AreEqual(Instruction.Mul(), instructions[2]);
+            Assert.AreEqual(3, nm.Instructions.Count);
+            Assert.AreEqual(i1, nm.Instructions[0]);
+            Assert.AreEqual(i2, nm.Instructions[1]);
+            Assert.AreEqual(Instruction.Mul(), nm.Instructions[2]);
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/NegIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/NegIlExpressionT/GetInstructionsTest.cs
@@ -37,15 +37,15 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.NegIlExpress
             var i1 = Instruction.LoadConstant(1);
             var expr = new NegIlExpression(
                 new MockIlExpression(il => il.Add(i1)));
-            var instructions = new List<Instruction>();
+            var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, instructions.Count);
+            Assert.AreEqual(0, nm.Instructions.Count);
             // when
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(2, instructions.Count);
-            Assert.AreEqual(i1, instructions[0]);
-            Assert.AreEqual(Instruction.Neg(), instructions[1]);
+            Assert.AreEqual(2, nm.Instructions.Count);
+            Assert.AreEqual(i1, nm.Instructions[0]);
+            Assert.AreEqual(Instruction.Neg(), nm.Instructions[1]);
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/NegIlExpressionT/NegIlExpressionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/NegIlExpressionT/NegIlExpressionTest.cs
@@ -43,7 +43,7 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.NegIlExpress
         }
 
         [Test]
-        public void ConstructorNullArgumenttThrows()
+        public void ConstructorNullArgumentThrows()
         {
             // expect
             var ex = Assert.Throws<ArgumentNullException>(

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/OrIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/OrIlExpressionT/GetInstructionsTest.cs
@@ -39,16 +39,16 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.OrIlExpressi
             var expr = new OrIlExpression(
                 new MockIlExpression(il => il.Add(i1)),
                 new MockIlExpression(il => il.Add(i2)));
-            var instructions = new List<Instruction>();
+            var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, instructions.Count);
+            Assert.AreEqual(0, nm.Instructions.Count);
             // when
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(3, instructions.Count);
-            Assert.AreEqual(i1, instructions[0]);
-            Assert.AreEqual(i2, instructions[1]);
-            Assert.AreEqual(Instruction.Or(), instructions[2]);
+            Assert.AreEqual(3, nm.Instructions.Count);
+            Assert.AreEqual(i1, nm.Instructions[0]);
+            Assert.AreEqual(i2, nm.Instructions[1]);
+            Assert.AreEqual(Instruction.Or(), nm.Instructions[2]);
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/RawInstructionsT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/RawInstructionsT/GetInstructionsTest.cs
@@ -37,13 +37,13 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.RawInstructi
             var expr = new RawInstructions(
                 Instruction.Add(),
                 Instruction.Div());
-            var instructions = new List<Instruction>();
+            var nm = new NascentMethod();
             // when
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(2, instructions.Count);
-            Assert.AreEqual(Instruction.Add(), instructions[0]);
-            Assert.AreEqual(Instruction.Div(), instructions[1]);
+            Assert.AreEqual(2, nm.Instructions.Count);
+            Assert.AreEqual(Instruction.Add(), nm.Instructions[0]);
+            Assert.AreEqual(Instruction.Div(), nm.Instructions[1]);
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/RemIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/RemIlExpressionT/GetInstructionsTest.cs
@@ -39,16 +39,16 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.RemIlExpress
             var expr = new RemIlExpression(
                 new MockIlExpression(il => il.Add(i1)),
                 new MockIlExpression(il => il.Add(i2)));
-            var instructions = new List<Instruction>();
+            var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, instructions.Count);
+            Assert.AreEqual(0, nm.Instructions.Count);
             // when
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(3, instructions.Count);
-            Assert.AreEqual(i1, instructions[0]);
-            Assert.AreEqual(i2, instructions[1]);
-            Assert.AreEqual(Instruction.Rem(), instructions[2]);
+            Assert.AreEqual(3, nm.Instructions.Count);
+            Assert.AreEqual(i1, nm.Instructions[0]);
+            Assert.AreEqual(i2, nm.Instructions[1]);
+            Assert.AreEqual(Instruction.Rem(), nm.Instructions[2]);
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/SubIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/SubIlExpressionT/GetInstructionsTest.cs
@@ -39,16 +39,16 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.SubIlExpress
             var expr = new SubIlExpression(
                 new MockIlExpression(il => il.Add(i1)),
                 new MockIlExpression(il => il.Add(i2)));
-            var instructions = new List<Instruction>();
+            var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, instructions.Count);
+            Assert.AreEqual(0, nm.Instructions.Count);
             // when
-            expr.GetInstructions(instructions);
+            expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(3, instructions.Count);
-            Assert.AreEqual(i1, instructions[0]);
-            Assert.AreEqual(i2, instructions[1]);
-            Assert.AreEqual(Instruction.Sub(), instructions[2]);
+            Assert.AreEqual(3, nm.Instructions.Count);
+            Assert.AreEqual(i1, nm.Instructions[0]);
+            Assert.AreEqual(i2, nm.Instructions[1]);
+            Assert.AreEqual(Instruction.Sub(), nm.Instructions[2]);
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/MetaphysicsIndustries.Solus.Test.csproj
+++ b/MetaphysicsIndustries.Solus.Test/MetaphysicsIndustries.Solus.Test.csproj
@@ -52,6 +52,8 @@
     <Compile Include="CompilerT\IlExpressionsT\ConvertR4IlExpressionT\GetInstructionsTest.cs" />
     <Compile Include="CompilerT\IlExpressionsT\DivIlExpressionT\DivIlExpressionTest.cs" />
     <Compile Include="CompilerT\IlExpressionsT\DivIlExpressionT\GetInstructionsTest.cs" />
+    <Compile Include="CompilerT\IlExpressionsT\DupIlExpressionT\DupIlExpressionTest.cs" />
+    <Compile Include="CompilerT\IlExpressionsT\DupIlExpressionT\GetInstructionsTest.cs" />
     <Compile Include="CompilerT\IlExpressionsT\IlExpressionSequenceT\GetInstructionsTest.cs" />
     <Compile Include="CompilerT\IlExpressionsT\IlExpressionSequenceT\IlExpressionSequenceTest.cs" />
     <Compile Include="CompilerT\IlExpressionsT\LoadConstantIlExpressionT\GetInstructionsTest.cs" />

--- a/MetaphysicsIndustries.Solus.Test/MetaphysicsIndustries.Solus.Test.csproj
+++ b/MetaphysicsIndustries.Solus.Test/MetaphysicsIndustries.Solus.Test.csproj
@@ -58,6 +58,8 @@
     <Compile Include="CompilerT\IlExpressionsT\IlExpressionSequenceT\IlExpressionSequenceTest.cs" />
     <Compile Include="CompilerT\IlExpressionsT\LoadConstantIlExpressionT\GetInstructionsTest.cs" />
     <Compile Include="CompilerT\IlExpressionsT\LoadConstantIlExpressionT\LoadConstantIlExpressionTest.cs" />
+    <Compile Include="CompilerT\IlExpressionsT\LoadLocalIlExpressionT\GetInstructionsTest.cs" />
+    <Compile Include="CompilerT\IlExpressionsT\LoadLocalIlExpressionT\LoadLocalIlExpressionTest.cs" />
     <Compile Include="CompilerT\IlExpressionsT\MockIlExpression.cs" />
     <Compile Include="CompilerT\IlExpressionsT\MulIlExpressionT\GetInstructionsTest.cs" />
     <Compile Include="CompilerT\IlExpressionsT\MulIlExpressionT\MulIlExpressionTest.cs" />

--- a/MetaphysicsIndustries.Solus.csproj
+++ b/MetaphysicsIndustries.Solus.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Compiler\IlExpressions\ConvertI4IlExpression.cs" />
     <Compile Include="Compiler\IlExpressions\ConvertR4IlExpression.cs" />
     <Compile Include="Compiler\IlExpressions\DivIlExpression.cs" />
+    <Compile Include="Compiler\IlExpressions\DupIlExpression.cs" />
     <Compile Include="Compiler\IlExpressions\IlExpression.cs" />
     <Compile Include="Compiler\IlExpressions\IlExpressionSequence.cs" />
     <Compile Include="Compiler\IlExpressions\LoadConstantIlExpression.cs" />

--- a/MetaphysicsIndustries.Solus.csproj
+++ b/MetaphysicsIndustries.Solus.csproj
@@ -78,7 +78,7 @@
     <Compile Include="Compiler\IlExpressions\RemIlExpression.cs" />
     <Compile Include="Compiler\IlExpressions\SubIlExpression.cs" />
     <Compile Include="Compiler\Instruction.cs" />
-    <Compile Include="Compiler\VariableToArgumentNumberMapper.cs" />
+    <Compile Include="Compiler\NascentMethod.cs" />
     <Compile Include="Evaluators\AggregateOp.cs" />
     <Compile Include="Evaluators\BasicEvaluator.cs" />
     <Compile Include="Evaluators\BasicEvaluator.Expressions.cs" />

--- a/MetaphysicsIndustries.Solus.csproj
+++ b/MetaphysicsIndustries.Solus.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Compiler\IlExpressions\IlExpression.cs" />
     <Compile Include="Compiler\IlExpressions\IlExpressionSequence.cs" />
     <Compile Include="Compiler\IlExpressions\LoadConstantIlExpression.cs" />
+    <Compile Include="Compiler\IlExpressions\LoadLocalIlExpression.cs" />
     <Compile Include="Compiler\IlExpressions\MulIlExpression.cs" />
     <Compile Include="Compiler\IlExpressions\NegIlExpression.cs" />
     <Compile Include="Compiler\IlExpressions\OrIlExpression.cs" />


### PR DESCRIPTION
This PR adds a couple more `IlExpression` classes and packages up the list of instructions and `VariableToArgumentNumberMapper` into a `NascentMethod` class to properly represent the method being created.