### PR TITLE
Evaluator 21: tensor expressions

### DIFF
--- a/Compiler/CompiledExpression.cs
+++ b/Compiler/CompiledExpression.cs
@@ -28,7 +28,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
 {
     public class CompiledExpression
     {
-        public Func<CompiledEnvironment, float> Method;
+        public Func<CompiledEnvironment, object> Method;
         public string[] CompiledVars;
 
         // diagnostics
@@ -37,9 +37,20 @@ namespace MetaphysicsIndustries.Solus.Compiler
         public List<Instruction> setup;
         public List<Instruction> shutdown;
 
-        public float Evaluate(CompiledEnvironment cenv)
+        public IMathObject Evaluate(CompiledEnvironment cenv)
         {
-            return (float)Method(cenv);
+            var result = Method(cenv);
+            if (result is float f)
+                return f.ToNumber();
+            if (result is float[] v)
+                return v.ToVector();
+            if (result is float[,] m)
+                return m.ToMatrix();
+            if (result is string s)
+                return s.ToStringValue();
+
+            throw new InvalidOperationException(
+                $"Unsupported result type: {result.GetType()}");
         }
     }
 }

--- a/Compiler/IlExpressions/AddIlExpression.cs
+++ b/Compiler/IlExpressions/AddIlExpression.cs
@@ -41,5 +41,15 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
             Right.GetInstructions(nm);
             nm.Instructions.Add(Instruction.Add());
         }
+
+        public override Type ResultType
+        {
+            get
+            {
+                if (Left.ResultType == Right.ResultType)
+                    return Left.ResultType;
+                return typeof(float);
+            }
+        }
     }
 }

--- a/Compiler/IlExpressions/BrFalseIlExpression.cs
+++ b/Compiler/IlExpressions/BrFalseIlExpression.cs
@@ -39,5 +39,8 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
             var label = nm.GetOrCreateExpressionLabel(Target);
             nm.Instructions.Add(Instruction.BrFalse(label));
         }
+
+        public override Type ResultType =>
+            throw new NotImplementedException();
     }
 }

--- a/Compiler/IlExpressions/BrTrueIlExpression.cs
+++ b/Compiler/IlExpressions/BrTrueIlExpression.cs
@@ -39,5 +39,8 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
             var label = nm.GetOrCreateExpressionLabel(Target);
             nm.Instructions.Add(Instruction.BrTrue(label));
         }
+
+        public override Type ResultType =>
+            throw new NotImplementedException();
     }
 }

--- a/Compiler/IlExpressions/BranchIlExpression.cs
+++ b/Compiler/IlExpressions/BranchIlExpression.cs
@@ -39,5 +39,8 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
             var label = nm.GetOrCreateExpressionLabel(Target);
             nm.Instructions.Add(Instruction.Branch(label));
         }
+
+        public override Type ResultType =>
+            throw new NotImplementedException();
     }
 }

--- a/Compiler/IlExpressions/CallIlExpression.cs
+++ b/Compiler/IlExpressions/CallIlExpression.cs
@@ -53,5 +53,7 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
             else
                 nm.Instructions.Add(Instruction.Call(Method));
         }
+
+        public override Type ResultType => Method.ReturnType;
     }
 }

--- a/Compiler/IlExpressions/CompareEqualIlExpression.cs
+++ b/Compiler/IlExpressions/CompareEqualIlExpression.cs
@@ -42,5 +42,7 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
             Right.GetInstructions(nm);
             nm.Instructions.Add(Instruction.CompareEqual());
         }
+
+        public override Type ResultType => typeof(bool);
     }
 }

--- a/Compiler/IlExpressions/CompareGreaterThanIlExpression.cs
+++ b/Compiler/IlExpressions/CompareGreaterThanIlExpression.cs
@@ -42,5 +42,7 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
             Right.GetInstructions(nm);
             nm.Instructions.Add(Instruction.CompareGreaterThan());
         }
+
+        public override Type ResultType => typeof(bool);
     }
 }

--- a/Compiler/IlExpressions/CompareLessThanIlExpression.cs
+++ b/Compiler/IlExpressions/CompareLessThanIlExpression.cs
@@ -42,5 +42,7 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
             Right.GetInstructions(nm);
             nm.Instructions.Add(Instruction.CompareLessThan());
         }
+
+        public override Type ResultType => typeof(bool);
     }
 }

