### PR TITLE
Evaluator 22: Function arg checks

### DIFF
--- a/Compiler/ILCompiler.cs
+++ b/Compiler/ILCompiler.cs
@@ -593,10 +593,38 @@ namespace MetaphysicsIndustries.Solus.Compiler
             ArccosineFunction func, NascentMethod nm,
             List<Expression> arguments)
         {
+            var excType = typeof(OperandException);
+            var ctor = excType.GetConstructor(
+                new Type[] { typeof(string), typeof(Exception) });
+            var test2 = new CompareGreaterThanIlExpression(
+                new DupIlExpression(),
+                new LoadConstantIlExpression(1f));
             var expr = new CallIlExpression(
-                new Func<double, double>(Math.Acos),
-                ConvertToIlExpression(arguments[0], nm));
-            return expr;
+                new Func<double, double>(Math.Acos));
+            var seq = new List<IlExpression>();
+            var arg = ConvertToIlExpression(arguments[0], nm);
+            seq.Add(arg);
+            seq.Add(
+                new CompareLessThanIlExpression(
+                    new DupIlExpression(),
+                    new LoadConstantIlExpression(-1f)));
+            seq.Add(new BrFalseIlExpression(test2));
+            seq.Add(
+                new ThrowIlExpression(
+                    new NewObjIlExpression(
+                        ctor,
+                        new LoadStringIlExpression("Argument less than -1"),
+                        new LoadNullIlExpression())));
+            seq.Add(test2);
+            seq.Add(new BrFalseIlExpression(expr));
+            seq.Add(
+                new ThrowIlExpression(
+                    new NewObjIlExpression(ctor,
+                        new LoadStringIlExpression("Argument greater than 1"),
+                        new LoadNullIlExpression())));
+            seq.Add(expr);
+
+            return new IlExpressionSequence(seq);
         }
 
         public IlExpression ConvertToIlExpression(
@@ -626,10 +654,39 @@ namespace MetaphysicsIndustries.Solus.Compiler
             ArcsineFunction func, NascentMethod nm,
             List<Expression> arguments)
         {
+            var arg = ConvertToIlExpression(arguments[0], nm);
+
+            var excType = typeof(OperandException);
+            var ctor = excType.GetConstructor(
+                new Type[] { typeof(string), typeof(Exception) });
+
+            var checkLess = new IfThenElseConstruct(
+                new CompareLessThanIlExpression(
+                    new DupIlExpression(),
+                    new LoadConstantIlExpression(-1f)),
+                new ThrowIlExpression(
+                    new NewObjIlExpression(
+                        ctor,
+                        new LoadStringIlExpression("Argument less than -1"),
+                        new LoadNullIlExpression())));
+            var checkGreater = new IfThenElseConstruct(
+                new CompareGreaterThanIlExpression(
+                    new DupIlExpression(),
+                    new LoadConstantIlExpression(1f)),
+                new ThrowIlExpression(
+                    new NewObjIlExpression(
+                        ctor,
+                        new LoadStringIlExpression("Argument greater than 1"),
+                        new LoadNullIlExpression())));
             var expr = new CallIlExpression(
-                new Func<double, double>(Math.Asin),
-                ConvertToIlExpression(arguments[0], nm));
-            return expr;
+                new Func<double, double>(Math.Asin));
+
+            return new IlExpressionSequence(
+                arg,
+                checkLess,
+                checkGreater,
+                expr,
+                new ConvertR4IlExpression());
         }
 
         public IlExpression ConvertToIlExpression(
@@ -761,10 +818,29 @@ namespace MetaphysicsIndustries.Solus.Compiler
             DivisionOperation func, NascentMethod nm,
             List<Expression> arguments)
         {
-            var expr = new DivIlExpression(
-                ConvertToIlExpression(arguments[0], nm),
-                ConvertToIlExpression(arguments[1], nm));
-            return expr;
+            var left = ConvertToIlExpression(arguments[0], nm);
+            var right = ConvertToIlExpression(arguments[1], nm);
+
+            var excType = typeof(OperandException);
+            var ctor = excType.GetConstructor(
+                new Type[] { typeof(string), typeof(Exception) });
+
+            var checkZero = new IfThenElseConstruct(
+                new CompareEqualIlExpression(
+                    new DupIlExpression(),
+                    new LoadConstantIlExpression(0f)),
+                new ThrowIlExpression(
+                    new NewObjIlExpression(
+                        ctor,
+                        new LoadStringIlExpression("Division by zero"),
+                        new LoadNullIlExpression())));
+
+            var expr = new DivIlExpression();
+            return new IlExpressionSequence(
+                left,
+                right,
+                checkZero,
+                expr);
         }
 
         public IlExpression ConvertToIlExpression(
@@ -869,32 +945,118 @@ namespace MetaphysicsIndustries.Solus.Compiler
             Log10Function func, NascentMethod nm,
             List<Expression> arguments)
         {
+            var arg = ConvertToIlExpression(arguments[0], nm);
+
+            var excType = typeof(OperandException);
+            var ctor = excType.GetConstructor(
+                new Type[] { typeof(string), typeof(Exception) });
+
+            var checkNotPos = new IfThenElseConstruct(
+                new CompareGreaterThanIlExpression(
+                    new DupIlExpression(),
+                    new LoadConstantIlExpression(0f)),
+                elseBlock: new ThrowIlExpression(
+                    new NewObjIlExpression(
+                        ctor,
+                        new LoadStringIlExpression("Argument must be positive"),
+                        new LoadNullIlExpression())));
+
             var expr = new CallIlExpression(
-                new Func<double, double>(Math.Log10),
-                ConvertToIlExpression(arguments[0], nm));
-            return expr;
+                new Func<double, double>(Math.Log10));
+
+            return new IlExpressionSequence(
+                arg,
+                checkNotPos,
+                expr,
+                new ConvertR4IlExpression());
         }
 
         public IlExpression ConvertToIlExpression(
             Log2Function func, NascentMethod nm,
             List<Expression> arguments)
         {
+            var arg = ConvertToIlExpression(arguments[0], nm);
+
+            var excType = typeof(OperandException);
+            var ctor = excType.GetConstructor(
+                new Type[] { typeof(string), typeof(Exception) });
+
+            var checkNotPos = new IfThenElseConstruct(
+                new CompareGreaterThanIlExpression(
+                    new DupIlExpression(),
+                    new LoadConstantIlExpression(0f)),
+                elseBlock: new ThrowIlExpression(
+                    new NewObjIlExpression(
+                        ctor,
+                        new LoadStringIlExpression("Argument must be positive"),
+                        new LoadNullIlExpression())));
+
             var expr = new CallIlExpression(
                 new Func<double, double, double>(Math.Log),
-                ConvertToIlExpression(arguments[0], nm),
+                // arg,
                 new LoadConstantIlExpression(2f));
-            return expr;
+
+            return new IlExpressionSequence(
+                arg,
+                checkNotPos,
+                expr,
+                new ConvertR4IlExpression());
         }
 
         public IlExpression ConvertToIlExpression(
             LogarithmFunction func, NascentMethod nm,
             List<Expression> arguments)
         {
+            var excType = typeof(OperandException);
+            var ctor = excType.GetConstructor(
+                new Type[] { typeof(string), typeof(Exception) });
+
+            var arg = ConvertToIlExpression(arguments[0], nm);
+
+            var checkArgNotPos = new IfThenElseConstruct(
+                new CompareGreaterThanIlExpression(
+                    new DupIlExpression(),
+                    new LoadConstantIlExpression(0f)),
+                elseBlock: new ThrowIlExpression(
+                    new NewObjIlExpression(
+                        ctor,
+                        new LoadStringIlExpression("Argument must be positive"),
+                        new LoadNullIlExpression())));
+
+            var base_ = ConvertToIlExpression(arguments[1], nm);
+
+            var checkBaseNotPos = new IfThenElseConstruct(
+                new CompareGreaterThanIlExpression(
+                    new DupIlExpression(),
+                    new LoadConstantIlExpression(0f)),
+                elseBlock: new ThrowIlExpression(
+                    new NewObjIlExpression(
+                        ctor,
+                        new LoadStringIlExpression("Base must be positive"),
+                        new LoadNullIlExpression())));
+            var checkBaseNotOne = new IfThenElseConstruct(
+                new CompareEqualIlExpression(
+                    new DupIlExpression(),
+                    new LoadConstantIlExpression(1f)),
+                thenBlock: new ThrowIlExpression(
+                    new NewObjIlExpression(
+                        ctor,
+                        new LoadStringIlExpression("Base must not be one"),
+                        new LoadNullIlExpression())));
+
             var expr = new CallIlExpression(
-                new Func<double, double, double>(Math.Log),
-                ConvertToIlExpression(arguments[0], nm),
-                ConvertToIlExpression(arguments[1], nm));
-            return expr;
+                new Func<double, double, double>(Math.Log)
+                // arg,
+                // base_
+                );
+            return new IlExpressionSequence(
+                arg,
+                checkArgNotPos,
+                base_,
+                checkBaseNotPos,
+                checkBaseNotOne,
+                expr,
+                new ConvertR4IlExpression());
         }
 
         public IlExpression ConvertToIlExpression(
@@ -948,10 +1110,10 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 var calcArg = ConvertToIlExpression(arguments[i], nm);
                 var call1 = new CallIlExpression(
                     new Func<float, bool>(float.IsInfinity),
-                    new DupIlExpression(calcArg));
+                    new DupIlExpression());
                 var call2 = new CallIlExpression(
                     new Func<float, bool>(float.IsNaN),
-                    new DupIlExpression(calcArg));
+                    new DupIlExpression());
                 var pop = new PopIlExpression();
                 var br1 = new BrTrueIlExpression(pop);
                 var br2 = new BrTrueIlExpression(pop);