--- a/Compiler/IlExpressions/ConvertI4IlExpression.cs
+++ b/Compiler/IlExpressions/ConvertI4IlExpression.cs
@@ -39,5 +39,7 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
             Argument.GetInstructions(nm);
             nm.Instructions.Add(Instruction.ConvertI4());
         }
+
+        public override Type ResultType => typeof(int);
     }
 }

--- a/Compiler/IlExpressions/ConvertR4IlExpression.cs
+++ b/Compiler/IlExpressions/ConvertR4IlExpression.cs
@@ -39,5 +39,7 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
             Argument.GetInstructions(nm);
             nm.Instructions.Add(Instruction.ConvertR4());
         }
+
+        public override Type ResultType => typeof(float);
     }
 }

--- a/Compiler/IlExpressions/DivIlExpression.cs
+++ b/Compiler/IlExpressions/DivIlExpression.cs
@@ -43,5 +43,15 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
             Divisor.GetInstructions(nm);
             nm.Instructions.Add(Instruction.Div());
         }
+
+        public override Type ResultType
+        {
+            get
+            {
+                if (Dividend.ResultType == Divisor.ResultType)
+                    return Dividend.ResultType;
+                return typeof(float);
+            }
+        }
     }
 }

--- a/Compiler/IlExpressions/DupIlExpression.cs
+++ b/Compiler/IlExpressions/DupIlExpression.cs
@@ -37,5 +37,7 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
         {
             nm.Instructions.Add(Instruction.Dup());
         }
+
+        public override Type ResultType => Target.ResultType;
     }
 }

--- a/Compiler/IlExpressions/IlExpression.cs
+++ b/Compiler/IlExpressions/IlExpression.cs
@@ -20,6 +20,8 @@
  *
  */
 
+using System;
+
 namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 {
     public abstract class IlExpression
@@ -33,5 +35,7 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
             GetInstructionsInternal(nm);
         }
         protected abstract void GetInstructionsInternal(NascentMethod nm);
+
+        public abstract Type ResultType { get; }
     }
 }

--- a/Compiler/IlExpressions/IlExpressionSequence.cs
+++ b/Compiler/IlExpressions/IlExpressionSequence.cs
@@ -20,6 +20,7 @@
  *
  */
 
+using System;
 using System.Collections.Generic;
 
 namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
@@ -44,5 +45,8 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
             foreach (var expr in Expressions)
                 expr.GetInstructions(nm);
         }
+
+        public override Type ResultType =>
+            Expressions[Expressions.Length - 1].ResultType;
     }
 }

--- a/Compiler/IlExpressions/LoadConstantIlExpression.cs
+++ b/Compiler/IlExpressions/LoadConstantIlExpression.cs
@@ -20,6 +20,8 @@
  *
  */
 
+using System;
+
 namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 {
     public class LoadConstantIlExpression : IlExpression
@@ -36,6 +38,30 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
         protected override void GetInstructionsInternal(NascentMethod nm)
         {
             nm.Instructions.Add(Instruction);
+        }
+
+        public override Type ResultType {
+            get
+            {
+                switch (Instruction.ArgType)
+                {
+                    case Instruction.ArgumentType.I1:
+                    case Instruction.ArgumentType.I2:
+                    case Instruction.ArgumentType.I4:
+                        return typeof(int);
+                    case Instruction.ArgumentType.I8:
+                        return typeof(long);
+                    case Instruction.ArgumentType.R4:
+                        return typeof(float);
+                    case Instruction.ArgumentType.R8:
+                        return typeof(double);
+                    case Instruction.ArgumentType.String:
+                        return typeof(string);
+                }
+
+                throw new ArgumentException(
+                    $"Unsupported argument type, {Instruction.ArgType}");
+            }
         }
     }
 }

--- a/Compiler/IlExpressions/LoadElemIlExpression.cs
+++ b/Compiler/IlExpressions/LoadElemIlExpression.cs
@@ -20,6 +20,8 @@
  *
  */
 
+using System;
+
 namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 {
     public class LoadElemIlExpression : IlExpression
@@ -40,5 +42,7 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
             if (Index != null) Index.GetInstructions(nm);
             nm.Instructions.Add(Instruction.LdElem(typeof(float)));
         }
+
+        public override Type ResultType => typeof(float);
     }
 }

--- a/Compiler/IlExpressions/LoadLocalIlExpression.cs
+++ b/Compiler/IlExpressions/LoadLocalIlExpression.cs
@@ -20,6 +20,8 @@
  *
  */
 