@@ -976,12 +1138,12 @@ namespace MetaphysicsIndustries.Solus.Compiler
             exprs.Add(
                 new CallIlExpression(
                     new Func<float, bool>(float.IsNegativeInfinity),
-                    new DupIlExpression(nop)));
-            var nop2 = new NopIlExpression();
-            exprs.Add(new BrFalseIlExpression(nop2));
+                    new DupIlExpression()));
+            var conv = new ConvertR4IlExpression();
+            exprs.Add(new BrFalseIlExpression(conv));
             exprs.Add(new PopIlExpression());
             exprs.Add(new LoadConstantIlExpression(float.NaN));
-            exprs.Add(nop2);
+            exprs.Add(conv);
 
             var seq = new IlExpressionSequence(exprs.ToArray());
             return seq;
@@ -1017,10 +1179,10 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 var calcArg = ConvertToIlExpression(arguments[i], nm);
                 var call1 = new CallIlExpression(
                     new Func<float, bool>(float.IsInfinity),
-                    new DupIlExpression(calcArg));
+                    new DupIlExpression());
                 var call2 = new CallIlExpression(
                     new Func<float, bool>(float.IsNaN),
-                    new DupIlExpression(calcArg));
+                    new DupIlExpression());
                 var pop = new PopIlExpression();
                 var br1 = new BrTrueIlExpression(pop);
                 var br2 = new BrTrueIlExpression(pop);
@@ -1046,11 +1208,11 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 new CallIlExpression(
                     new Func<float, bool>(float.IsPositiveInfinity),
                     new DupIlExpression(nop)));
-            var nop2 = new NopIlExpression();
-            exprs.Add(new BrFalseIlExpression(nop2));
+            var conv = new ConvertR4IlExpression();
+            exprs.Add(new BrFalseIlExpression(conv));
             exprs.Add(new PopIlExpression());
             exprs.Add(new LoadConstantIlExpression(float.NaN));
-            exprs.Add(nop2);
+            exprs.Add(conv);
 
             var seq = new IlExpressionSequence(exprs.ToArray());
             return seq;
@@ -1077,13 +1239,35 @@ namespace MetaphysicsIndustries.Solus.Compiler
             ModularDivision func, NascentMethod nm,
             List<Expression> arguments)
         {
+            var excType = typeof(OperandException);
+            var ctor = excType.GetConstructor(
+                new Type[] { typeof(string), typeof(Exception) });
+
+            var left =
+                new ConvertI4IlExpression(
+                    ConvertToIlExpression(arguments[0], nm));
+            var right =
+                new ConvertI4IlExpression(
+                    ConvertToIlExpression(arguments[1], nm));
+
+            var checkZero = new IfThenElseConstruct(
+                new CompareEqualIlExpression(
+                    new DupIlExpression(),
+                    new LoadConstantIlExpression(0)),
+                new ThrowIlExpression(
+                    new NewObjIlExpression(
+                        ctor,
+                        new LoadStringIlExpression("Division by zero"),
+                        new LoadNullIlExpression())));
+
             var expr = new ConvertR4IlExpression(
-                new RemIlExpression(
-                    new ConvertI4IlExpression(
-                        ConvertToIlExpression(arguments[0], nm)),
-                    new ConvertI4IlExpression(
-                        ConvertToIlExpression(arguments[1], nm))));
-            return expr;
+                new RemIlExpression());
+
+            return new IlExpressionSequence(
+                left,
+                right,
+                checkZero,
+                expr);
         }
 
         public IlExpression ConvertToIlExpression(
@@ -1104,10 +1288,30 @@ namespace MetaphysicsIndustries.Solus.Compiler
             NascentMethod nm,
             List<Expression> arguments)
         {
+
+            var excType = typeof(OperandException);
+            var ctor = excType.GetConstructor(
+                new Type[] { typeof(string), typeof(Exception) });
+
+            var arg = ConvertToIlExpression(arguments[0], nm);
+
+            var checkNotPos = new IfThenElseConstruct(
+                new CompareGreaterThanIlExpression(
+                    new DupIlExpression(),
+                    new LoadConstantIlExpression(0f)),
+                elseBlock: new ThrowIlExpression(
+                    new NewObjIlExpression(
+                        ctor,
+                        new LoadStringIlExpression("Argument must be positive"),
+                        new LoadNullIlExpression())));
+
             var expr = new CallIlExpression(
-                new Func<double, double>(Math.Log),
-                ConvertToIlExpression(arguments[0], nm));
-            return expr;
+                new Func<double, double>(Math.Log));
+            return new IlExpressionSequence(
+                arg,
+                checkNotPos,
+                expr,
+                new ConvertR4IlExpression());
         }
 
         public IlExpression ConvertToIlExpression(

--- a/Compiler/IlExpressions/ConvertI4IlExpression.cs
+++ b/Compiler/IlExpressions/ConvertI4IlExpression.cs
@@ -26,17 +26,17 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 {
     public class ConvertI4IlExpression : IlExpression
     {
-        public ConvertI4IlExpression(IlExpression argument)
+        public ConvertI4IlExpression(IlExpression argument = null)
         {
-            Argument = argument ??
-                       throw new ArgumentNullException(nameof(argument));
+            Argument = argument;
         }
 
         public IlExpression Argument { get; }
 
         protected override void GetInstructionsInternal(NascentMethod nm)
         {
-            Argument.GetInstructions(nm);
+            if (Argument != null)
+                Argument.GetInstructions(nm);
             nm.Instructions.Add(Instruction.ConvertI4());
         }
 

--- a/Compiler/IlExpressions/ConvertR4IlExpression.cs
+++ b/Compiler/IlExpressions/ConvertR4IlExpression.cs
@@ -26,17 +26,17 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 {
     public class ConvertR4IlExpression : IlExpression
     {
-        public ConvertR4IlExpression(IlExpression argument)
+        public ConvertR4IlExpression(IlExpression argument=null)
         {
-            Argument = argument ??
-                       throw new ArgumentNullException(nameof(argument));
+            Argument = argument;
         }
 
         public IlExpression Argument { get; }
 
         protected override void GetInstructionsInternal(NascentMethod nm)
         {
-            Argument.GetInstructions(nm);
+            if (Argument != null)
+                Argument.GetInstructions(nm);
             nm.Instructions.Add(Instruction.ConvertR4());
         }
 

--- a/Compiler/IlExpressions/DivIlExpression.cs
+++ b/Compiler/IlExpressions/DivIlExpression.cs
@@ -26,12 +26,11 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 {
     public class DivIlExpression : IlExpression
     {
-        public DivIlExpression(IlExpression dividend, IlExpression divisor)
+        public DivIlExpression(IlExpression dividend=null,
+            IlExpression divisor=null)
         {
-            Dividend = dividend ??
-                       throw new ArgumentNullException(nameof(dividend));
-            Divisor = divisor ??
-                      throw new ArgumentNullException(nameof(divisor));
+            Dividend = dividend;
+            Divisor = divisor;
         }
 
         public IlExpression Dividend { get; }
@@ -39,8 +38,10 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 
         protected override void GetInstructionsInternal(NascentMethod nm)
         {
-            Dividend.GetInstructions(nm);
-            Divisor.GetInstructions(nm);
+            if (Dividend != null)
+                Dividend.GetInstructions(nm);
+            if (Divisor != null)
+                Divisor.GetInstructions(nm);
             nm.Instructions.Add(Instruction.Div());
         }
 
@@ -48,7 +49,9 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
         {
             get
             {
-                if (Dividend.ResultType == Divisor.ResultType)
+                if (Dividend != null &&
+                    Divisor != null &&
+                    Dividend.ResultType == Divisor.ResultType)
                     return Dividend.ResultType;
                 return typeof(float);
             }

--- a/Compiler/IlExpressions/IfThenElseConstruct.cs
+++ b/Compiler/IlExpressions/IfThenElseConstruct.cs
@@ -1,0 +1,59 @@
+using System;
+
+namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
+{
+    public class IfThenElseConstruct : IlExpression
+    {
+        public IfThenElseConstruct(IlExpression condition=null,
+            IlExpression thenBlock=null, IlExpression elseBlock=null)
+        {
+            Condition = condition;
+            ThenBlock = thenBlock;
+            ElseBlock = elseBlock;
+        }
+
+        public IlExpression Condition { get; }
+        public IlExpression ThenBlock { get; }
+        public IlExpression ElseBlock { get; }
+
+        protected override void GetInstructionsInternal(NascentMethod nm)
+        {
+            if (Condition != null)
+                Condition.GetInstructions(nm);
+            if (ThenBlock != null && ElseBlock != null)
+            {
+                var nop = new NopIlExpression();
+                var br1 = new BrFalseIlExpression(ElseBlock);
+                br1.GetInstructions(nm);
+                ThenBlock.GetInstructions(nm);
+                var br2 = new BranchIlExpression(nop);
+                br2.GetInstructions(nm);
+                ElseBlock.GetInstructions(nm);
+                nop.GetInstructions(nm);
+            }
+            else if (ThenBlock != null)
+            {
+                var nop = new NopIlExpression();
+                var br = new BrFalseIlExpression(nop);
+                br.GetInstructions(nm);
+                ThenBlock.GetInstructions(nm);
+                nop.GetInstructions(nm);
+            }
+            else if (ElseBlock != null)
+            {
+                var nop = new NopIlExpression();
+                var br = new BrTrueIlExpression(nop);
+                br.GetInstructions(nm);
+                ElseBlock.GetInstructions(nm);
+                nop.GetInstructions(nm);
+            }
+            else
+            {
+                nm.Instructions.Add(Instruction.Pop());
+            }
+        }
+
+        public override Type ResultType =>
+            throw new NotImplementedException();
+    }
+}

--- a/Compiler/IlExpressions/RemIlExpression.cs
+++ b/Compiler/IlExpressions/RemIlExpression.cs
@@ -26,12 +26,11 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 {
     public class RemIlExpression : IlExpression
     {
-        public RemIlExpression(IlExpression dividend, IlExpression divisor)
+        public RemIlExpression(IlExpression dividend=null,
+            IlExpression divisor=null)
         {
-            Dividend = dividend ??
-                       throw new ArgumentNullException(nameof(dividend));
-            Divisor = divisor ??
-                      throw new ArgumentNullException(nameof(divisor));
+            Dividend = dividend;
+            Divisor = divisor;
         }
 
         public IlExpression Dividend { get; }
@@ -39,8 +38,10 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
 
         protected override void GetInstructionsInternal(NascentMethod nm)
         {
-            Dividend.GetInstructions(nm);
-            Divisor.GetInstructions(nm);
+            if (Dividend != null)
+                Dividend.GetInstructions(nm);
+            if (Divisor != null)
+                Divisor.GetInstructions(nm);
             nm.Instructions.Add(Instruction.Rem());
         }
 
@@ -48,7 +49,9 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
         {
             get
             {
-                if (Dividend.ResultType == Divisor.ResultType)
+                if (Dividend != null &&
+                    Divisor != null &&
+                    Dividend.ResultType == Divisor.ResultType)
                     return Dividend.ResultType;
                 return typeof(float);
             }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/ConvertI4IlExpressionT/ConvertI4IlExpressionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/ConvertI4IlExpressionT/ConvertI4IlExpressionTest.cs
@@ -44,15 +44,14 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
         }
 
         [Test]
-        public void ConstructorNullArgumentThrows()
+        public void ConstructorNullArgumentDoesNotDoesNotThrow()
         {
-            // expect
-            var ex = Assert.Throws<ArgumentNullException>(
-                () => new ConvertI4IlExpression(null));
-            // and
-            Assert.AreEqual(
-                "Value cannot be null.\nParameter name: argument",
-                ex.Message);
+            // when
+            var result = new ConvertI4IlExpression(null);
+            // then
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOf<ConvertI4IlExpression>(result);
+            Assert.IsNull(result.Argument);
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/ConvertR4IlExpressionT/ConvertR4IlExpressionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/ConvertR4IlExpressionT/ConvertR4IlExpressionTest.cs
@@ -44,15 +44,14 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
         }
 
         [Test]
-        public void ConstructorNullArgumentThrows()
+        public void ConstructorNullArgumentDoesNotThrow()
         {
-            // expect
-            var ex = Assert.Throws<ArgumentNullException>(
-                () => new ConvertR4IlExpression(null));
-            // and
-            Assert.AreEqual(
-                "Value cannot be null.\nParameter name: argument",
-                ex.Message);
+            // when
+            var result = new ConvertR4IlExpression(null);
+            // then
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOf<ConvertR4IlExpression>(result);
+            Assert.IsNull(result.Argument);
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/DivIlExpressionT/DivIlExpressionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/DivIlExpressionT/DivIlExpressionTest.cs
@@ -46,43 +46,43 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
         }
 
         [Test]
-        public void ConstructorNullDividendThrows()
+        public void ConstructorNullDividendDoesNotThrow()
         {
             // given
             var divisor = new MockIlExpression();
-            // expect
-            var ex = Assert.Throws<ArgumentNullException>(
-                () => new DivIlExpression(null, divisor));
-            // and
-            Assert.AreEqual(
-                "Value cannot be null.\nParameter name: dividend",
-                ex.Message);
+            // when
+            var result = new DivIlExpression(null, divisor);
+            // then
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOf<DivIlExpression>(result);
+            Assert.IsNull(result.Dividend);
+            Assert.AreSame(divisor, result.Divisor);
         }
 
         [Test]
-        public void ConstructorNullDivisorThrows()
+        public void ConstructorNullDivisorDoesNotThrow()
         {
             // given
             var dividend = new MockIlExpression();
-            // expect
-            var ex = Assert.Throws<ArgumentNullException>(
-                () => new DivIlExpression(dividend, null));
-            // and
-            Assert.AreEqual(
-                "Value cannot be null.\nParameter name: divisor",
-                ex.Message);
+            // when
+            var result = new DivIlExpression(dividend, null);
+            // then
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOf<DivIlExpression>(result);
+            Assert.AreSame(dividend, result.Dividend);
+            Assert.IsNull(result.Divisor);
         }
 
         [Test]
-        public void ConstructorNullBothThrows()
+        public void ConstructorNullBothDoesNotThrow()
         {
             // expect
-            var ex = Assert.Throws<ArgumentNullException>(
-                () => new DivIlExpression(null, null));
-            // and
-            Assert.AreEqual(
-                "Value cannot be null.\nParameter name: dividend",
-                ex.Message);
+            var result = new DivIlExpression(null, null);
+            // then
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOf<DivIlExpression>(result);
+            Assert.IsNull(result.Dividend);
+            Assert.IsNull(result.Divisor);
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/RemIlExpressionT/RemIlExpressionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/RemIlExpressionT/RemIlExpressionTest.cs
@@ -46,43 +46,43 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
         }
 
         [Test]
-        public void ConstructorNullDividendThrows()
+        public void ConstructorNullDividendDoesNotThrow()
         {
             // given
             var divisor = new MockIlExpression();
             // expect
-            var ex = Assert.Throws<ArgumentNullException>(
-                () => new RemIlExpression(null, divisor));
-            // and
-            Assert.AreEqual(
-                "Value cannot be null.\nParameter name: dividend",
-                ex.Message);
+            var result = new RemIlExpression(null, divisor);
+            // then
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOf<RemIlExpression>(result);
+            Assert.IsNull(result.Dividend);
+            Assert.AreSame(divisor, result.Divisor);
         }
 
         [Test]
-        public void ConstructorNullDivisorThrows()
+        public void ConstructorNullDivisorDoesNotThrow()
         {
             // given
             var dividend = new MockIlExpression();
             // expect
-            var ex = Assert.Throws<ArgumentNullException>(
-                () => new RemIlExpression(dividend, null));
-            // and
-            Assert.AreEqual(
-                "Value cannot be null.\nParameter name: divisor",
-                ex.Message);
+            var result = new RemIlExpression(dividend, null);
+            // then
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOf<RemIlExpression>(result);
+            Assert.AreSame(dividend, result.Dividend);
+            Assert.IsNull(result.Divisor);
         }
 
         [Test]
-        public void ConstructorNullBothThrows()
+        public void ConstructorNullBothDoesNotThrow()
         {
             // expect
-            var ex = Assert.Throws<ArgumentNullException>(
-                () => new RemIlExpression(null, null));
-            // and
-            Assert.AreEqual(
-                "Value cannot be null.\nParameter name: dividend",
-                ex.Message);
+            var result = new RemIlExpression(null, null);
+            // then
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOf<RemIlExpression>(result);
+            Assert.IsNull(result.Dividend);
+            Assert.IsNull(result.Divisor);
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.csproj
+++ b/MetaphysicsIndustries.Solus.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Compiler\IlExpressions\ConvertR4IlExpression.cs" />
     <Compile Include="Compiler\IlExpressions\DivIlExpression.cs" />
     <Compile Include="Compiler\IlExpressions\DupIlExpression.cs" />
+    <Compile Include="Compiler\IlExpressions\IfThenElseConstruct.cs" />
     <Compile Include="Compiler\IlExpressions\IlExpression.cs" />
     <Compile Include="Compiler\IlExpressions\IlExpressionSequence.cs" />
     <Compile Include="Compiler\IlExpressions\LoadConstantIlExpression.cs" />


### PR DESCRIPTION
This PR fixes a number of points in the compiling evaluator where functions would return results but not check the validity of inputs beforehand.