+using System;
+
 namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 {
     public class LoadLocalIlExpression : IlExpression
@@ -36,5 +38,8 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
             var index = nm.GetIndexOfLocal(Local);
             nm.Instructions.Add(Instruction.LoadLocalVariable(index));
         }
+
+        public override Type ResultType =>
+            throw new NotImplementedException();
     }
 }

--- a/Compiler/IlExpressions/LoadNullIlExpression.cs
+++ b/Compiler/IlExpressions/LoadNullIlExpression.cs
@@ -24,32 +24,17 @@ using System;
 
 namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 {
-    public class AndIlExpression : IlExpression
+    public class LoadNullIlExpression : IlExpression
     {
-        public AndIlExpression(IlExpression left, IlExpression right)
+        public LoadNullIlExpression()
         {
-            Left = left ?? throw new ArgumentNullException(nameof(left));
-            Right = right ?? throw new ArgumentNullException(nameof(right));
         }
-
-        public IlExpression Left { get; }
-        public IlExpression Right { get; }
 
         protected override void GetInstructionsInternal(NascentMethod nm)
         {
-            Left.GetInstructions(nm);
-            Right.GetInstructions(nm);
-            nm.Instructions.Add(Instruction.And());
+            nm.Instructions.Add(Instruction.LoadNull());
         }
 
-        public override Type ResultType
-        {
-            get
-            {
-                if (Left.ResultType == Right.ResultType)
-                    return Left.ResultType;
-                return typeof(int);
-            }
-        }
+        public override Type ResultType => typeof(object);
     }
 }

--- a/Compiler/IlExpressions/LoadStringIlExpression.cs
+++ b/Compiler/IlExpressions/LoadStringIlExpression.cs
@@ -35,5 +35,7 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
         {
             nm.Instructions.Add(Instruction.LdStr(Value));
         }
+
+        public override Type ResultType => typeof(string);
     }
 }

--- a/Compiler/IlExpressions/MulIlExpression.cs
+++ b/Compiler/IlExpressions/MulIlExpression.cs
@@ -41,5 +41,15 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
             Right.GetInstructions(nm);
             nm.Instructions.Add(Instruction.Mul());
         }
+
+        public override Type ResultType
+        {
+            get
+            {
+                if (Left.ResultType == Right.ResultType)
+                    return Left.ResultType;
+                return typeof(float);
+            }
+        }
     }
 }

--- a/Compiler/IlExpressions/NegIlExpression.cs
+++ b/Compiler/IlExpressions/NegIlExpression.cs
@@ -39,5 +39,7 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
             Argument.GetInstructions(nm);
             nm.Instructions.Add(Instruction.Neg());
         }
+
+        public override Type ResultType => Argument.ResultType;
     }
 }

--- a/Compiler/IlExpressions/NewArrIlExpression.cs
+++ b/Compiler/IlExpressions/NewArrIlExpression.cs
@@ -42,5 +42,7 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
             if (Length != null) Length.GetInstructions(nm);
             nm.Instructions.Add(Instruction.NewArr(ElemType));
         }
+
+        public override Type ResultType => ElemType.MakeArrayType();
     }
 }

--- a/Compiler/IlExpressions/NewObjIlExpression.cs
+++ b/Compiler/IlExpressions/NewObjIlExpression.cs
@@ -47,5 +47,7 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
                 Arguments[i].GetInstructions(nm);
             nm.Instructions.Add(Instruction.NewObj(Constructor));
         }
+
+        public override Type ResultType => Constructor.DeclaringType;
     }
 }

--- a/Compiler/IlExpressions/NopIlExpression.cs
+++ b/Compiler/IlExpressions/NopIlExpression.cs
@@ -20,6 +20,8 @@
  *
  */
 
+using System;
+
 namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 {
     public class NopIlExpression : IlExpression
@@ -28,5 +30,7 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
         {
             nm.Instructions.Add(Instruction.Nop());
         }
+
+        public override Type ResultType => typeof(void);
     }
 }

--- a/Compiler/IlExpressions/OrIlExpression.cs
+++ b/Compiler/IlExpressions/OrIlExpression.cs
@@ -41,5 +41,15 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
             Right.GetInstructions(nm);
             nm.Instructions.Add(Instruction.Or());
         }
+
+        public override Type ResultType
+        {
+            get
+            {
+                if (Left.ResultType == Right.ResultType)
+                    return Left.ResultType;
+                return typeof(int);
+            }
+        }
     }
 }

--- a/Compiler/IlExpressions/PopIlExpression.cs
+++ b/Compiler/IlExpressions/PopIlExpression.cs
@@ -20,6 +20,8 @@
  *
  */
 
+using System;
+
 namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 {
     public class PopIlExpression : IlExpression
@@ -28,5 +30,7 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
         {
             nm.Instructions.Add(Instruction.Pop());
         }
+
+        public override Type ResultType => typeof(void);
     }
 }

--- a/Compiler/IlExpressions/RawInstructions.cs
+++ b/Compiler/IlExpressions/RawInstructions.cs
@@ -20,12 +20,20 @@
  *
  */
 
+using System;
+
 namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 {
-    public class RawInstructions:IlExpression
+    public class RawInstructions : IlExpression
     {
         public RawInstructions(params Instruction[] instructions)
+            : this(null, instructions)
         {
+        }
+        public RawInstructions(Type resultType=null,
+            params Instruction[] instructions)
+        {
+            ResultType = resultType;
             Instructions = instructions;
         }
 
@@ -37,5 +45,7 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
             for (i = 0; i < Instructions.Length; i++)
                 nm.Instructions.Add(Instructions[i]);
         }
+
+        public override Type ResultType { get; }
     }
 }

--- a/Compiler/IlExpressions/RemIlExpression.cs
+++ b/Compiler/IlExpressions/RemIlExpression.cs
@@ -43,5 +43,15 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
             Divisor.GetInstructions(nm);
             nm.Instructions.Add(Instruction.Rem());
         }
+
+        public override Type ResultType
+        {
+            get
+            {
+                if (Dividend.ResultType == Divisor.ResultType)
+                    return Dividend.ResultType;
+                return typeof(float);
+            }
+        }
     }
 }

--- a/Compiler/IlExpressions/StoreElemIlExpression.cs
+++ b/Compiler/IlExpressions/StoreElemIlExpression.cs
@@ -20,6 +20,8 @@
  *
  */
 
+using System;
+
 namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 {
     public class StoreElemIlExpression : IlExpression
@@ -43,5 +45,7 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
             if (Value != null) Value.GetInstructions(nm);
             nm.Instructions.Add(Instruction.StElem(typeof(float)));
         }
+
+        public override Type ResultType => typeof(void);
     }
 }

--- a/Compiler/IlExpressions/SubIlExpression.cs
+++ b/Compiler/IlExpressions/SubIlExpression.cs
@@ -41,5 +41,15 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
             Right.GetInstructions(nm);
             nm.Instructions.Add(Instruction.Sub());
         }
+
+        public override Type ResultType
+        {
+            get
+            {
+                if (Left.ResultType == Right.ResultType)
+                    return Left.ResultType;
+                return typeof(float);
+            }
+        }
     }
 }

--- a/Compiler/IlExpressions/ThrowIlExpression.cs
+++ b/Compiler/IlExpressions/ThrowIlExpression.cs
@@ -37,5 +37,7 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
             Argument.GetInstructions(nm);
             nm.Instructions.Add(Instruction.Throw());
         }
+
+        public override Type ResultType => typeof(void);
     }
 }

--- a/Compiler/Instruction.cs
+++ b/Compiler/Instruction.cs
@@ -100,6 +100,9 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 case ArgumentType.Label:
                     arg = LabelArg.ToString();
                     break;
+                case ArgumentType.Type:
+                    arg = $" {TypeArg}";
+                    break;
                 }
 
                 return string.Format("{0} {1}", OpCode.Name, arg);

--- a/Compiler/Instruction.cs
+++ b/Compiler/Instruction.cs
@@ -373,6 +373,9 @@ namespace MetaphysicsIndustries.Solus.Compiler
             };
         }
 
+        public static Instruction LoadNull() =>
+            new Instruction { OpCode = OpCodes.Ldnull };
+
         public static Instruction ConvertR4()
         {
             return new Instruction { OpCode = OpCodes.Conv_R4 };
@@ -380,6 +383,28 @@ namespace MetaphysicsIndustries.Solus.Compiler
 
         public static Instruction ConvertI4() =>
             new Instruction { OpCode = OpCodes.Conv_I4 };
+
+        public static Instruction Box(Type type) =>
+            new Instruction
+            {
+                OpCode = OpCodes.Box,
+                ArgType = ArgumentType.Type,
+                TypeArg = type
+            };
+        public static Instruction Unbox(Type type) =>
+            new Instruction
+            {
+                OpCode = OpCodes.Unbox,
+                ArgType = ArgumentType.Type,
+                TypeArg = type
+            };
+        public static Instruction UnboxAny(Type type) =>
+            new Instruction
+            {
+                OpCode = OpCodes.Unbox_Any,
+                ArgType = ArgumentType.Type,
+                TypeArg = type
+            };
 
         public static Instruction Return()
         {

--- a/Evaluators/CompilingEvaluator.cs
+++ b/Evaluators/CompilingEvaluator.cs
@@ -39,7 +39,7 @@ namespace MetaphysicsIndustries.Solus.Evaluators
             var compiled = _compiler.Compile(expr);
             var cenv =
                 _compiler.CompileEnvironment(compiled, env, this);
-            return compiled.Evaluate(cenv).ToNumber();
+            return compiled.Evaluate(cenv);
         }
 
         public Expression Simplify(Expression expr, SolusEnvironment env)

--- a/Expressions/ComponentAccess.cs
+++ b/Expressions/ComponentAccess.cs
@@ -156,19 +156,20 @@ namespace MetaphysicsIndustries.Solus.Expressions
             // object is known to have components all of a particular type,
             // e.g. 3-vector in R^3. otherwise, we have to evaluate the
             // indexes.
+            // For now, we assume all components are scalars.
             public ResultC(ComponentAccess ca) => _ca = ca;
             private readonly ComponentAccess _ca;
-            public bool? IsScalar(SolusEnvironment env) => null;
-            public bool? IsVector(SolusEnvironment env) => null;
-            public bool? IsMatrix(SolusEnvironment env) => null;
-            public int? GetTensorRank(SolusEnvironment env) => null;
-            public bool? IsString(SolusEnvironment env) => null;
+            public bool? IsScalar(SolusEnvironment env) => true;
+            public bool? IsVector(SolusEnvironment env) => false;
+            public bool? IsMatrix(SolusEnvironment env) => false;
+            public int? GetTensorRank(SolusEnvironment env) => 0;
+            public bool? IsString(SolusEnvironment env) => false;
             public int? GetDimension(SolusEnvironment env, int index) => null;
             public int[] GetDimensions(SolusEnvironment env) => null;
             public int? GetVectorLength(SolusEnvironment env) => null;
-            public bool? IsInterval(SolusEnvironment env) => null;
-            public bool? IsFunction(SolusEnvironment env) => null;
-            public bool? IsExpression(SolusEnvironment env) => null;
+            public bool? IsInterval(SolusEnvironment env) => false;
+            public bool? IsFunction(SolusEnvironment env) => false;
+            public bool? IsExpression(SolusEnvironment env) => false;
             public bool IsConcrete => false;
             public string DocString => "";
         }

--- a/Expressions/FunctionCall.cs
+++ b/Expressions/FunctionCall.cs
@@ -221,6 +221,14 @@ namespace MetaphysicsIndustries.Solus.Expressions
             var name = "[unknown function]";
             if (expr is VariableAccess va)
                 name = va.VariableName;
+            if (expr is Literal lit)
+            {
+                if (lit.Value.IsIsFunction(null))
+                    name = ((Function)lit.Value).Name;
+                if (lit.Value is Macro macro)
+                    name = macro.Name;
+            }
+
 
             var exprs = Arguments.ToArray();
             var strs = Array.ConvertAll(exprs, Expression.ToString);

--- a/Expressions/VariableAccess.cs
+++ b/Expressions/VariableAccess.cs
@@ -92,6 +92,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
 
             public bool? IsScalar(SolusEnvironment env)
             {
+                if (env == null) return null;
                 if (!env.ContainsVariable(_va.VariableName)) return null;
                 var varexpr = env.GetVariable(_va.VariableName);
                 if (varexpr.IsIsExpression(env))
@@ -101,6 +102,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
 
             public bool? IsVector(SolusEnvironment env)
             {
+                if (env == null) return null;
                 if (!env.ContainsVariable(_va.VariableName)) return null;
                 var varexpr = env.GetVariable(_va.VariableName);
                 if (varexpr.IsIsExpression(env))
@@ -110,6 +112,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
 
             public bool? IsMatrix(SolusEnvironment env)
             {
+                if (env == null) return null;
                 if (!env.ContainsVariable(_va.VariableName)) return null;
                 var varexpr = env.GetVariable(_va.VariableName);
                 if (varexpr.IsIsExpression(env))
@@ -119,6 +122,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
 
             public int? GetTensorRank(SolusEnvironment env)
             {
+                if (env == null) return null;
                 if (!env.ContainsVariable(_va.VariableName)) return null;
                 var varexpr = env.GetVariable(_va.VariableName);
                 if (varexpr.IsIsExpression(env))
@@ -128,6 +132,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
 
             public bool? IsString(SolusEnvironment env)
             {
+                if (env == null) return null;
                 if (!env.ContainsVariable(_va.VariableName)) return null;
                 var varexpr = env.GetVariable(_va.VariableName);
                 if (varexpr.IsIsExpression(env))
@@ -137,6 +142,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
 
             public int? GetDimension(SolusEnvironment env, int index)
             {
+                if (env == null) return null;
                 if (!env.ContainsVariable(_va.VariableName)) return null;
                 var varexpr = env.GetVariable(_va.VariableName);
                 if (varexpr.IsIsExpression(env))
@@ -146,6 +152,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
 
             public int[] GetDimensions(SolusEnvironment env)
             {
+                if (env == null) return null;
                 if (!env.ContainsVariable(_va.VariableName)) return null;
                 var varexpr = env.GetVariable(_va.VariableName);
                 if (varexpr.IsIsExpression(env))
@@ -155,6 +162,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
 
             public int? GetVectorLength(SolusEnvironment env)
             {
+                if (env == null) return null;
                 if (!env.ContainsVariable(_va.VariableName)) return null;
                 var varexpr = env.GetVariable(_va.VariableName);
                 if (varexpr.IsIsExpression(env))
@@ -164,6 +172,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
 
             public bool? IsInterval(SolusEnvironment env)
             {
+                if (env == null) return null;
                 if (!env.ContainsVariable(_va.VariableName)) return null;
                 var varexpr = env.GetVariable(_va.VariableName);
                 if (varexpr.IsIsExpression(env))
@@ -173,6 +182,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
 
             public bool? IsFunction(SolusEnvironment env)
             {
+                if (env == null) return null;
                 if (!env.ContainsVariable(_va.VariableName)) return null;
                 var varexpr = env.GetVariable(_va.VariableName);
                 if (varexpr.IsIsExpression(env))
@@ -182,6 +192,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
 
             public bool? IsExpression(SolusEnvironment env)
             {
+                if (env == null) return null;
                 if (!env.ContainsVariable(_va.VariableName)) return null;
                 var varexpr = env.GetVariable(_va.VariableName);
                 if (varexpr.IsIsExpression(env))

--- a/MathObjectHelper.cs
+++ b/MathObjectHelper.cs
@@ -88,6 +88,9 @@ namespace MetaphysicsIndustries.Solus
         public static Vector ToVector(this int[] values) =>
             new Vector(values.Select(v => (float) v).ToArray());
 
+        public static Matrix ToMatrix(this float[,] values) =>
+            new Matrix(values);
+
         public static StringValue ToStringValue(this string value) =>
             new StringValue(value);
 

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/MockIlExpression.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/MockIlExpression.cs
@@ -40,5 +40,8 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT
         {
             GetInstructionsF?.Invoke(nm.Instructions);
         }
+
+        public override Type ResultType =>
+            throw new NotImplementedException();
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/ComponentAccessT/ResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/ComponentAccessT/ResultTest.cs
@@ -29,7 +29,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
     public class ResultTest
     {
         [Test]
-        public void IsResultScalarYieldsNull1()
+        public void IsResultScalarYieldsTrue1()
         {
             // given
             var expr = new ComponentAccess(
@@ -48,11 +48,11 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = expr.Result.IsScalar(env);
             // then
-            Assert.IsNull(result);
+            Assert.IsTrue(result);
         }
 
         [Test]
-        public void IsResultScalarYieldsNull2()
+        public void IsResultScalarYieldsTrue2()
         {
             // given
             var expr = new ComponentAccess(
@@ -69,11 +69,11 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = expr.Result.IsScalar(env);
             // then
-            Assert.IsNull(result);
+            Assert.IsTrue(result);
         }
 
         [Test]
-        public void IsResultVectorYieldsNull1()
+        public void IsResultVectorYieldsFalse1()
         {
             // given
             var expr = new ComponentAccess(
@@ -92,11 +92,11 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = expr.Result.IsVector(env);
             // then
-            Assert.IsNull(result);
+            Assert.IsFalse(result);
         }
 
         [Test]
-        public void IsResultVectorYieldsNull2()
+        public void IsResultVectorYieldsFalse2()
         {
             // given
             var expr = new ComponentAccess(
@@ -115,11 +115,11 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = expr.Result.IsVector(env);
             // then
-            Assert.IsNull(result);
+            Assert.IsFalse(result);
         }
 
         [Test]
-        public void IsResultMatrixYieldsNull1()
+        public void IsResultMatrixYieldsFalse1()
         {
             // given
             var expr = new ComponentAccess(
@@ -138,11 +138,11 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = expr.Result.IsMatrix(env);
             // then
-            Assert.IsNull(result);
+            Assert.IsFalse(result);
         }
 
         [Test]
-        public void IsResultMatrixYieldsNull2()
+        public void IsResultMatrixYieldsFalse2()
         {
             // given
             var expr = new ComponentAccess(
@@ -161,11 +161,11 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = expr.Result.IsMatrix(env);
             // then
-            Assert.IsNull(result);
+            Assert.IsFalse(result);
         }
 
         [Test]
-        public void IsResultStringYieldsNull1()
+        public void IsResultStringYieldsFalse1()
         {
             // given
             var expr = new ComponentAccess(
@@ -184,11 +184,11 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = expr.Result.IsString(env);
             // then
-            Assert.IsNull(result);
+            Assert.IsFalse(result);
         }
 
         [Test]
-        public void IsResultStringYieldsNull2()
+        public void IsResultStringYieldsFalse2()
         {
             // given
             var expr = new ComponentAccess(
@@ -207,11 +207,11 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = expr.Result.IsString(env);
             // then
-            Assert.IsNull(result);
+            Assert.IsFalse(result);
         }
 
         [Test]
-        public void GetResultTensorRankYieldsNull1()
+        public void GetResultTensorRankYieldsZero1()
         {
             // given
             var expr = new ComponentAccess(
@@ -230,11 +230,11 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = expr.Result.GetTensorRank(env);
             // then
-            Assert.IsNull(result);
+            Assert.AreEqual(result, 0);
         }
 
         [Test]
-        public void GetResultTensorRankYieldsNull2()
+        public void GetResultTensorRankYieldsZero2()
         {
             // given
             var expr = new ComponentAccess(
@@ -253,7 +253,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = expr.Result.GetTensorRank(env);
             // then
-            Assert.IsNull(result);
+            Assert.AreEqual(result, 0);
         }
 
         [Test]
@@ -328,7 +328,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
         }
 
         [Test]
-        public void MatrixComponentYieldsNull()
+        public void MatrixComponentYieldsTrue()
         {
             // given
             var expr = new ComponentAccess(
@@ -350,7 +350,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = expr.Result.IsScalar(env);
             // then
-            Assert.IsNull(result);
+            Assert.IsTrue(result);
         }
 
         [Test]
@@ -369,8 +369,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             var env = new SolusEnvironment();
             // when
             var result = expr.Result.IsString(env);
-            // then
-            Assert.IsNull(result);
+            // theTruesert.IsNull(result);
         }
 
         // scalar?

--- a/MetaphysicsIndustries.Solus.csproj
+++ b/MetaphysicsIndustries.Solus.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Compiler\IlExpressions\LoadConstantIlExpression.cs" />
     <Compile Include="Compiler\IlExpressions\LoadElemIlExpression.cs" />
     <Compile Include="Compiler\IlExpressions\LoadLocalIlExpression.cs" />
+    <Compile Include="Compiler\IlExpressions\LoadNullIlExpression.cs" />
     <Compile Include="Compiler\IlExpressions\LoadStringIlExpression.cs" />
     <Compile Include="Compiler\IlExpressions\MulIlExpression.cs" />
     <Compile Include="Compiler\IlExpressions\NegIlExpression.cs" />


### PR DESCRIPTION
This PR implements `VectorExpression` and `MatrixExpression` nodes in the compiling evaluator. Additionally, it adds a `ResultType` property to `IlExpression`, to be able to determine what epilogue code to generate. It also adds the `LoadNullIlExpression` class.