### PR TITLE
Evaluator 28: User-defined functions

### DIFF
--- a/Compiler/ILCompiler.Expressions.ComponentAccess.cs
+++ b/Compiler/ILCompiler.Expressions.ComponentAccess.cs
@@ -21,6 +21,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using MetaphysicsIndustries.Solus.Compiler.IlExpressions;
 using MetaphysicsIndustries.Solus.Exceptions;
 using MetaphysicsIndustries.Solus.Expressions;
@@ -39,15 +40,15 @@ namespace MetaphysicsIndustries.Solus.Compiler
         }
 
         public IlExpression ConvertToIlExpression(ComponentAccess expr,
-            NascentMethod nm)
+            NascentMethod nm, VariableIdentityMap variables)
         {
-            var expr2 = ConvertToIlExpression(expr.Expr, nm);
+            var expr2 = ConvertToIlExpression(expr.Expr, nm, variables);
             var indexes2 = new IlExpression[expr.Indexes.Count];
             int i;
             for (i = 0; i < indexes2.Length; i++)
             {
                 indexes2[i] = new ConvertI4IlExpression(
-                    ConvertToIlExpression(expr.Indexes[i], nm));
+                    ConvertToIlExpression(expr.Indexes[i], nm, variables));
             }
 
             // TODO: check expr.ResultType against the number of indexes

--- a/Compiler/ILCompiler.Expressions.FunctionCall.cs
+++ b/Compiler/ILCompiler.Expressions.FunctionCall.cs
@@ -21,6 +21,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using MetaphysicsIndustries.Solus.Compiler.IlExpressions;
 using MetaphysicsIndustries.Solus.Expressions;
 using MetaphysicsIndustries.Solus.Functions;
@@ -30,11 +31,12 @@ namespace MetaphysicsIndustries.Solus.Compiler
     public partial class ILCompiler
     {
         public IlExpression ConvertToIlExpression(
-            FunctionCall expr, NascentMethod nm)
+            FunctionCall expr, NascentMethod nm,
+            VariableIdentityMap variables)
         {
             if (expr.Function is Literal literal &&
                 literal.Value is Function f)
-                return ConvertToIlExpression(f, nm, expr.Arguments);
+                return ConvertToIlExpression(f, nm, variables, expr.Arguments);
 
             // TODO:
             throw new NotImplementedException(

--- a/Compiler/ILCompiler.Expressions.Literal.cs
+++ b/Compiler/ILCompiler.Expressions.Literal.cs
@@ -30,7 +30,8 @@ namespace MetaphysicsIndustries.Solus.Compiler
     public partial class ILCompiler
     {
         public IlExpression ConvertToIlExpression(
-            Literal expr, NascentMethod nm)
+            Literal expr, NascentMethod nm,
+            VariableIdentityMap variables)
         {
             if (expr.Value.IsIsScalar(null))
             {

--- a/Compiler/ILCompiler.Expressions.MatrixExpression.cs
+++ b/Compiler/ILCompiler.Expressions.MatrixExpression.cs
@@ -29,7 +29,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
     public partial class ILCompiler
     {
         public IlExpression ConvertToIlExpression(MatrixExpression expr,
-            NascentMethod nm)
+            NascentMethod nm, VariableIdentityMap variables)
         {
             var arrayType = typeof(float[,]);
             var ctor = arrayType.GetConstructor(
@@ -51,7 +51,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
                         dup,
                         new LoadConstantIlExpression(r),
                         new LoadConstantIlExpression(c),
-                        ConvertToIlExpression(expr[r, c], nm)));
+                        ConvertToIlExpression(expr[r, c], nm, variables)));
             return new IlExpressionSequence(seq);
         }
     }

--- a/Compiler/ILCompiler.Expressions.VariableAccess.cs
+++ b/Compiler/ILCompiler.Expressions.VariableAccess.cs
@@ -20,6 +20,7 @@
  *
  */
 
+using System.Collections.Generic;
 using MetaphysicsIndustries.Solus.Compiler.IlExpressions;
 using MetaphysicsIndustries.Solus.Expressions;
 
@@ -28,7 +29,8 @@ namespace MetaphysicsIndustries.Solus.Compiler
     public partial class ILCompiler
     {
         public IlExpression ConvertToIlExpression(
-            VariableAccess expr, NascentMethod nm)
+            VariableAccess expr, NascentMethod nm,
+            VariableIdentityMap variables)
         {
             var param = nm.CreateParam(expr.VariableName);
             return new LoadParamIlExpression(param);

--- a/Compiler/ILCompiler.Expressions.VariableAccess.cs
+++ b/Compiler/ILCompiler.Expressions.VariableAccess.cs
@@ -32,8 +32,15 @@ namespace MetaphysicsIndustries.Solus.Compiler
             VariableAccess expr, NascentMethod nm,
             VariableIdentityMap variables)
         {
-            var param = nm.CreateParam(expr.VariableName);
-            return new LoadParamIlExpression(param);
+            var vi = variables[expr.VariableName];
+            if (vi.Source == VariableSource.Param)
+            {
+                var param = nm.CreateParam(expr.VariableName);
+                return new LoadParamIlExpression(param);
+            }
+
+            var local = vi.LocalSource;
+            return new LoadLocalIlExpression(local);
         }
     }
 }

--- a/Compiler/ILCompiler.Expressions.VectorExpression.cs
+++ b/Compiler/ILCompiler.Expressions.VectorExpression.cs
@@ -29,7 +29,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
     public partial class ILCompiler
     {
         public IlExpression ConvertToIlExpression(VectorExpression expr,
-            NascentMethod nm)
+            NascentMethod nm, VariableIdentityMap variables)
         {
             var seq = new List<IlExpression>();
             var newarr = new NewArrIlExpression(
@@ -42,7 +42,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
                     new StoreElemIlExpression(
                         array_: new DupIlExpression(newarr),
                         index: new LoadConstantIlExpression(i),
-                        value: ConvertToIlExpression(expr[i], nm)));
+                        value: ConvertToIlExpression(expr[i], nm, variables)));
 
             return new IlExpressionSequence(seq);
         }

--- a/Compiler/ILCompiler.Expressions.cs
+++ b/Compiler/ILCompiler.Expressions.cs
@@ -21,6 +21,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using MetaphysicsIndustries.Solus.Compiler.IlExpressions;
 using MetaphysicsIndustries.Solus.Expressions;
 
@@ -29,20 +30,21 @@ namespace MetaphysicsIndustries.Solus.Compiler
     public partial class ILCompiler
     {
         public IlExpression ConvertToIlExpression(
-            Expression expr, NascentMethod nm)
+            Expression expr, NascentMethod nm,
+            VariableIdentityMap variables)
         {
             if (expr is FunctionCall call)
-                return ConvertToIlExpression(call, nm);
+                return ConvertToIlExpression(call, nm, variables);
             if (expr is Literal lit)
-                return ConvertToIlExpression(lit, nm);
+                return ConvertToIlExpression(lit, nm, variables);
             if (expr is VariableAccess va)
-                return ConvertToIlExpression(va, nm);
+                return ConvertToIlExpression(va, nm, variables);
             if (expr is ComponentAccess ca)
-                return ConvertToIlExpression(ca, nm);
+                return ConvertToIlExpression(ca, nm, variables);
             if (expr is VectorExpression ve)
-                return ConvertToIlExpression(ve, nm);
+                return ConvertToIlExpression(ve, nm, variables);
             if (expr is MatrixExpression me)
-                return ConvertToIlExpression(me, nm);
+                return ConvertToIlExpression(me, nm, variables);
             throw new ArgumentException(
                 $"Unsupported expression type: \"{expr}\"", nameof(expr));
         }

--- a/Compiler/ILCompiler.Functions.AbsoluteValueFunction.cs
+++ b/Compiler/ILCompiler.Functions.AbsoluteValueFunction.cs
@@ -32,11 +32,12 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             AbsoluteValueFunction func, NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
             return new CallIlExpression(
                 new Func<double, double>(Math.Abs),
-                ConvertToIlExpression(arguments[0], nm));
+                ConvertToIlExpression(arguments[0], nm, variables));
         }
     }
 }

--- a/Compiler/ILCompiler.Functions.AdditionOperation.cs
+++ b/Compiler/ILCompiler.Functions.AdditionOperation.cs
@@ -31,6 +31,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             AdditionOperation func, NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
             IlExpression expr = new RawInstructions();
@@ -45,15 +46,16 @@ namespace MetaphysicsIndustries.Solus.Compiler
                     f == NegationOperation.Value)
                 {
                     expr = new SubIlExpression(expr,
-                        ConvertToIlExpression(call.Arguments[0], nm));
+                        ConvertToIlExpression(call.Arguments[0], nm,
+                            variables));
                 }
                 else
                 {
                     if (first)
-                        expr = ConvertToIlExpression(arg, nm);
+                        expr = ConvertToIlExpression(arg, nm, variables);
                     else
                         expr = new AddIlExpression(expr,
-                            ConvertToIlExpression(arg, nm));
+                            ConvertToIlExpression(arg, nm, variables));
                     first = false;
                 }
             }

--- a/Compiler/ILCompiler.Functions.ArccosecantFunction.cs
+++ b/Compiler/ILCompiler.Functions.ArccosecantFunction.cs
@@ -32,6 +32,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             ArccosecantFunction func, NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new CallIlExpression(
@@ -39,7 +40,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
                     "Asin", new [] { typeof(float) }),
                 new DivIlExpression(
                     new LoadConstantIlExpression(1f),
-                    ConvertToIlExpression(arguments[0], nm)));
+                    ConvertToIlExpression(arguments[0], nm, variables)));
             return expr;
         }
     }

--- a/Compiler/ILCompiler.Functions.ArccosineFunction.cs
+++ b/Compiler/ILCompiler.Functions.ArccosineFunction.cs
@@ -33,6 +33,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             ArccosineFunction func, NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var excType = typeof(OperandException);
@@ -44,7 +45,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Acos));
             var seq = new List<IlExpression>();
-            var arg = ConvertToIlExpression(arguments[0], nm);
+            var arg = ConvertToIlExpression(arguments[0], nm, variables);
             seq.Add(arg);
             seq.Add(
                 new CompareLessThanIlExpression(

--- a/Compiler/ILCompiler.Functions.ArccotangentFunction.cs
+++ b/Compiler/ILCompiler.Functions.ArccotangentFunction.cs
@@ -32,12 +32,13 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             ArccotangentFunction func, NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new CallIlExpression(
                 new Func<double, double, double>(Math.Atan2),
                 new LoadConstantIlExpression(1f),
-                ConvertToIlExpression(arguments[0], nm));
+                ConvertToIlExpression(arguments[0], nm, variables));
             return expr;
         }
     }

--- a/Compiler/ILCompiler.Functions.ArcsecantFunction.cs
+++ b/Compiler/ILCompiler.Functions.ArcsecantFunction.cs
@@ -32,13 +32,15 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             ArcsecantFunction func, NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Acos),
                 new DivIlExpression(
                     new LoadConstantIlExpression(1f),
-                    ConvertToIlExpression(arguments[0], nm)));
+                    ConvertToIlExpression(arguments[0], nm,
+                        variables)));
             return expr;
         }
     }

--- a/Compiler/ILCompiler.Functions.ArcsineFunction.cs
+++ b/Compiler/ILCompiler.Functions.ArcsineFunction.cs
@@ -33,9 +33,10 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             ArcsineFunction func, NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
-            var arg = ConvertToIlExpression(arguments[0], nm);
+            var arg = ConvertToIlExpression(arguments[0], nm, variables);
 
             var excType = typeof(OperandException);
             var ctor = excType.GetConstructor(

--- a/Compiler/ILCompiler.Functions.Arctangent2Function.cs
+++ b/Compiler/ILCompiler.Functions.Arctangent2Function.cs
@@ -32,12 +32,13 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             Arctangent2Function func, NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new CallIlExpression(
                 new Func<double, double, double>(Math.Atan2),
-                ConvertToIlExpression(arguments[0], nm),
-                ConvertToIlExpression(arguments[1], nm));
+                ConvertToIlExpression(arguments[0], nm, variables),
+                ConvertToIlExpression(arguments[1], nm, variables));
             return expr;
         }
     }

--- a/Compiler/ILCompiler.Functions.ArctangentFunction.cs
+++ b/Compiler/ILCompiler.Functions.ArctangentFunction.cs
@@ -32,11 +32,12 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             ArctangentFunction func, NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Atan),
-                ConvertToIlExpression(arguments[0], nm));
+                ConvertToIlExpression(arguments[0], nm, variables));
             return expr;
         }
     }

--- a/Compiler/ILCompiler.Functions.BitwiseAndOperation.cs
+++ b/Compiler/ILCompiler.Functions.BitwiseAndOperation.cs
@@ -31,14 +31,17 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             BitwiseAndOperation func, NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new ConvertR4IlExpression(
                 new AndIlExpression(
                     new ConvertI4IlExpression(
-                        ConvertToIlExpression(arguments[0], nm)),
+                        ConvertToIlExpression(arguments[0], nm,
+                            variables)),
                     new ConvertI4IlExpression(
-                        ConvertToIlExpression(arguments[1], nm))));
+                        ConvertToIlExpression(arguments[1], nm,
+                            variables))));
             return expr;
         }
     }

--- a/Compiler/ILCompiler.Functions.BitwiseOrOperation.cs
+++ b/Compiler/ILCompiler.Functions.BitwiseOrOperation.cs
@@ -31,14 +31,17 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             BitwiseOrOperation func, NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new ConvertR4IlExpression(
                 new OrIlExpression(
                     new ConvertI4IlExpression(
-                        ConvertToIlExpression(arguments[0], nm)),
+                        ConvertToIlExpression(arguments[0], nm,
+                            variables)),
                     new ConvertI4IlExpression(
-                        ConvertToIlExpression(arguments[1], nm))));
+                        ConvertToIlExpression(arguments[1], nm,
+                            variables))));
             return expr;
         }
     }

--- a/Compiler/ILCompiler.Functions.CeilingFunction.cs
+++ b/Compiler/ILCompiler.Functions.CeilingFunction.cs
@@ -32,11 +32,12 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             CeilingFunction func, NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Ceiling),
-                ConvertToIlExpression(arguments[0], nm));
+                ConvertToIlExpression(arguments[0], nm, variables));
             return expr;
         }
     }

--- a/Compiler/ILCompiler.Functions.CosecantFunction.cs
+++ b/Compiler/ILCompiler.Functions.CosecantFunction.cs
@@ -32,13 +32,15 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             CosecantFunction func, NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new DivIlExpression(
                 new LoadConstantIlExpression(1f),
                 new CallIlExpression(
                     new Func<double, double>(Math.Sin),
-                    ConvertToIlExpression(arguments[0], nm)));
+                    ConvertToIlExpression(arguments[0], nm,
+                        variables)));
             return expr;
         }
     }

--- a/Compiler/ILCompiler.Functions.CosineFunction.cs
+++ b/Compiler/ILCompiler.Functions.CosineFunction.cs
@@ -32,11 +32,12 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             CosineFunction func, NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Cos),
-                ConvertToIlExpression(arguments[0], nm));
+                ConvertToIlExpression(arguments[0], nm, variables));
             return expr;
         }
     }

--- a/Compiler/ILCompiler.Functions.CotangentFunction.cs
+++ b/Compiler/ILCompiler.Functions.CotangentFunction.cs
@@ -32,13 +32,14 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             CotangentFunction func, NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new DivIlExpression(
                 new LoadConstantIlExpression(1f),
                 new CallIlExpression(
                     new Func<double, double>(Math.Tan),
-                    ConvertToIlExpression(arguments[0], nm)));
+                    ConvertToIlExpression(arguments[0], nm, variables)));
             return expr;
         }
     }

--- a/Compiler/ILCompiler.Functions.DistFunction.cs
+++ b/Compiler/ILCompiler.Functions.DistFunction.cs
@@ -32,10 +32,13 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             DistFunction func, NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
-            var x = ConvertToIlExpression(arguments[0], nm);
-            var y = ConvertToIlExpression(arguments[1], nm);
+            var x = ConvertToIlExpression(arguments[0], nm,
+                variables);
+            var y = ConvertToIlExpression(arguments[1], nm,
+                variables);
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Sqrt),
                 new AddIlExpression(

--- a/Compiler/ILCompiler.Functions.DistSqFunction.cs
+++ b/Compiler/ILCompiler.Functions.DistSqFunction.cs
@@ -31,10 +31,13 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             DistSqFunction func, NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
-            var x = ConvertToIlExpression(arguments[0], nm);
-            var y = ConvertToIlExpression(arguments[1], nm);
+            var x = ConvertToIlExpression(arguments[0], nm,
+                variables);
+            var y = ConvertToIlExpression(arguments[1], nm,
+                variables);
             var expr = new AddIlExpression(
                 new MulIlExpression(
                     x,

--- a/Compiler/ILCompiler.Functions.DivisionOperation.cs
+++ b/Compiler/ILCompiler.Functions.DivisionOperation.cs
@@ -33,10 +33,13 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             DivisionOperation func, NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
-            var left = ConvertToIlExpression(arguments[0], nm);
-            var right = ConvertToIlExpression(arguments[1], nm);
+            var left = ConvertToIlExpression(arguments[0], nm,
+                variables);
+            var right = ConvertToIlExpression(arguments[1], nm,
+                variables);
 
             var excType = typeof(OperandException);
             var ctor = excType.GetConstructor(

--- a/Compiler/ILCompiler.Functions.EqualComparisonOperation.cs
+++ b/Compiler/ILCompiler.Functions.EqualComparisonOperation.cs
@@ -32,12 +32,13 @@ namespace MetaphysicsIndustries.Solus.Compiler
         public IlExpression ConvertToIlExpression(
             EqualComparisonOperation func,
             NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new ConvertR4IlExpression(
                 new CompareEqualIlExpression(
-                    ConvertToIlExpression(arguments[0], nm),
-                    ConvertToIlExpression(arguments[1], nm)));
+                    ConvertToIlExpression(arguments[0], nm, variables),
+                    ConvertToIlExpression(arguments[1], nm, variables)));
             return expr;
         }
     }

--- a/Compiler/ILCompiler.Functions.ExponentOperation.cs
+++ b/Compiler/ILCompiler.Functions.ExponentOperation.cs
@@ -32,12 +32,13 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             ExponentOperation func, NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
             return new CallIlExpression(
                 new Func<double, double, double>(Math.Pow),
-                ConvertToIlExpression(arguments[0], nm),
-                ConvertToIlExpression(arguments[1], nm));
+                ConvertToIlExpression(arguments[0], nm, variables),
+                ConvertToIlExpression(arguments[1], nm, variables));
         }
     }
 }

--- a/Compiler/ILCompiler.Functions.FactorialFunction.cs
+++ b/Compiler/ILCompiler.Functions.FactorialFunction.cs
@@ -32,13 +32,14 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             FactorialFunction func, NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var product = nm.CreateLocal(typeof(float), "product");
             var n = nm.CreateLocal(typeof(float), "n");
             // n = ...
             var initN = new StoreLocalIlExpression(
-                n, ConvertToIlExpression(arguments[0], nm));
+                n, ConvertToIlExpression(arguments[0], nm, variables));
             // product = 1
             var initProduct = new StoreLocalIlExpression(
                 product, new LoadConstantIlExpression(1f));

--- a/Compiler/ILCompiler.Functions.FloorFunction.cs
+++ b/Compiler/ILCompiler.Functions.FloorFunction.cs
@@ -32,11 +32,12 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             FloorFunction func, NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Floor),
-                ConvertToIlExpression(arguments[0], nm));
+                ConvertToIlExpression(arguments[0], nm, variables));
             return expr;
         }
     }

--- a/Compiler/ILCompiler.Functions.GreaterThanComparisonOperation.cs
+++ b/Compiler/ILCompiler.Functions.GreaterThanComparisonOperation.cs
@@ -32,12 +32,13 @@ namespace MetaphysicsIndustries.Solus.Compiler
         public IlExpression ConvertToIlExpression(
             GreaterThanComparisonOperation func,
             NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new ConvertR4IlExpression(
                 new CompareGreaterThanIlExpression(
-                    ConvertToIlExpression(arguments[0], nm),
-                    ConvertToIlExpression(arguments[1], nm)));
+                    ConvertToIlExpression(arguments[0], nm, variables),
+                    ConvertToIlExpression(arguments[1], nm, variables)));
             return expr;
         }
     }

--- a/Compiler/ILCompiler.Functions.GreaterThanOrEqualComparisonOperation.cs
+++ b/Compiler/ILCompiler.Functions.GreaterThanOrEqualComparisonOperation.cs
@@ -32,14 +32,17 @@ namespace MetaphysicsIndustries.Solus.Compiler
         public IlExpression ConvertToIlExpression(
             GreaterThanOrEqualComparisonOperation func,
             NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new ConvertR4IlExpression(
                 new CompareEqualIlExpression(
                     new LoadConstantIlExpression(0),
                     new CompareLessThanIlExpression(
-                        ConvertToIlExpression(arguments[0], nm),
-                        ConvertToIlExpression(arguments[1], nm))));
+                        ConvertToIlExpression(arguments[0], nm,
+                            variables),
+                        ConvertToIlExpression(arguments[1], nm,
+                            variables))));
             return expr;
         }
     }

--- a/Compiler/ILCompiler.Functions.LessThanComparisonOperation.cs
+++ b/Compiler/ILCompiler.Functions.LessThanComparisonOperation.cs
@@ -32,12 +32,13 @@ namespace MetaphysicsIndustries.Solus.Compiler
         public IlExpression ConvertToIlExpression(
             LessThanComparisonOperation func,
             NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new ConvertR4IlExpression(
                 new CompareLessThanIlExpression(
-                    ConvertToIlExpression(arguments[0], nm),
-                    ConvertToIlExpression(arguments[1], nm)));
+                    ConvertToIlExpression(arguments[0], nm, variables),
+                    ConvertToIlExpression(arguments[1], nm, variables)));
             return expr;
         }
     }

--- a/Compiler/ILCompiler.Functions.LessThanOrEqualComparisonOperation.cs
+++ b/Compiler/ILCompiler.Functions.LessThanOrEqualComparisonOperation.cs
@@ -32,14 +32,17 @@ namespace MetaphysicsIndustries.Solus.Compiler
         public IlExpression ConvertToIlExpression(
             LessThanOrEqualComparisonOperation func,
             NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new ConvertR4IlExpression(
                 new CompareEqualIlExpression(
                     new LoadConstantIlExpression(0),
                     new CompareGreaterThanIlExpression(
-                        ConvertToIlExpression(arguments[0], nm),
-                        ConvertToIlExpression(arguments[1], nm))));
+                        ConvertToIlExpression(arguments[0], nm,
+                            variables),
+                        ConvertToIlExpression(arguments[1], nm,
+                            variables))));
             return expr;
         }
     }

--- a/Compiler/ILCompiler.Functions.LoadImageFunction.cs
+++ b/Compiler/ILCompiler.Functions.LoadImageFunction.cs
@@ -32,6 +32,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             LoadImageFunction func, NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
             throw new NotImplementedException();

--- a/Compiler/ILCompiler.Functions.Log10Function.cs
+++ b/Compiler/ILCompiler.Functions.Log10Function.cs
@@ -33,9 +33,11 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             Log10Function func, NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
-            var arg = ConvertToIlExpression(arguments[0], nm);
+            var arg = ConvertToIlExpression(arguments[0], nm,
+                variables);
 
             var excType = typeof(OperandException);
             var ctor = excType.GetConstructor(

--- a/Compiler/ILCompiler.Functions.Log2Function.cs
+++ b/Compiler/ILCompiler.Functions.Log2Function.cs
@@ -33,9 +33,11 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             Log2Function func, NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
-            var arg = ConvertToIlExpression(arguments[0], nm);
+            var arg = ConvertToIlExpression(arguments[0], nm,
+                variables);
 
             var excType = typeof(OperandException);
             var ctor = excType.GetConstructor(

--- a/Compiler/ILCompiler.Functions.LogarithmFunction.cs
+++ b/Compiler/ILCompiler.Functions.LogarithmFunction.cs
@@ -33,13 +33,15 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             LogarithmFunction func, NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var excType = typeof(OperandException);
             var ctor = excType.GetConstructor(
                 new Type[] { typeof(string), typeof(Exception) });
 
-            var arg = ConvertToIlExpression(arguments[0], nm);
+            var arg = ConvertToIlExpression(arguments[0], nm,
+                variables);
 
             var checkArgNotPos = new IfThenElseConstruct(
                 new CompareGreaterThanIlExpression(
@@ -52,7 +54,8 @@ namespace MetaphysicsIndustries.Solus.Compiler
                             "Argument must be positive"),
                         new LoadNullIlExpression())));
 
-            var base_ = ConvertToIlExpression(arguments[1], nm);
+            var base_ = ConvertToIlExpression(arguments[1], nm,
+                variables);
 
             var checkBaseNotPos = new IfThenElseConstruct(
                 new CompareGreaterThanIlExpression(

--- a/Compiler/ILCompiler.Functions.LogicalAndOperation.cs
+++ b/Compiler/ILCompiler.Functions.LogicalAndOperation.cs
@@ -31,6 +31,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             LogicalAndOperation func, NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new ConvertR4IlExpression(
@@ -40,11 +41,13 @@ namespace MetaphysicsIndustries.Solus.Compiler
                         new CompareEqualIlExpression(
                             new LoadConstantIlExpression(0),
                             new ConvertI4IlExpression(
-                                ConvertToIlExpression(arguments[0], nm))),
+                                ConvertToIlExpression(arguments[0],
+                                    nm, variables))),
                         new CompareEqualIlExpression(
                             new LoadConstantIlExpression(0),
                             new ConvertI4IlExpression(
-                                ConvertToIlExpression(arguments[1], nm))))));
+                                ConvertToIlExpression(arguments[1], nm,
+                                    variables))))));
             return expr;
         }
     }

--- a/Compiler/ILCompiler.Functions.LogicalOrOperation.cs
+++ b/Compiler/ILCompiler.Functions.LogicalOrOperation.cs
@@ -31,6 +31,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             LogicalOrOperation func, NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new ConvertR4IlExpression(
@@ -39,11 +40,13 @@ namespace MetaphysicsIndustries.Solus.Compiler
                         new CompareEqualIlExpression(
                             new LoadConstantIlExpression(0),
                             new ConvertI4IlExpression(
-                                ConvertToIlExpression(arguments[0], nm))),
+                                ConvertToIlExpression(arguments[0], nm,
+                                    variables))),
                         new CompareEqualIlExpression(
                             new LoadConstantIlExpression(0),
                             new ConvertI4IlExpression(
-                                ConvertToIlExpression(arguments[1], nm)))),
+                                ConvertToIlExpression(arguments[1], nm,
+                                    variables)))),
                     new LoadConstantIlExpression(2)));
             return expr;
         }

--- a/Compiler/ILCompiler.Functions.MaximumFiniteFunction.cs
+++ b/Compiler/ILCompiler.Functions.MaximumFiniteFunction.cs
@@ -32,6 +32,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             MaximumFiniteFunction func, NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var exprs = new List<IlExpression>(8 * arguments.Count + 7);
@@ -40,7 +41,8 @@ namespace MetaphysicsIndustries.Solus.Compiler
             IlExpression first = nop;
             for (int i = arguments.Count - 1; i >= 0; i--)
             {
-                var calcArg = ConvertToIlExpression(arguments[i], nm);
+                var calcArg = ConvertToIlExpression(arguments[i], nm,
+                    variables);
                 var call1 = new CallIlExpression(
                     new Func<float, bool>(float.IsInfinity),
                     new DupIlExpression());

--- a/Compiler/ILCompiler.Functions.MaximumFunction.cs
+++ b/Compiler/ILCompiler.Functions.MaximumFunction.cs
@@ -32,16 +32,18 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             MaximumFunction func, NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
-            var expr = ConvertToIlExpression(arguments[0], nm);
+            var expr = ConvertToIlExpression(arguments[0], nm,
+                variables);
             int i;
             for (i = 1; i < arguments.Count; i++)
             {
                 expr = new CallIlExpression(
                     new Func<float, float, float>(Math.Max),
                     expr,
-                    ConvertToIlExpression(arguments[i], nm));
+                    ConvertToIlExpression(arguments[i], nm, variables));
             }
 
             return expr;

--- a/Compiler/ILCompiler.Functions.MinimumFiniteFunction.cs
+++ b/Compiler/ILCompiler.Functions.MinimumFiniteFunction.cs
@@ -32,6 +32,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             MinimumFiniteFunction func, NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var exprs = new List<IlExpression>(8 * arguments.Count + 7);
@@ -40,7 +41,8 @@ namespace MetaphysicsIndustries.Solus.Compiler
             IlExpression first = nop;
             for (int i = arguments.Count - 1; i >= 0; i--)
             {
-                var calcArg = ConvertToIlExpression(arguments[i], nm);
+                var calcArg = ConvertToIlExpression(arguments[i], nm,
+                    variables);
                 var call1 = new CallIlExpression(
                     new Func<float, bool>(float.IsInfinity),
                     new DupIlExpression());

--- a/Compiler/ILCompiler.Functions.ModularDivision.cs
+++ b/Compiler/ILCompiler.Functions.ModularDivision.cs
@@ -33,6 +33,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             ModularDivision func, NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var excType = typeof(OperandException);
@@ -41,10 +42,12 @@ namespace MetaphysicsIndustries.Solus.Compiler
 
             var left =
                 new ConvertI4IlExpression(
-                    ConvertToIlExpression(arguments[0], nm));
+                    ConvertToIlExpression(arguments[0], nm,
+                        variables));
             var right =
                 new ConvertI4IlExpression(
-                    ConvertToIlExpression(arguments[1], nm));
+                    ConvertToIlExpression(arguments[1], nm,
+                        variables));
 
             var checkZero = new IfThenElseConstruct(
                 new CompareEqualIlExpression(

--- a/Compiler/ILCompiler.Functions.MultiplicationOperation.cs
+++ b/Compiler/ILCompiler.Functions.MultiplicationOperation.cs
@@ -30,15 +30,17 @@ namespace MetaphysicsIndustries.Solus.Compiler
     public partial class ILCompiler
     {
         public IlExpression ConvertToIlExpression(
-            MultiplicationOperation func,
-            NascentMethod nm, List<Expression> arguments)
+            MultiplicationOperation func, NascentMethod nm,
+            VariableIdentityMap variables,
+            List<Expression> arguments)
         {
-            var expr = ConvertToIlExpression(arguments[0], nm);
+            var expr = ConvertToIlExpression(arguments[0], nm,
+                variables);
             int i;
             for (i = 1; i < arguments.Count; i++)
                 expr = new MulIlExpression(
                     expr,
-                    ConvertToIlExpression(arguments[i], nm));
+                    ConvertToIlExpression(arguments[i], nm, variables));
             return expr;
         }
     }

--- a/Compiler/ILCompiler.Functions.NaturalLogarithmFunction.cs
+++ b/Compiler/ILCompiler.Functions.NaturalLogarithmFunction.cs
@@ -32,8 +32,8 @@ namespace MetaphysicsIndustries.Solus.Compiler
     public partial class ILCompiler
     {
         public IlExpression ConvertToIlExpression(
-            NaturalLogarithmFunction func,
-            NascentMethod nm,
+            NaturalLogarithmFunction func, NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
 
@@ -41,7 +41,8 @@ namespace MetaphysicsIndustries.Solus.Compiler
             var ctor = excType.GetConstructor(
                 new Type[] { typeof(string), typeof(Exception) });
 
-            var arg = ConvertToIlExpression(arguments[0], nm);
+            var arg = ConvertToIlExpression(arguments[0], nm,
+                variables);
 
             var checkNotPos = new IfThenElseConstruct(
                 new CompareGreaterThanIlExpression(

--- a/Compiler/ILCompiler.Functions.NegationOperation.cs
+++ b/Compiler/ILCompiler.Functions.NegationOperation.cs
@@ -31,10 +31,12 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             NegationOperation func, NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new NegIlExpression(
-                ConvertToIlExpression(arguments[0], nm));
+                ConvertToIlExpression(arguments[0], nm,
+                    variables));
             return expr;
         }
     }

--- a/Compiler/ILCompiler.Functions.NotEqualComparisonOperation.cs
+++ b/Compiler/ILCompiler.Functions.NotEqualComparisonOperation.cs
@@ -32,14 +32,16 @@ namespace MetaphysicsIndustries.Solus.Compiler
         public IlExpression ConvertToIlExpression(
             NotEqualComparisonOperation func,
             NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new ConvertR4IlExpression(
                 new CompareEqualIlExpression(
                     new LoadConstantIlExpression(0),
                     new CompareEqualIlExpression(
-                        ConvertToIlExpression(arguments[0], nm),
-                        ConvertToIlExpression(arguments[1], nm))));
+                        ConvertToIlExpression(arguments[0], nm, variables),
+                        ConvertToIlExpression(arguments[1], nm,
+                            variables))));
             return expr;
         }
     }

--- a/Compiler/ILCompiler.Functions.SecantFunction.cs
+++ b/Compiler/ILCompiler.Functions.SecantFunction.cs
@@ -32,13 +32,15 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             SecantFunction func, NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new DivIlExpression(
                 new LoadConstantIlExpression(1f),
                 new CallIlExpression(
                     new Func<double, double>(Math.Cos),
-                    ConvertToIlExpression(arguments[0], nm)));
+                    ConvertToIlExpression(arguments[0], nm,
+                        variables)));
             return expr;
         }
     }

--- a/Compiler/ILCompiler.Functions.SineFunction.cs
+++ b/Compiler/ILCompiler.Functions.SineFunction.cs
@@ -32,11 +32,13 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             SineFunction func, NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Sin),
-                ConvertToIlExpression(arguments[0], nm));
+                ConvertToIlExpression(arguments[0], nm,
+                    variables));
             return expr;
         }
     }

--- a/Compiler/ILCompiler.Functions.SizeFunction.cs
+++ b/Compiler/ILCompiler.Functions.SizeFunction.cs
@@ -32,9 +32,11 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             SizeFunction func, NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
-            var arg = ConvertToIlExpression(arguments[0], nm);
+            var arg = ConvertToIlExpression(arguments[0], nm,
+                variables);
             if (arg.ResultType == typeof(byte) ||
                 arg.ResultType == typeof(sbyte) ||
                 arg.ResultType == typeof(short) ||

--- a/Compiler/ILCompiler.Functions.TangentFunction.cs
+++ b/Compiler/ILCompiler.Functions.TangentFunction.cs
@@ -32,11 +32,12 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             TangentFunction func, NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Tan),
-                ConvertToIlExpression(arguments[0], nm));
+                ConvertToIlExpression(arguments[0], nm, variables));
             return expr;
         }
     }

--- a/Compiler/ILCompiler.Functions.UnitStepFunction.cs
+++ b/Compiler/ILCompiler.Functions.UnitStepFunction.cs
@@ -31,12 +31,13 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             UnitStepFunction func, NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new ConvertR4IlExpression(
                 new CompareLessThanIlExpression(
                     new CompareLessThanIlExpression(
-                        ConvertToIlExpression(arguments[0], nm),
+                        ConvertToIlExpression(arguments[0], nm, variables),
                         new LoadConstantIlExpression(0f)),
                     new LoadConstantIlExpression(1)));
             return expr;

--- a/Compiler/ILCompiler.Functions.UserDefinedFunction.cs
+++ b/Compiler/ILCompiler.Functions.UserDefinedFunction.cs
@@ -35,7 +35,34 @@ namespace MetaphysicsIndustries.Solus.Compiler
             VariableIdentityMap variables,
             List<Expression> arguments)
         {
-            throw new NotImplementedException();
+            // TODO: the variables in the udf definition should be
+            //       implemented as locals
+            int i;
+            var seq = new List<IlExpression>();
+            var variables2 = variables.CreateChild();
+            for (i = 0; i < func.Argnames.Length; i++)
+            {
+                var name = func.Argnames[i];
+                var value = arguments[i];
+                var arg = ConvertToIlExpression(arguments[i], nm,
+                    variables);
+                var varType = arg.ResultType;
+                var local = nm.CreateLocal(varType, name);
+                variables2.SetVariable(name, new VariableIdentity
+                {
+                    Name = name,
+                    IlType = varType,
+                    Value = value,
+                    Source = VariableSource.Local,
+                    LocalSource = local,
+                });
+                seq.Add(new StoreLocalIlExpression(local, arg));
+            }
+
+            var ilexpr = ConvertToIlExpression(func.Expression, nm,
+                variables2);
+            seq.Add(ilexpr);
+            return new IlExpressionSequence(seq);
         }
     }
 }

--- a/Compiler/ILCompiler.Functions.UserDefinedFunction.cs
+++ b/Compiler/ILCompiler.Functions.UserDefinedFunction.cs
@@ -32,6 +32,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             UserDefinedFunction func, NascentMethod nm,
+            VariableIdentityMap variables,
             List<Expression> arguments)
         {
             throw new NotImplementedException();

--- a/Compiler/ILCompiler.Functions.cs
+++ b/Compiler/ILCompiler.Functions.cs
@@ -176,6 +176,9 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 case UnitStepFunction usf:
                     return ConvertToIlExpression(usf, nm, variables,
                         arguments);
+                case UserDefinedFunction udf:
+                    return ConvertToIlExpression(udf, nm, variables,
+                        arguments);
                 default:
                     // if (func.ProvidesCustomCall)
                     // {
@@ -185,7 +188,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
                     //         args2[i] = ConvertToIlExpression(arguments[i],
                     //             nm);
                     //     var expr = new CallIlExpression(
-                    //         new Func< func.CustomCall, args2);
+                    //         func.CustomCall, args2);
                     //
                     //     var expr = ConvertToIlExpression(
                     //         arguments[0], nm);

--- a/Compiler/ILCompiler.Functions.cs
+++ b/Compiler/ILCompiler.Functions.cs
@@ -30,103 +30,152 @@ namespace MetaphysicsIndustries.Solus.Compiler
 {
     public partial class ILCompiler
     {
-        public IlExpression ConvertToIlExpression(Function func,
-            NascentMethod nm, List<Expression> arguments)
+        public IlExpression ConvertToIlExpression(
+            Function func,
+            NascentMethod nm,
+            VariableIdentityMap variables,
+            List<Expression> arguments)
         {
             switch (func)
             {
                 case AbsoluteValueFunction ff:
-                    return ConvertToIlExpression(ff, nm, arguments);
+                    return ConvertToIlExpression(ff, nm, variables,
+                        arguments);
                 case AdditionOperation ao:
-                    return ConvertToIlExpression(ao, nm, arguments);
+                    return ConvertToIlExpression(ao, nm, variables,
+                        arguments);
                 case ArccosecantFunction ff:
-                    return ConvertToIlExpression(ff, nm, arguments);
+                    return ConvertToIlExpression(ff, nm, variables,
+                        arguments);
                 case ArccosineFunction ff:
-                    return ConvertToIlExpression(ff, nm, arguments);
+                    return ConvertToIlExpression(ff, nm, variables,
+                        arguments);
                 case ArccotangentFunction ff:
-                    return ConvertToIlExpression(ff, nm, arguments);
+                    return ConvertToIlExpression(ff, nm, variables,
+                        arguments);
                 case ArcsecantFunction ff:
-                    return ConvertToIlExpression(ff, nm, arguments);
+                    return ConvertToIlExpression(ff, nm, variables,
+                        arguments);
                 case ArcsineFunction ff:
-                    return ConvertToIlExpression(ff, nm, arguments);
+                    return ConvertToIlExpression(ff, nm, variables,
+                        arguments);
                 case Arctangent2Function ff:
-                    return ConvertToIlExpression(ff, nm, arguments);
+                    return ConvertToIlExpression(ff, nm, variables,
+                        arguments);
                 case ArctangentFunction ff:
-                    return ConvertToIlExpression(ff, nm, arguments);
+                    return ConvertToIlExpression(ff, nm, variables,
+                        arguments);
                 case BitwiseAndOperation ff:
-                    return ConvertToIlExpression(ff, nm, arguments);
+                    return ConvertToIlExpression(ff, nm, variables,
+                        arguments);
                 case BitwiseOrOperation ff:
-                    return ConvertToIlExpression(ff, nm, arguments);
+                    return ConvertToIlExpression(ff, nm, variables,
+                        arguments);
                 case CeilingFunction ff:
-                    return ConvertToIlExpression(ff, nm, arguments);
+                    return ConvertToIlExpression(ff, nm, variables,
+                        arguments);
                 case CosecantFunction ff:
-                    return ConvertToIlExpression(ff, nm, arguments);
+                    return ConvertToIlExpression(ff, nm, variables,
+                        arguments);
                 case CosineFunction c:
-                    return ConvertToIlExpression(c, nm, arguments);
+                    return ConvertToIlExpression(c, nm, variables,
+                        arguments);
                 case CotangentFunction ff:
-                    return ConvertToIlExpression(ff, nm, arguments);
+                    return ConvertToIlExpression(ff, nm, variables,
+                        arguments);
                 case DistFunction ff:
-                    return ConvertToIlExpression(ff, nm, arguments);
+                    return ConvertToIlExpression(ff, nm, variables,
+                        arguments);
                 case DistSqFunction ff:
-                    return ConvertToIlExpression(ff, nm, arguments);
+                    return ConvertToIlExpression(ff, nm, variables,
+                        arguments);
                 case DivisionOperation ff:
-                    return ConvertToIlExpression(ff, nm, arguments);
+                    return ConvertToIlExpression(ff, nm, variables,
+                        arguments);
                 case EqualComparisonOperation ff:
-                    return ConvertToIlExpression(ff, nm, arguments);
+                    return ConvertToIlExpression(ff, nm, variables,
+                        arguments);
                 case ExponentOperation eo:
-                    return ConvertToIlExpression(eo, nm, arguments);
+                    return ConvertToIlExpression(eo, nm, variables,
+                        arguments);
                 case FactorialFunction ff:
-                    return ConvertToIlExpression(ff, nm, arguments);
+                    return ConvertToIlExpression(ff, nm, variables,
+                        arguments);
                 case FloorFunction ff:
-                    return ConvertToIlExpression(ff, nm, arguments);
+                    return ConvertToIlExpression(ff, nm, variables,
+                        arguments);
                 case GreaterThanComparisonOperation ff:
-                    return ConvertToIlExpression(ff, nm, arguments);
+                    return ConvertToIlExpression(ff, nm, variables,
+                        arguments);
                 case GreaterThanOrEqualComparisonOperation ff:
-                    return ConvertToIlExpression(ff, nm, arguments);
+                    return ConvertToIlExpression(ff, nm, variables,
+                        arguments);
                 case LessThanComparisonOperation ff:
-                    return ConvertToIlExpression(ff, nm, arguments);
+                    return ConvertToIlExpression(ff, nm, variables,
+                        arguments);
                 case LessThanOrEqualComparisonOperation ff:
-                    return ConvertToIlExpression(ff, nm, arguments);
+                    return ConvertToIlExpression(ff, nm, variables,
+                        arguments);
                 case LoadImageFunction ff:
-                    return ConvertToIlExpression(ff, nm, arguments);
+                    return ConvertToIlExpression(ff, nm, variables,
+                        arguments);
                 case Log10Function ff:
-                    return ConvertToIlExpression(ff, nm, arguments);
+                    return ConvertToIlExpression(ff, nm, variables,
+                        arguments);
                 case Log2Function ff:
-                    return ConvertToIlExpression(ff, nm, arguments);
+                    return ConvertToIlExpression(ff, nm, variables,
+                        arguments);
                 case LogarithmFunction ff:
-                    return ConvertToIlExpression(ff, nm, arguments);
+                    return ConvertToIlExpression(ff, nm, variables,
+                        arguments);
                 case LogicalAndOperation ff:
-                    return ConvertToIlExpression(ff, nm, arguments);
+                    return ConvertToIlExpression(ff, nm, variables,
+                        arguments);
                 case LogicalOrOperation ff:
-                    return ConvertToIlExpression(ff, nm, arguments);
+                    return ConvertToIlExpression(ff, nm, variables,
+                        arguments);
                 case MaximumFiniteFunction ff:
-                    return ConvertToIlExpression(ff, nm, arguments);
+                    return ConvertToIlExpression(ff, nm, variables,
+                        arguments);
                 case MaximumFunction ff:
-                    return ConvertToIlExpression(ff, nm, arguments);
+                    return ConvertToIlExpression(ff, nm, variables,
+                        arguments);
                 case MinimumFiniteFunction ff:
-                    return ConvertToIlExpression(ff, nm, arguments);
+                    return ConvertToIlExpression(ff, nm, variables,
+                        arguments);
                 case MinimumFunction ff:
-                    return ConvertToIlExpression(ff, nm, arguments);
+                    return ConvertToIlExpression(ff, nm, variables,
+                        arguments);
                 case ModularDivision ff:
-                    return ConvertToIlExpression(ff, nm, arguments);
+                    return ConvertToIlExpression(ff, nm, variables,
+                        arguments);
                 case MultiplicationOperation mo:
-                    return ConvertToIlExpression(mo, nm, arguments);
+                    return ConvertToIlExpression(mo, nm, variables,
+                        arguments);
                 case NaturalLogarithmFunction ff:
-                    return ConvertToIlExpression(ff, nm, arguments);
+                    return ConvertToIlExpression(ff, nm, variables,
+                        arguments);
                 case NegationOperation no:
-                    return ConvertToIlExpression(no, nm, arguments);
+                    return ConvertToIlExpression(no, nm, variables,
+                        arguments);
                 case NotEqualComparisonOperation ff:
-                    return ConvertToIlExpression(ff, nm, arguments);
+                    return ConvertToIlExpression(ff, nm, variables,
+                        arguments);
                 case SecantFunction ff:
-                    return ConvertToIlExpression(ff, nm, arguments);
+                    return ConvertToIlExpression(ff, nm, variables,
+                        arguments);
                 case SineFunction s:
-                    return ConvertToIlExpression(s, nm, arguments);
+                    return ConvertToIlExpression(s, nm, variables,
+                        arguments);
                 case SizeFunction ff:
-                    return ConvertToIlExpression(ff, nm, arguments);
+                    return ConvertToIlExpression(ff, nm, variables,
+                        arguments);
                 case TangentFunction ff:
-                    return ConvertToIlExpression(ff, nm, arguments);
+                    return ConvertToIlExpression(ff, nm, variables,
+                        arguments);
                 case UnitStepFunction usf:
-                    return ConvertToIlExpression(usf, nm, arguments);
+                    return ConvertToIlExpression(usf, nm, variables,
+                        arguments);
                 default:
                     // if (func.ProvidesCustomCall)
                     // {

--- a/Compiler/ILCompiler.StoreOp.cs
+++ b/Compiler/ILCompiler.StoreOp.cs
@@ -21,6 +21,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using MetaphysicsIndustries.Solus.Compiler.IlExpressions;
 using MetaphysicsIndustries.Solus.Evaluators;
 
@@ -28,20 +29,24 @@ namespace MetaphysicsIndustries.Solus.Compiler
 {
     public partial class ILCompiler
     {
-        public IlExpression ConvertToIlExpression(StoreOp1 op,
-            NascentMethod nm)
+        public IlExpression ConvertToIlExpression(
+            StoreOp1 op, NascentMethod nm,
+            VariableIdentityMap variables)
         {
             if (op is IGenericStoreOp g)
-                return ConvertToIlExpression(op, g.ElementType, nm);
+                return ConvertToIlExpression(op, g.ElementType, nm, variables);
             if (op is VectorStoreOp vso)
-                return ConvertToIlExpression(vso, nm);
+                return ConvertToIlExpression(vso, nm, variables);
 
             throw new ArgumentException(
                 $"Unsupported store operation: \"{op}\"", nameof(op));
         }
 
-        public IlExpression ConvertToIlExpression(StoreOp1 op,
-            Type elementType, NascentMethod nm)
+        public IlExpression ConvertToIlExpression(
+            StoreOp1 op,
+            Type elementType,
+            NascentMethod nm,
+            VariableIdentityMap variables)
         {
             // var storeParam = nm.CreateParam()
             // return new IlExpressionSequence(
@@ -50,8 +55,10 @@ namespace MetaphysicsIndustries.Solus.Compiler
             throw new NotImplementedException();
         }
 
-        public IlExpression ConvertToIlExpression(VectorStoreOp op,
-            NascentMethod nm)
+        public IlExpression ConvertToIlExpression(
+            VectorStoreOp op,
+            NascentMethod nm,
+            VariableIdentityMap variables)
         {
             throw new NotImplementedException();
         }

--- a/Compiler/ILCompiler.cs
+++ b/Compiler/ILCompiler.cs
@@ -184,6 +184,8 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 return typeof(float[]);
             if (value.IsIsMatrix(typeEnv))
                 return typeof(float[,]);
+            if (value.IsIsFunction(typeEnv))
+                return typeof(MethodInfo);
             throw new NotImplementedException(
                 $"Unrecognized type, {value.GetType()}");
         }

--- a/Compiler/ILCompiler.cs
+++ b/Compiler/ILCompiler.cs
@@ -83,7 +83,8 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 i++;
             }
 
-            var returnType = ResolveType(expr.Result, typeEnv);
+            var returnType = ResolveType(
+                expr.GetResultType(typeEnv), typeEnv);
 
             ilexpr.GetInstructions(nm);
 

--- a/Compiler/VariableIdentity.cs
+++ b/Compiler/VariableIdentity.cs
@@ -21,32 +21,15 @@
  */
 
 using System;
-using System.Collections.Generic;
-using MetaphysicsIndustries.Solus.Compiler.IlExpressions;
-using MetaphysicsIndustries.Solus.Expressions;
-using MetaphysicsIndustries.Solus.Functions;
 
 namespace MetaphysicsIndustries.Solus.Compiler
 {
-    public partial class ILCompiler
+    public class VariableIdentity
     {
-        public IlExpression ConvertToIlExpression(
-            MinimumFunction func, NascentMethod nm,
-            VariableIdentityMap variables,
-            List<Expression> arguments)
-        {
-            var expr = ConvertToIlExpression(arguments[0], nm,
-                variables);
-            int i;
-            for (i = 1; i < arguments.Count; i++)
-            {
-                expr = new CallIlExpression(
-                    new Func<float, float, float>(Math.Min),
-                    expr,
-                    ConvertToIlExpression(arguments[i], nm, variables));
-            }
-
-            return expr;
-        }
+        public string Name;
+        public IMathObject MathType;
+        public Type IlType;
+        public IMathObject Value;
+        public VariableSource Source;
     }
 }

--- a/Compiler/VariableIdentity.cs
+++ b/Compiler/VariableIdentity.cs
@@ -31,5 +31,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
         public Type IlType;
         public IMathObject Value;
         public VariableSource Source;
+        public IlLocal LocalSource;
+        public IlParam ParamSource;
     }
 }

--- a/Compiler/VariableIdentityMap.cs
+++ b/Compiler/VariableIdentityMap.cs
@@ -1,0 +1,82 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2021 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using System.Collections.Generic;
+
+namespace MetaphysicsIndustries.Solus.Compiler
+{
+    public class VariableIdentityMap
+    {
+        public VariableIdentityMap(VariableIdentityMap parent = null)
+        {
+            Parent = parent;
+        }
+
+        private readonly Dictionary<string, VariableIdentity> _variables =
+            new Dictionary<string, VariableIdentity>();
+
+        private readonly HashSet<string> _removedVariables =
+            new HashSet<string>();
+
+        public VariableIdentityMap Parent { get; }
+
+        public VariableIdentity this[string name]
+        {
+            get => GetVariable(name);
+            set => SetVariable(name, value);
+        }
+
+        public VariableIdentity GetVariable(string name)
+        {
+            if (_removedVariables.Contains(name))
+                return null;
+            if (_variables.ContainsKey(name))
+                return _variables[name];
+            if (Parent != null)
+                return Parent[name];
+            return null;
+        }
+
+        public void SetVariable(string name, VariableIdentity value)
+        {
+            _removedVariables.Remove(name);
+            _variables[name] = value;
+        }
+
+        public bool ContainsVariable(string name)
+        {
+            if (_removedVariables.Contains(name)) return false;
+            if (_variables.ContainsKey(name)) return true;
+            if (Parent != null) return Parent.ContainsVariable(name);
+            return false;
+        }
+
+        public void RemoveVariable(string name)
+        {
+            _variables.Remove(name);
+            _removedVariables.Add(name);
+        }
+
+        public VariableIdentityMap CreateChild() =>
+            new VariableIdentityMap(this);
+    }
+}

--- a/Compiler/VariableSource.cs
+++ b/Compiler/VariableSource.cs
@@ -20,33 +20,11 @@
  *
  */
 
-using System;
-using System.Collections.Generic;
-using MetaphysicsIndustries.Solus.Compiler.IlExpressions;
-using MetaphysicsIndustries.Solus.Expressions;
-using MetaphysicsIndustries.Solus.Functions;
-
 namespace MetaphysicsIndustries.Solus.Compiler
 {
-    public partial class ILCompiler
+    public enum VariableSource
     {
-        public IlExpression ConvertToIlExpression(
-            MinimumFunction func, NascentMethod nm,
-            VariableIdentityMap variables,
-            List<Expression> arguments)
-        {
-            var expr = ConvertToIlExpression(arguments[0], nm,
-                variables);
-            int i;
-            for (i = 1; i < arguments.Count; i++)
-            {
-                expr = new CallIlExpression(
-                    new Func<float, float, float>(Math.Min),
-                    expr,
-                    ConvertToIlExpression(arguments[i], nm, variables));
-            }
-
-            return expr;
-        }
+        Param,
+        Local
     }
 }

--- a/Evaluators/CompilingEvaluator.cs
+++ b/Evaluators/CompilingEvaluator.cs
@@ -48,7 +48,8 @@ namespace MetaphysicsIndustries.Solus.Evaluators
             ec.Check(expr, env);
 
             var varNames = Expression.GatherVariables(expr);
-            var varTypes = new Dictionary<string, IMathObject>();
+            var variables =
+                new VariableIdentityMap();
             foreach (var varName in varNames)
             {
                 if (!env.ContainsVariable(varName))
@@ -57,10 +58,17 @@ namespace MetaphysicsIndustries.Solus.Evaluators
                 var value = env.GetVariable(varName);
                 if (value.IsIsExpression(env))
                     value = ((Expression)value).Result;
-                varTypes[varName] = value;
+                variables[varName] = new VariableIdentity
+                {
+                    Name = varName,
+                    MathType = value,
+                    // IlType =
+                    Value = value,
+                    Source = VariableSource.Param
+                };
             }
 
-            var compiled = _compiler.Compile(expr, varTypes);
+            var compiled = _compiler.Compile(expr, variables);
             return compiled.Evaluate(env);
         }
 
@@ -90,7 +98,8 @@ namespace MetaphysicsIndustries.Solus.Evaluators
                 store.SetMinArraySize(numSteps);
 
             var varNames = Expression.GatherVariables(expr);
-            var varTypes = new Dictionary<string, IMathObject>();
+            var variables =
+                new VariableIdentityMap();
             foreach (var varName in varNames)
             {
                 if (!env.ContainsVariable(varName) &&
@@ -98,13 +107,25 @@ namespace MetaphysicsIndustries.Solus.Evaluators
                     throw new NameException(
                         $"Variable \"{varName}\" is not bound");
                 if (varName == interval.Variable)
-                    varTypes[varName] = ScalarMathObject.Value;
+                    variables[varName] = new VariableIdentity
+                    {
+                        Name = varName,
+                        MathType = ScalarMathObject.Value,
+                        Source = VariableSource.Param
+                    };
                 else
                 {
                     var value = env.GetVariable(varName);
                     if (value.IsIsExpression(env))
                         value = ((Expression)value).Result;
-                    varTypes[varName] = value;
+                    variables[varName] = new VariableIdentity
+                    {
+                        Name = varName,
+                        MathType = value,
+                        // IlType =
+                        Value = value,
+                        Source = VariableSource.Param
+                    };
                 }
             }
 
@@ -113,7 +134,7 @@ namespace MetaphysicsIndustries.Solus.Evaluators
             var env2 = env.CreateChildEnvironment();
             env2.RemoveVariable(interval.Variable);
             var expr2 = Simplify(expr, env2);
-            var compiled = _compiler.Compile(expr2, varTypes);
+            var compiled = _compiler.Compile(expr2, variables);
             object[] varValuesInOrder = null;
             compiled.CompileEnvironment(env2, ref varValuesInOrder);
 
@@ -143,7 +164,7 @@ namespace MetaphysicsIndustries.Solus.Evaluators
                 store.SetMinArraySize(numSteps1, numSteps2);
 
             var varNames = Expression.GatherVariables(expr);
-            var varTypes = new Dictionary<string, IMathObject>();
+            var variables = new VariableIdentityMap();
             foreach (var varName in varNames)
             {
                 if (!env.ContainsVariable(varName) &&
@@ -153,13 +174,25 @@ namespace MetaphysicsIndustries.Solus.Evaluators
                         $"Variable \"{varName}\" is not bound");
                 if (varName == interval1.Variable ||
                     varName == interval2.Variable)
-                    varTypes[varName] = ScalarMathObject.Value;
+                    variables[varName] = new VariableIdentity
+                    {
+                        Name = varName,
+                        MathType = ScalarMathObject.Value,
+                        Source = VariableSource.Param
+                    };
                 else
                 {
                     var value = env.GetVariable(varName);
                     if (value.IsIsExpression(env))
                         value = ((Expression)value).Result;
-                    varTypes[varName] = value;
+                    variables[varName] = new VariableIdentity
+                    {
+                        Name = varName,
+                        MathType = value,
+                        // IlType =
+                        Value = value,
+                        Source = VariableSource.Param
+                    };
                 }
             }
 
@@ -170,7 +203,7 @@ namespace MetaphysicsIndustries.Solus.Evaluators
             env2.RemoveVariable(interval1.Variable);
             env2.RemoveVariable(interval2.Variable);
             var expr2 = Simplify(expr, env2);
-            var compiled = _compiler.Compile(expr2, varTypes);
+            var compiled = _compiler.Compile(expr2, variables);
             object[] varValuesInOrder = null;
             compiled.CompileEnvironment(env2, ref varValuesInOrder);
 
@@ -210,7 +243,7 @@ namespace MetaphysicsIndustries.Solus.Evaluators
                 store.SetMinArraySize(numSteps1, numSteps2, numSteps3);
 
             var varNames = Expression.GatherVariables(expr);
-            var varTypes = new Dictionary<string, IMathObject>();
+            var variables = new VariableIdentityMap();
             foreach (var varName in varNames)
             {
                 if (!env.ContainsVariable(varName) &&
@@ -222,13 +255,25 @@ namespace MetaphysicsIndustries.Solus.Evaluators
                 if (varName == interval1.Variable ||
                     varName == interval2.Variable ||
                     varName == interval3.Variable)
-                    varTypes[varName] = ScalarMathObject.Value;
+                    variables[varName] = new VariableIdentity
+                    {
+                        Name = varName,
+                        MathType = ScalarMathObject.Value,
+                        Source = VariableSource.Param
+                    };
                 else
                 {
                     var value = env.GetVariable(varName);
                     if (value.IsIsExpression(env))
                         value = ((Expression)value).Result;
-                    varTypes[varName] = value;
+                    variables[varName] = new VariableIdentity
+                    {
+                        Name = varName,
+                        //MathType =
+                        // IlType =
+                        Value = value,
+                        Source = VariableSource.Param
+                    };
                 }
             }
 
@@ -241,7 +286,7 @@ namespace MetaphysicsIndustries.Solus.Evaluators
             env2.RemoveVariable(interval2.Variable);
             env2.RemoveVariable(interval3.Variable);
             var expr2 = Simplify(expr, env2);
-            var compiled = _compiler.Compile(expr2, varTypes);
+            var compiled = _compiler.Compile(expr2, variables);
             object[] varValuesInOrder = null;
             compiled.CompileEnvironment(env2, ref varValuesInOrder);
 

--- a/Evaluators/CompilingEvaluator.cs
+++ b/Evaluators/CompilingEvaluator.cs
@@ -57,7 +57,7 @@ namespace MetaphysicsIndustries.Solus.Evaluators
                         $"Variable \"{varName}\" is not bound");
                 var value = env.GetVariable(varName);
                 if (value.IsIsExpression(env))
-                    value = ((Expression)value).Result;
+                    value = ((Expression)value).GetResultType(env);
                 variables[varName] = new VariableIdentity
                 {
                     Name = varName,
@@ -117,7 +117,7 @@ namespace MetaphysicsIndustries.Solus.Evaluators
                 {
                     var value = env.GetVariable(varName);
                     if (value.IsIsExpression(env))
-                        value = ((Expression)value).Result;
+                        value = ((Expression)value).GetResultType(env);
                     variables[varName] = new VariableIdentity
                     {
                         Name = varName,
@@ -184,7 +184,7 @@ namespace MetaphysicsIndustries.Solus.Evaluators
                 {
                     var value = env.GetVariable(varName);
                     if (value.IsIsExpression(env))
-                        value = ((Expression)value).Result;
+                        value = ((Expression)value).GetResultType(env);
                     variables[varName] = new VariableIdentity
                     {
                         Name = varName,
@@ -265,7 +265,7 @@ namespace MetaphysicsIndustries.Solus.Evaluators
                 {
                     var value = env.GetVariable(varName);
                     if (value.IsIsExpression(env))
-                        value = ((Expression)value).Result;
+                        value = ((Expression)value).GetResultType(env);
                     variables[varName] = new VariableIdentity
                     {
                         Name = varName,

--- a/Expressions/ColorExpression.cs
+++ b/Expressions/ColorExpression.cs
@@ -98,6 +98,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
             throw new NotImplementedException();
         }
 
-        public override IMathObject Result => ScalarMathObject.Value;
+        public override IMathObject GetResultType(SolusEnvironment env) =>
+            ScalarMathObject.Value;
     }
 }

--- a/Expressions/ComponentAccess.cs
+++ b/Expressions/ComponentAccess.cs
@@ -33,11 +33,12 @@ namespace MetaphysicsIndustries.Solus.Expressions
         {
             Expr = expr;
             Indexes = new ReadOnlyCollection<Expression>(indexes.ToList());
-            Result = new ResultC(this);
+            _result = new ResultC(this);
         }
 
         public readonly Expression Expr;
         public readonly ReadOnlyCollection<Expression> Indexes;
+        private readonly IMathObject _result;
 
         public override Expression Simplify(SolusEnvironment env)
         {
@@ -146,7 +147,8 @@ namespace MetaphysicsIndustries.Solus.Expressions
             return sb.ToString();
         }
 
-        public override IMathObject Result { get; }
+        public override IMathObject GetResultType(SolusEnvironment env) =>
+            _result;
 
         private class ResultC : IMathObject
         {
@@ -160,7 +162,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
 
             public bool? IsScalar(SolusEnvironment env)
             {
-                if (_ca.Expr.Result.IsIsString(env))
+                if (_ca.Expr.GetResultType(env).IsIsString(env))
                     return false;
                 return true;
             }
@@ -169,7 +171,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
             public int? GetTensorRank(SolusEnvironment env) => 0;
             public bool? IsString(SolusEnvironment env)
             {
-                if (_ca.Expr.Result.IsIsString(env))
+                if (_ca.Expr.GetResultType(env).IsIsString(env))
                     return true;
                 return false;
             }

--- a/Expressions/DerivativeOfVariable.cs
+++ b/Expressions/DerivativeOfVariable.cs
@@ -86,7 +86,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
             visitor.Visit(this);
         }
 
-        public override IMathObject Result =>
+        public override IMathObject GetResultType(SolusEnvironment env) =>
             throw new NotImplementedException();
     }
 }

--- a/Expressions/Expression.cs
+++ b/Expressions/Expression.cs
@@ -127,7 +127,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
             return expr.ToString();
         }
 
-        public abstract IMathObject Result { get; }
+        public abstract IMathObject GetResultType(SolusEnvironment env);
 
         public bool? IsScalar(SolusEnvironment env) => false;
         public bool? IsVector(SolusEnvironment env) => false;

--- a/Expressions/ExpressionChecker.cs
+++ b/Expressions/ExpressionChecker.cs
@@ -81,7 +81,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
             for (i = 0; i < expr.Indexes.Count; i++)
                 Check(expr.Indexes[i], env);
 
-            var value = expr.Expr.Result;
+            var value = expr.Expr.GetResultType(env);
             if (value.IsIsString(env))
             {
                 if (expr.Indexes.Count != 1)
@@ -102,7 +102,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
 
             for (i = 0; i < expr.Indexes.Count; i++)
             {
-                var si = expr.Indexes[i].Result;
+                var si = expr.Indexes[i].GetResultType(env);
                 if (si == null) continue;
                 if (!si.IsIsScalar(env))
                     throw new IndexException(
@@ -183,7 +183,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
 
                 for (var i = 0; i < args.Count; i++)
                 {
-                    var argtype = args[i].Result.GetMathType();
+                    var argtype = args[i].GetResultType(env).GetMathType();
                     if (argtype != Types.Scalar)
                         throw new ArgumentException(
                             $"Argument {i} wrong type: expected " +
@@ -301,7 +301,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
 
             for (var i = 0; i < args.Count; i++)
             {
-                var argtype = args[i].Result.GetMathType();
+                var argtype = args[i].GetResultType(env).GetMathType();
                 if (argtype != f.ParamTypes[i])
                 {
                     throw new ArgumentException(
@@ -314,12 +314,12 @@ namespace MetaphysicsIndustries.Solus.Expressions
         public void Check(IntervalExpression expr, SolusEnvironment env)
         {
             Check(expr.LowerBound, env);
-            var lower = expr.LowerBound.Result;
+            var lower = expr.LowerBound.GetResultType(env);
             if (!lower.IsIsScalar(env))
                 throw new OperandException("Lower bound is not a scalar");
 
             Check(expr.UpperBound, env);
-            var upper = expr.UpperBound.Result;
+            var upper = expr.UpperBound.GetResultType(env);
             if (!upper.IsIsScalar(env))
                 throw new OperandException("Upper bound is not a scalar");
         }
@@ -517,7 +517,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
                 throw new ArgumentException("No arguments passed");
             for (var i = 0; i < args.Count; i++)
             {
-                var argtype = args[i].Result.GetMathType();
+                var argtype = args[i].GetResultType(env).GetMathType();
                 if (argtype != Types.Scalar)
                     throw new ArgumentException(
                         $"Argument {i} wrong type: expected " +
@@ -531,7 +531,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
                 throw new ArgumentException("No arguments passed");
             for (var i = 0; i < args.Count; i++)
             {
-                var argtype = args[i].Result.GetMathType();
+                var argtype = args[i].GetResultType(env).GetMathType();
                 if (argtype != Types.Scalar)
                     throw new ArgumentException(
                         $"Argument {i} wrong type: expected " +
@@ -545,7 +545,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
                 throw new ArgumentException("No arguments passed");
             for (var i = 0; i < args.Count; i++)
             {
-                var argtype = args[i].Result.GetMathType();
+                var argtype = args[i].GetResultType(env).GetMathType();
                 if (argtype != Types.Scalar)
                     throw new ArgumentException(
                         $"Argument {i} wrong type: expected " +
@@ -559,7 +559,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
                 throw new ArgumentException("No arguments passed");
             for (var i = 0; i < args.Count; i++)
             {
-                var argtype = args[i].Result.GetMathType();
+                var argtype = args[i].GetResultType(env).GetMathType();
                 if (argtype != Types.Scalar)
                     throw new ArgumentException(
                         $"Argument {i} wrong type: expected " +
@@ -609,7 +609,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
                     $"Wrong number of arguments given to " +
                     $"{ff.DisplayName} (expected 1 but got " +
                     $"{args.Count})");
-            var argtype = args[0].Result.GetMathType();
+            var argtype = args[0].GetResultType(env).GetMathType();
             if (argtype != Types.Vector &&
                 argtype != Types.Matrix &&
                 argtype != Types.String)

--- a/Expressions/FunctionCall.cs
+++ b/Expressions/FunctionCall.cs
@@ -250,7 +250,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
             int i;
             for (i = 0; i < Arguments.Count; i++)
                 _argumentResultCache[i] = Arguments[i].GetResultType(env);
-            return f.GetResult(_argumentResultCache);
+            return f.GetResultType(env, _argumentResultCache);
         }
     }
 }

--- a/Expressions/FunctionCall.cs
+++ b/Expressions/FunctionCall.cs
@@ -237,23 +237,20 @@ namespace MetaphysicsIndustries.Solus.Expressions
 
         private IMathObject[] _argumentResultCache;
 
-        public override IMathObject Result
+        public override IMathObject GetResultType(SolusEnvironment env)
         {
-            get
-            {
-                if (!(Function is Expression expr) ||
-                    !(expr is Literal literal) ||
-                    !(literal.Value is Function f))
-                    return null;
+            if (!(Function is Expression expr) ||
+                !(expr is Literal literal) ||
+                !(literal.Value is Function f))
+                return null;
 
-                if (_argumentResultCache == null ||
-                    _argumentResultCache.Length < Arguments.Count)
-                    _argumentResultCache = new IMathObject[Arguments.Count];
-                int i;
-                for (i = 0; i < Arguments.Count; i++)
-                    _argumentResultCache[i] = Arguments[i].Result;
-                return f.GetResult(_argumentResultCache);
-            }
+            if (_argumentResultCache == null ||
+                _argumentResultCache.Length < Arguments.Count)
+                _argumentResultCache = new IMathObject[Arguments.Count];
+            int i;
+            for (i = 0; i < Arguments.Count; i++)
+                _argumentResultCache[i] = Arguments[i].GetResultType(env);
+            return f.GetResult(_argumentResultCache);
         }
     }
 }

--- a/Expressions/IntervalExpression.cs
+++ b/Expressions/IntervalExpression.cs
@@ -54,6 +54,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
             UpperBound.AcceptVisitor(visitor);
         }
 
-        public override IMathObject Result => IntervalMathObject.Value;
+        public override IMathObject GetResultType(SolusEnvironment env) =>
+            IntervalMathObject.Value;
     }
 }

--- a/Expressions/Literal.cs
+++ b/Expressions/Literal.cs
@@ -98,6 +98,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
             visitor.Visit(this);
         }
 
-        public override IMathObject Result => Value;
-    }
+        public override IMathObject GetResultType(SolusEnvironment env) =>
+	        Value;
+	}
 }

--- a/Expressions/MatrixExpression.cs
+++ b/Expressions/MatrixExpression.cs
@@ -70,7 +70,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
                 }
             }
 
-            Result = new ResultC(this);
+            _result = new ResultC(this);
         }
 
         public MatrixExpression(int rows, int columns,
@@ -151,6 +151,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
         }
 
         private Expression[,] _array;
+        private readonly IMathObject _result;
 
         public int Count { get { return RowCount * ColumnCount; } }
 
@@ -768,7 +769,8 @@ namespace MetaphysicsIndustries.Solus.Expressions
             return sb.ToString();
         }
 
-        public override IMathObject Result { get; }
+        public override IMathObject GetResultType(SolusEnvironment env) =>
+            _result;
 
         private class ResultC : IMathObject
         {

--- a/Expressions/RandomExpression.cs
+++ b/Expressions/RandomExpression.cs
@@ -29,6 +29,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
         public static readonly Random Source = new Random();
 
         float _value = (float)Source.NextDouble();
+        private readonly IMathObject _result = new ResultC();
 
         public override Expression Clone()
         {
@@ -40,7 +41,8 @@ namespace MetaphysicsIndustries.Solus.Expressions
             throw new NotImplementedException();
         }
 
-        public override IMathObject Result { get; } = new ResultC();
+        public override IMathObject GetResultType(SolusEnvironment env) =>
+            _result;
 
         private class ResultC : IMathObject
         {

--- a/Expressions/VariableAccess.cs
+++ b/Expressions/VariableAccess.cs
@@ -38,7 +38,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
             if (string.IsNullOrEmpty(variableName)) throw new ArgumentNullException("variableName");
 
             VariableName = variableName;
-            Result = new ResultC(this);
+            _result = new ResultC(this);
         }
 
         private readonly HashSet<VariableAccess> _visitedVarrefs =
@@ -72,6 +72,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
         }
 
         public string VariableName;
+        private readonly IMathObject _result;
 
         public override string ToString()
         {
@@ -83,7 +84,8 @@ namespace MetaphysicsIndustries.Solus.Expressions
             visitor.Visit(this);
         }
 
-        public override IMathObject Result { get; }
+        public override IMathObject GetResultType(SolusEnvironment env) =>
+            _result;
 
         private class ResultC : IMathObject
         {
@@ -96,7 +98,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
                 if (!env.ContainsVariable(_va.VariableName)) return null;
                 var varexpr = env.GetVariable(_va.VariableName);
                 if (varexpr.IsIsExpression(env))
-                    varexpr = ((Expression)varexpr).Result;
+                    varexpr = ((Expression)varexpr).GetResultType(env);
                 return varexpr.IsScalar(env);
             }
 
@@ -106,7 +108,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
                 if (!env.ContainsVariable(_va.VariableName)) return null;
                 var varexpr = env.GetVariable(_va.VariableName);
                 if (varexpr.IsIsExpression(env))
-                    varexpr = ((Expression)varexpr).Result;
+                    varexpr = ((Expression)varexpr).GetResultType(env);
                 return varexpr.IsVector(env);
             }
 
@@ -116,7 +118,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
                 if (!env.ContainsVariable(_va.VariableName)) return null;
                 var varexpr = env.GetVariable(_va.VariableName);
                 if (varexpr.IsIsExpression(env))
-                    varexpr = ((Expression)varexpr).Result;
+                    varexpr = ((Expression)varexpr).GetResultType(env);
                 return varexpr.IsMatrix(env);
             }
 
@@ -126,7 +128,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
                 if (!env.ContainsVariable(_va.VariableName)) return null;
                 var varexpr = env.GetVariable(_va.VariableName);
                 if (varexpr.IsIsExpression(env))
-                    varexpr = ((Expression)varexpr).Result;
+                    varexpr = ((Expression)varexpr).GetResultType(env);
                 return varexpr.GetTensorRank(env);
             }
 
@@ -136,7 +138,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
                 if (!env.ContainsVariable(_va.VariableName)) return null;
                 var varexpr = env.GetVariable(_va.VariableName);
                 if (varexpr.IsIsExpression(env))
-                    varexpr = ((Expression)varexpr).Result;
+                    varexpr = ((Expression)varexpr).GetResultType(env);
                 return varexpr.IsString(env);
             }
 
@@ -146,7 +148,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
                 if (!env.ContainsVariable(_va.VariableName)) return null;
                 var varexpr = env.GetVariable(_va.VariableName);
                 if (varexpr.IsIsExpression(env))
-                    varexpr = ((Expression)varexpr).Result;
+                    varexpr = ((Expression)varexpr).GetResultType(env);
                 return varexpr.GetDimension(env, index);
             }
 
@@ -156,7 +158,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
                 if (!env.ContainsVariable(_va.VariableName)) return null;
                 var varexpr = env.GetVariable(_va.VariableName);
                 if (varexpr.IsIsExpression(env))
-                    varexpr = ((Expression)varexpr).Result;
+                    varexpr = ((Expression)varexpr).GetResultType(env);
                 return varexpr.GetDimensions(env);
             }
 
@@ -166,7 +168,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
                 if (!env.ContainsVariable(_va.VariableName)) return null;
                 var varexpr = env.GetVariable(_va.VariableName);
                 if (varexpr.IsIsExpression(env))
-                    varexpr = ((Expression)varexpr).Result;
+                    varexpr = ((Expression)varexpr).GetResultType(env);
                 return varexpr.GetVectorLength(env);
             }
 
@@ -176,7 +178,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
                 if (!env.ContainsVariable(_va.VariableName)) return null;
                 var varexpr = env.GetVariable(_va.VariableName);
                 if (varexpr.IsIsExpression(env))
-                    varexpr = ((Expression)varexpr).Result;
+                    varexpr = ((Expression)varexpr).GetResultType(env);
                 return varexpr.IsInterval(env);
             }
 
@@ -186,7 +188,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
                 if (!env.ContainsVariable(_va.VariableName)) return null;
                 var varexpr = env.GetVariable(_va.VariableName);
                 if (varexpr.IsIsExpression(env))
-                    varexpr = ((Expression)varexpr).Result;
+                    varexpr = ((Expression)varexpr).GetResultType(env);
                 return false;
             }
 
@@ -196,7 +198,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
                 if (!env.ContainsVariable(_va.VariableName)) return null;
                 var varexpr = env.GetVariable(_va.VariableName);
                 if (varexpr.IsIsExpression(env))
-                    varexpr = ((Expression)varexpr).Result;
+                    varexpr = ((Expression)varexpr).GetResultType(env);
                 return true;
             }
 

--- a/Expressions/VectorExpression.cs
+++ b/Expressions/VectorExpression.cs
@@ -62,7 +62,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
                 _array[i] = Literal.Zero;
             }
 
-            Result = new ResultC(this);
+            _result = new ResultC(this);
         }
 
         public VectorExpression(int length, params float[] initialContents)
@@ -218,6 +218,8 @@ namespace MetaphysicsIndustries.Solus.Expressions
         }
 
         private Expression[] _valuesCache = null;
+        private readonly IMathObject _result;
+
         public override Expression Simplify(SolusEnvironment env)
         {
             if (_valuesCache == null ||
@@ -285,7 +287,8 @@ namespace MetaphysicsIndustries.Solus.Expressions
             return sb.ToString();
         }
 
-        public override IMathObject Result { get; }
+        public override IMathObject GetResultType(SolusEnvironment env) =>
+            _result;
 
         private class ResultC : IMathObject
         {

--- a/Functions/AbsoluteValueFunction.cs
+++ b/Functions/AbsoluteValueFunction.cs
@@ -51,7 +51,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             }
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             return ScalarMathObject.Value;
         }

--- a/Functions/AdditionOperation.cs
+++ b/Functions/AdditionOperation.cs
@@ -48,9 +48,10 @@ namespace MetaphysicsIndustries.Solus.Functions
             }
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
-            return args.First();
+            return argTypes.First();
         }
     }
 }

--- a/Functions/AdditionOperation.cs
+++ b/Functions/AdditionOperation.cs
@@ -21,8 +21,6 @@
  */
 
 using System.Collections.Generic;
-using System.Linq;
-using MetaphysicsIndustries.Solus.Values;
 
 namespace MetaphysicsIndustries.Solus.Functions
 {
@@ -51,7 +49,9 @@ namespace MetaphysicsIndustries.Solus.Functions
         public override IMathObject GetResultType(SolusEnvironment env,
             IEnumerable<IMathObject> argTypes)
         {
-            return argTypes.First();
+            // TODO: tensor arithmetic
+            // TODO: string concatenation
+            return ScalarMathObject.Value;
         }
     }
 }

--- a/Functions/ArccosecantFunction.cs
+++ b/Functions/ArccosecantFunction.cs
@@ -59,7 +59,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             }
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             return ScalarMathObject.Value;
         }

--- a/Functions/ArccosineFunction.cs
+++ b/Functions/ArccosineFunction.cs
@@ -60,7 +60,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             }
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             return ScalarMathObject.Value;
         }

--- a/Functions/ArccotangentFunction.cs
+++ b/Functions/ArccotangentFunction.cs
@@ -59,7 +59,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             }
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             return ScalarMathObject.Value;
         }

--- a/Functions/ArcsecantFunction.cs
+++ b/Functions/ArcsecantFunction.cs
@@ -59,7 +59,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             }
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             return ScalarMathObject.Value;
         }

--- a/Functions/ArcsineFunction.cs
+++ b/Functions/ArcsineFunction.cs
@@ -60,7 +60,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             }
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             return ScalarMathObject.Value;
         }

--- a/Functions/Arctangent2Function.cs
+++ b/Functions/Arctangent2Function.cs
@@ -50,7 +50,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             }
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             return ScalarMathObject.Value;
         }

--- a/Functions/ArctangentFunction.cs
+++ b/Functions/ArctangentFunction.cs
@@ -59,7 +59,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             }
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             return ScalarMathObject.Value;
         }

--- a/Functions/BitwiseAndOperation.cs
+++ b/Functions/BitwiseAndOperation.cs
@@ -48,7 +48,8 @@ namespace MetaphysicsIndustries.Solus.Functions
         //    get { return false; }
         //}
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             return ScalarMathObject.Value;
         }

--- a/Functions/BitwiseOrOperation.cs
+++ b/Functions/BitwiseOrOperation.cs
@@ -54,7 +54,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             get { return 0; }
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             return ScalarMathObject.Value;
         }

--- a/Functions/CatmullRomSpline.cs
+++ b/Functions/CatmullRomSpline.cs
@@ -127,7 +127,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             return v;
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             return ScalarMathObject.Value;
         }

--- a/Functions/CeilingFunction.cs
+++ b/Functions/CeilingFunction.cs
@@ -59,7 +59,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             }
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             return ScalarMathObject.Value;
         }

--- a/Functions/CosecantFunction.cs
+++ b/Functions/CosecantFunction.cs
@@ -59,7 +59,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             }
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             return ScalarMathObject.Value;
         }

--- a/Functions/CosineFunction.cs
+++ b/Functions/CosineFunction.cs
@@ -59,7 +59,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             }
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             return ScalarMathObject.Value;
         }

--- a/Functions/CotangentFunction.cs
+++ b/Functions/CotangentFunction.cs
@@ -59,7 +59,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             }
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             return ScalarMathObject.Value;
         }

--- a/Functions/DistFunction.cs
+++ b/Functions/DistFunction.cs
@@ -39,7 +39,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             get { return "dist"; }
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             return ScalarMathObject.Value;
         }

--- a/Functions/DistSqFunction.cs
+++ b/Functions/DistSqFunction.cs
@@ -38,7 +38,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             get { return "distsq"; }
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             return ScalarMathObject.Value;
         }

--- a/Functions/DivisionOperation.cs
+++ b/Functions/DivisionOperation.cs
@@ -46,7 +46,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             }
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             // TODO: vector divided by scalar
             // TODO: matrix divided by scalar

--- a/Functions/EqualComparisonOperation.cs
+++ b/Functions/EqualComparisonOperation.cs
@@ -51,7 +51,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             }
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             // TODO: boolean
             // TODO: matrix

--- a/Functions/ExponentOperation.cs
+++ b/Functions/ExponentOperation.cs
@@ -39,7 +39,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             get { return OperationPrecedence.Exponent; }
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             // TODO: square matrix
             return ScalarMathObject.Value;

--- a/Functions/FactorialFunction.cs
+++ b/Functions/FactorialFunction.cs
@@ -49,7 +49,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             return base.ToString(arguments);
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             return ScalarMathObject.Value;
         }

--- a/Functions/FloorFunction.cs
+++ b/Functions/FloorFunction.cs
@@ -59,7 +59,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             }
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             return ScalarMathObject.Value;
         }

--- a/Functions/Function.cs
+++ b/Functions/Function.cs
@@ -144,7 +144,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             get { return string.Empty; }
         }
 
-        public abstract IMathObject GetResult(IEnumerable<IMathObject> args);
+        public abstract IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes);
 
         public bool? IsScalar(SolusEnvironment env) => false;
         public bool? IsVector(SolusEnvironment env) => false;

--- a/Functions/GreaterThanComparisonOperation.cs
+++ b/Functions/GreaterThanComparisonOperation.cs
@@ -38,7 +38,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             return x > y;
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             // TODO: boolean
             return ScalarMathObject.Value;

--- a/Functions/GreaterThanOrEqualComparisonOperation.cs
+++ b/Functions/GreaterThanOrEqualComparisonOperation.cs
@@ -38,7 +38,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             return x >= y;
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             // TODO: boolean
             return ScalarMathObject.Value;

--- a/Functions/LessThanComparisonOperation.cs
+++ b/Functions/LessThanComparisonOperation.cs
@@ -38,7 +38,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             return x < y;
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             // TODO: boolean
             return ScalarMathObject.Value;

--- a/Functions/LessThanOrEqualComparisonOperation.cs
+++ b/Functions/LessThanOrEqualComparisonOperation.cs
@@ -38,7 +38,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             return x <= y;
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             // TODO: boolean
             return ScalarMathObject.Value;

--- a/Functions/LoadImageFunction.cs
+++ b/Functions/LoadImageFunction.cs
@@ -104,7 +104,8 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         private readonly ResultC _result = new ResultC();
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             return _result;
         }

--- a/Functions/Log10Function.cs
+++ b/Functions/Log10Function.cs
@@ -44,7 +44,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             }
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             return ScalarMathObject.Value;
         }

--- a/Functions/Log2Function.cs
+++ b/Functions/Log2Function.cs
@@ -44,7 +44,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             }
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             return ScalarMathObject.Value;
         }

--- a/Functions/LogarithmFunction.cs
+++ b/Functions/LogarithmFunction.cs
@@ -43,7 +43,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             }
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             return ScalarMathObject.Value;
         }

--- a/Functions/LogicalAndOperation.cs
+++ b/Functions/LogicalAndOperation.cs
@@ -38,7 +38,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             get { return OperationPrecedence.LogicalAnd; }
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             return ScalarMathObject.Value;
         }

--- a/Functions/LogicalOrOperation.cs
+++ b/Functions/LogicalOrOperation.cs
@@ -38,7 +38,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             get { return OperationPrecedence.LogicalOr; }
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             return ScalarMathObject.Value;
         }

--- a/Functions/MaximumFiniteFunction.cs
+++ b/Functions/MaximumFiniteFunction.cs
@@ -56,7 +56,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             }
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             return ScalarMathObject.Value;
         }

--- a/Functions/MaximumFunction.cs
+++ b/Functions/MaximumFunction.cs
@@ -53,7 +53,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             }
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             return ScalarMathObject.Value;
         }

--- a/Functions/MinimumFiniteFunction.cs
+++ b/Functions/MinimumFiniteFunction.cs
@@ -56,7 +56,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             }
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             return ScalarMathObject.Value;
         }

--- a/Functions/MinimumFunction.cs
+++ b/Functions/MinimumFunction.cs
@@ -53,7 +53,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             }
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             return ScalarMathObject.Value;
         }

--- a/Functions/ModularDivision.cs
+++ b/Functions/ModularDivision.cs
@@ -39,7 +39,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             get { return OperationPrecedence.Multiplication; }
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             return ScalarMathObject.Value;
         }

--- a/Functions/MultiplicationOperation.cs
+++ b/Functions/MultiplicationOperation.cs
@@ -72,13 +72,14 @@ namespace MetaphysicsIndustries.Solus.Functions
             }
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             // TODO: matrix multiplication
             // TODO: matrix times scalar and vice-versa
             // TODO: matrix times vector and vice-versa
             // TODO: vector times scalar
-            return args.First();
+            return argTypes.First();
         }
     }
 }

--- a/Functions/NaturalLogarithmFunction.cs
+++ b/Functions/NaturalLogarithmFunction.cs
@@ -52,7 +52,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             }
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             return ScalarMathObject.Value;
         }

--- a/Functions/NegationOperation.cs
+++ b/Functions/NegationOperation.cs
@@ -62,9 +62,10 @@ namespace MetaphysicsIndustries.Solus.Functions
             get { return 0; }
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
-            return args.First();
+            return argTypes.First();
         }
     }
 }

--- a/Functions/NotEqualComparisonOperation.cs
+++ b/Functions/NotEqualComparisonOperation.cs
@@ -53,7 +53,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             }
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             // TODO: boolean
             // TODO: matrix

--- a/Functions/SecantFunction.cs
+++ b/Functions/SecantFunction.cs
@@ -51,7 +51,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             }
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             return ScalarMathObject.Value;
         }

--- a/Functions/SineFunction.cs
+++ b/Functions/SineFunction.cs
@@ -59,7 +59,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             }
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             return ScalarMathObject.Value;
         }

--- a/Functions/SizeFunction.cs
+++ b/Functions/SizeFunction.cs
@@ -99,9 +99,10 @@ namespace MetaphysicsIndustries.Solus.Functions
             public string DocString => "";
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
-            return new ResultC(args.First());
+            return new ResultC(argTypes.First());
         }
     }
 }

--- a/Functions/TangentFunction.cs
+++ b/Functions/TangentFunction.cs
@@ -51,7 +51,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             }
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             return ScalarMathObject.Value;
         }

--- a/Functions/UnitStepFunction.cs
+++ b/Functions/UnitStepFunction.cs
@@ -50,7 +50,8 @@ namespace MetaphysicsIndustries.Solus.Functions
             }
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             return ScalarMathObject.Value;
         }

--- a/Functions/UserDefinedFunction.cs
+++ b/Functions/UserDefinedFunction.cs
@@ -50,7 +50,8 @@ namespace MetaphysicsIndustries.Solus.Functions
                     $"{args.Length})");
         }
 
-        public override IMathObject GetResult(IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             return Expression.GetResultType(null);
         }

--- a/Functions/UserDefinedFunction.cs
+++ b/Functions/UserDefinedFunction.cs
@@ -52,7 +52,7 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public override IMathObject GetResult(IEnumerable<IMathObject> args)
         {
-            return Expression.Result;
+            return Expression.GetResultType(null);
         }
     }
 }

--- a/Functions/UserDefinedFunction.cs
+++ b/Functions/UserDefinedFunction.cs
@@ -53,7 +53,21 @@ namespace MetaphysicsIndustries.Solus.Functions
         public override IMathObject GetResultType(SolusEnvironment env,
             IEnumerable<IMathObject> argTypes)
         {
-            return Expression.GetResultType(null);
+            SolusEnvironment env2;
+            if (env != null)
+                env2 = env.CreateChildEnvironment();
+            else
+                env2 = new SolusEnvironment();
+            var argValues = argTypes.ToList();
+            int i;
+            for (i = 0; i < Argnames.Length; i++)
+            {
+                var argName = Argnames[i];
+                var argValue = argValues[i];
+                env2.SetVariable(argName, argValue);
+            }
+
+            return Expression.GetResultType(env2);
         }
     }
 }

--- a/MathObjectHelper.cs
+++ b/MathObjectHelper.cs
@@ -21,6 +21,7 @@
  */
 
 using System.Linq;
+using MetaphysicsIndustries.Solus.Functions;
 using MetaphysicsIndustries.Solus.Values;
 
 namespace MetaphysicsIndustries.Solus
@@ -99,6 +100,9 @@ namespace MetaphysicsIndustries.Solus
 
         public static float ToFloat(this IMathObject value) =>
             value.ToNumber().Value;
+
+        public static Function ToFunction(this IMathObject mo) =>
+            (Function)mo;
 
         public static Types GetMathType(this IMathObject mo,
             SolusEnvironment env=null)

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/ColorExpressionT/ResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/ColorExpressionT/ResultTest.cs
@@ -36,7 +36,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ColorExpressionT
             var expr = new ColorExpression(Color.Red);
             var env = new SolusEnvironment();
             // when
-            var result = expr.Result;
+            var result = expr.GetResultType(env);
             // then
             Assert.IsTrue(result.IsScalar(env));
             Assert.IsFalse(result.IsVector(env));

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/ComponentAccessT/ResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/ComponentAccessT/ResultTest.cs
@@ -46,7 +46,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
                 new[] { new Literal(1) });
             var env = new SolusEnvironment();
             // when
-            var result = expr.Result.IsScalar(env);
+            var result = expr.GetResultType(env).IsScalar(env);
             // then
             Assert.IsTrue(result);
         }
@@ -67,7 +67,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
                 new[] { new Literal(1) });
             var env = new SolusEnvironment();
             // when
-            var result = expr.Result.IsScalar(env);
+            var result = expr.GetResultType(env).IsScalar(env);
             // then
             Assert.IsTrue(result);
         }
@@ -90,7 +90,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
                 new[] { new Literal(1) });
             var env = new SolusEnvironment();
             // when
-            var result = expr.Result.IsVector(env);
+            var result = expr.GetResultType(env).IsVector(env);
             // then
             Assert.IsFalse(result);
         }
@@ -113,7 +113,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
                 new[] { new Literal(1) });
             var env = new SolusEnvironment();
             // when
-            var result = expr.Result.IsVector(env);
+            var result = expr.GetResultType(env).IsVector(env);
             // then
             Assert.IsFalse(result);
         }
@@ -136,7 +136,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
                 new[] { new Literal(1) });
             var env = new SolusEnvironment();
             // when
-            var result = expr.Result.IsMatrix(env);
+            var result = expr.GetResultType(env).IsMatrix(env);
             // then
             Assert.IsFalse(result);
         }
@@ -159,7 +159,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
                 new[] { new Literal(1) });
             var env = new SolusEnvironment();
             // when
-            var result = expr.Result.IsMatrix(env);
+            var result = expr.GetResultType(env).IsMatrix(env);
             // then
             Assert.IsFalse(result);
         }
@@ -182,7 +182,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
                 new[] { new Literal(1) });
             var env = new SolusEnvironment();
             // when
-            var result = expr.Result.IsString(env);
+            var result = expr.GetResultType(env).IsString(env);
             // then
             Assert.IsFalse(result);
         }
@@ -205,7 +205,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
                 new[] { new Literal(1) });
             var env = new SolusEnvironment();
             // when
-            var result = expr.Result.IsString(env);
+            var result = expr.GetResultType(env).IsString(env);
             // then
             Assert.IsFalse(result);
         }
@@ -228,7 +228,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
                 new[] { new Literal(1) });
             var env = new SolusEnvironment();
             // when
-            var result = expr.Result.GetTensorRank(env);
+            var result = expr.GetResultType(env).GetTensorRank(env);
             // then
             Assert.AreEqual(result, 0);
         }
@@ -251,7 +251,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
                 new[] { new Literal(1) });
             var env = new SolusEnvironment();
             // when
-            var result = expr.Result.GetTensorRank(env);
+            var result = expr.GetResultType(env).GetTensorRank(env);
             // then
             Assert.AreEqual(result, 0);
         }
@@ -274,7 +274,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
                 new[] { new Literal(1) });
             var env = new SolusEnvironment();
             // when
-            var result = expr.Result.GetDimension(env, 0);
+            var result = expr.GetResultType(env).GetDimension(env, 0);
             // then
             Assert.IsNull(result);
         }
@@ -299,7 +299,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
                 new[] { new Literal(1) });
             var env = new SolusEnvironment();
             // when
-            var result = expr.Result.GetDimensions(env);
+            var result = expr.GetResultType(env).GetDimensions(env);
             // then
             Assert.IsNull(result);
         }
@@ -322,7 +322,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
                 new[] { new Literal(1) });
             var env = new SolusEnvironment();
             // when
-            var result = expr.Result.GetVectorLength(env);
+            var result = expr.GetResultType(env).GetVectorLength(env);
             // then
             Assert.IsNull(result);
         }
@@ -348,7 +348,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
                 new[] { new Literal(0), new Literal(1) });
             var env = new SolusEnvironment();
             // when
-            var result = expr.Result.IsScalar(env);
+            var result = expr.GetResultType(env).IsScalar(env);
             // then
             Assert.IsTrue(result);
         }
@@ -368,7 +368,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
                 new[] { new Literal(1) });
             var env = new SolusEnvironment();
             // when
-            var result = expr.Result.IsString(env);
+            var result = expr.GetResultType(env).IsString(env);
             // theTruesert.IsNull(result);
         }
 

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/ComponentAccessT/SimplifyTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/ComponentAccessT/SimplifyTest.cs
@@ -175,10 +175,12 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
 
         class MockTensorExpression : TensorExpression
         {
+            private readonly IMathObject _result;
+
             public MockTensorExpression(int tensorRank)
             {
                 TensorRank = tensorRank;
-                Result = new MockMathObjectF(
+                _result = new MockMathObjectF(
                     isScalarF: e => TensorRank == 0,
                     isVectorF: e => TensorRank == 1,
                     isMatrixF: e => TensorRank == 2,
@@ -202,7 +204,8 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             public override void ApplyToAll(Modulator mod) =>
                 throw new NotImplementedException();
 
-            public override IMathObject Result { get; }
+            public override IMathObject GetResultType(SolusEnvironment env) =>
+                _result;
         }
 
         [Test]

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/DerivativeOfVariableT/ResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/DerivativeOfVariableT/ResultTest.cs
@@ -39,7 +39,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.DerivativeOfVariableT
             Assert.Throws<NotImplementedException>(
                 () =>
                 {
-                    var result = expr.Result;
+                    var result = expr.GetResultType(env);
                 });
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/FunctionCallT/ResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/FunctionCallT/ResultTest.cs
@@ -49,7 +49,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.FunctionCallT
             Assert.IsFalse(mmo.IsFunction(env));
             Assert.IsFalse(mmo.IsExpression(env));
             // when
-            var result = expr.Result;
+            var result = expr.GetResultType(env);
             // then
             Assert.IsTrue(result.IsScalar(env));
             Assert.IsFalse(result.IsVector(env));
@@ -84,7 +84,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.FunctionCallT
             Assert.IsFalse(mmo.IsFunction(env));
             Assert.IsFalse(mmo.IsExpression(env));
             // when
-            var result = expr.Result;
+            var result = expr.GetResultType(env);
             // then
             Assert.IsFalse(result.IsScalar(env));
             Assert.IsFalse(result.IsVector(env));

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/IntervalExpressionT/ResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/IntervalExpressionT/ResultTest.cs
@@ -37,7 +37,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.IntervalExpressionT
                 new Literal(2), true);
             var env = new SolusEnvironment();
             // when
-            var result = expr.Result;
+            var result = expr.GetResultType(env);
             // then
             Assert.IsFalse(result.IsScalar(env));
             Assert.IsFalse(result.IsVector(env));
@@ -58,7 +58,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.IntervalExpressionT
                 new VariableAccess("b"), true);
             var env = new SolusEnvironment();
             // when
-            var result = expr.Result;
+            var result = expr.GetResultType(env);
             // then
             Assert.IsFalse(result.IsScalar(env));
             Assert.IsFalse(result.IsVector(env));

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/LiteralT/ResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/LiteralT/ResultTest.cs
@@ -43,7 +43,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.LiteralT
             Assert.AreEqual(0, value.GetTensorRank(env));
             Assert.IsFalse(value.IsString(env));
             // when
-            var result = expr.Result;
+            var result = expr.GetResultType(env);
             // then
             Assert.IsTrue(result.IsScalar(env));
             Assert.IsFalse(result.IsVector(env));
@@ -75,7 +75,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.LiteralT
             Assert.AreEqual(4, value.GetDimension(env, 1));
             Assert.IsFalse(value.IsString(env));
             // when
-            var result = expr.Result;
+            var result = expr.GetResultType(env);
             // then
             Assert.IsFalse(result.IsScalar(env));
             Assert.IsFalse(result.IsVector(env));
@@ -100,7 +100,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.LiteralT
             Assert.AreEqual(0, value.GetTensorRank(env));
             Assert.IsTrue(value.IsString(env));
             // when
-            var result = expr.Result;
+            var result = expr.GetResultType(env);
             // then
             Assert.IsFalse(result.IsScalar(env));
             Assert.IsFalse(result.IsVector(env));

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/MatrixExpressionT/ResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/MatrixExpressionT/ResultTest.cs
@@ -41,7 +41,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.MatrixExpressionT
                 new VariableAccess("f"));
             var env = new SolusEnvironment();
             // when
-            var result = expr.Result;
+            var result = expr.GetResultType(env);
             // then
             Assert.IsFalse(result.IsScalar(env));
             Assert.IsFalse(result.IsVector(env));

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/RandomExpressionT/ResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/RandomExpressionT/ResultTest.cs
@@ -35,7 +35,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.RandomExpressionT
             var expr = new RandomExpression();
             var env = new SolusEnvironment();
             // when
-            var result = expr.Result;
+            var result = expr.GetResultType(env);
             // then
             Assert.IsTrue(result.IsScalar(env));
             Assert.IsFalse(result.IsVector(env));

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/VariableAccessT/ResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/VariableAccessT/ResultTest.cs
@@ -44,7 +44,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.VariableAccessT
             Assert.AreEqual(0, mmo.GetTensorRank(env));
             Assert.IsFalse(mmo.IsString(env));
             // when
-            var result = expr.Result;
+            var result = expr.GetResultType(env);
             // then
             Assert.IsTrue(result.IsScalar(env));
             Assert.IsFalse(result.IsVector(env));
@@ -72,7 +72,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.VariableAccessT
             Assert.AreEqual(4, mmo.GetDimension(env, 1));
             Assert.IsFalse(mmo.IsString(env));
             // when
-            var result = expr.Result;
+            var result = expr.GetResultType(env);
             // then
             Assert.IsFalse(result.IsScalar(env));
             Assert.IsFalse(result.IsVector(env));
@@ -100,7 +100,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.VariableAccessT
             Assert.AreEqual(0, mmo.GetTensorRank(env));
             Assert.IsTrue(mmo.IsString(env));
             // when
-            var result = expr.Result;
+            var result = expr.GetResultType(env);
             // then
             Assert.IsFalse(result.IsScalar(env));
             Assert.IsFalse(result.IsVector(env));
@@ -116,7 +116,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.VariableAccessT
             var expr = new VariableAccess("a");
             var env = new SolusEnvironment();  // no "a"
             // when
-            var result = expr.Result;
+            var result = expr.GetResultType(env);
             // then
             Assert.IsNull(result.IsScalar(env));
             Assert.IsNull(result.IsVector(env));

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/VectorExpressionT/ResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/VectorExpressionT/ResultTest.cs
@@ -39,7 +39,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.VectorExpressionT
                 new VariableAccess("d"));
             var env = new SolusEnvironment();
             // when
-            var result = expr.Result;
+            var result = expr.GetResultType(env);
             // then
             Assert.IsFalse(result.IsScalar(env));
             Assert.IsTrue(result.IsVector(env));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/AbsoluteValueFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/AbsoluteValueFunctionT/GetResultTest.cs
@@ -42,7 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.AbsoluteValueFunctionT
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = AbsoluteValueFunction.Value.GetResult(args);
+            var value = AbsoluteValueFunction.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/AdditionOperationT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/AdditionOperationT/GetResultTest.cs
@@ -43,7 +43,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.AdditionOperationT
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = AdditionOperation.Value.GetResult(args);
+            var value = AdditionOperation.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
@@ -66,7 +67,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.AdditionOperationT
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsTrue(arg1.IsString(null));
             // when
-            var result = AdditionOperation.Value.GetResult(args);
+            var value = AdditionOperation.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsFalse(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/AdditionOperationT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/AdditionOperationT/GetResultTest.cs
@@ -70,11 +70,11 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.AdditionOperationT
             var value = AdditionOperation.Value;
             var result = value.GetResultType(null, args);
             // then
-            Assert.IsFalse(result.IsScalar(null));
+            Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
             Assert.AreEqual(0, result.GetTensorRank(null));
-            Assert.IsTrue(result.IsString(null));
+            Assert.IsFalse(result.IsString(null));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/ArccosecantFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/ArccosecantFunctionT/GetResultTest.cs
@@ -42,7 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.ArccosecantFunctionT
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = ArccosecantFunction.Value.GetResult(args);
+            var value = ArccosecantFunction.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/ArccosineFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/ArccosineFunctionT/GetResultTest.cs
@@ -42,7 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.ArccosineFunctionT
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = ArccosineFunction.Value.GetResult(args);
+            var value = ArccosineFunction.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/ArccotangentFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/ArccotangentFunctionT/GetResultTest.cs
@@ -42,7 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.ArccotangentFunctionT
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = ArccotangentFunction.Value.GetResult(args);
+            var value = ArccotangentFunction.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/ArcsecantFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/ArcsecantFunctionT/GetResultTest.cs
@@ -42,7 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.ArcsecantFunctionT
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = ArcsecantFunction.Value.GetResult(args);
+            var value = ArcsecantFunction.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/ArcsineFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/ArcsineFunctionT/GetResultTest.cs
@@ -42,7 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.ArcsineFunctionT
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = ArcsineFunction.Value.GetResult(args);
+            var value = ArcsineFunction.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/Arctangent2FunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/Arctangent2FunctionT/GetResultTest.cs
@@ -42,7 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.Arctangent2FunctionT
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = Arctangent2Function.Value.GetResult(args);
+            var value = Arctangent2Function.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/ArctangentFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/ArctangentFunctionT/GetResultTest.cs
@@ -42,7 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.ArctangentFunctionT
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = ArctangentFunction.Value.GetResult(args);
+            var value = ArctangentFunction.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/BitwiseAndOperationT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/BitwiseAndOperationT/GetResultTest.cs
@@ -42,7 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.BitwiseAndOperationT
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = BitwiseAndOperation.Value.GetResult(args);
+            var value = BitwiseAndOperation.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/BitwiseOrOperationT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/BitwiseOrOperationT/GetResultTest.cs
@@ -42,7 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.BitwiseOrOperationT
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = BitwiseOrOperation.Value.GetResult(args);
+            var value = BitwiseOrOperation.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/CatmullRomSplineT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/CatmullRomSplineT/GetResultTest.cs
@@ -44,7 +44,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.CatmullRomSplineT
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = f.GetResult(args);
+            var result = f.GetResultType(null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/CeilingFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/CeilingFunctionT/GetResultTest.cs
@@ -42,7 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.CeilingFunctionT
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = CeilingFunction.Value.GetResult(args);
+            var value = CeilingFunction.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/CosecantFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/CosecantFunctionT/GetResultTest.cs
@@ -42,7 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.CosecantFunctionT
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = CosecantFunction.Value.GetResult(args);
+            var value = CosecantFunction.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/CosineFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/CosineFunctionT/GetResultTest.cs
@@ -42,7 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.CosineFunctionT
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = CosineFunction.Value.GetResult(args);
+            var value = CosineFunction.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/CotangentFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/CotangentFunctionT/GetResultTest.cs
@@ -42,7 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.CotangentFunctionT
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = CotangentFunction.Value.GetResult(args);
+            var value = CotangentFunction.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/DistFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/DistFunctionT/GetResultTest.cs
@@ -42,7 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.DistFunctionT
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = DistFunction.Value.GetResult(args);
+            var value = DistFunction.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/DistSqFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/DistSqFunctionT/GetResultTest.cs
@@ -42,7 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.DistSqFunctionT
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = DistSqFunction.Value.GetResult(args);
+            var value = DistSqFunction.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/DivisionOperationT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/DivisionOperationT/GetResultTest.cs
@@ -42,7 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.DivisionOperationT
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = DivisionOperation.Value.GetResult(args);
+            var value = DivisionOperation.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/EqualComparisonOperationT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/EqualComparisonOperationT/GetResultTest.cs
@@ -43,7 +43,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = EqualComparisonOperation.Value.GetResult(args);
+            var value = EqualComparisonOperation.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/ExponentOperationT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/ExponentOperationT/GetResultTest.cs
@@ -42,7 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.ExponentOperationT
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = ExponentOperation.Value.GetResult(args);
+            var value = ExponentOperation.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/FactorialFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/FactorialFunctionT/GetResultTest.cs
@@ -42,7 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.FactorialFunctionT
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = FactorialFunction.Value.GetResult(args);
+            var value = FactorialFunction.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/FloorFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/FloorFunctionT/GetResultTest.cs
@@ -42,7 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.FloorFunctionT
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = FloorFunction.Value.GetResult(args);
+            var value = FloorFunction.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/GreaterThanComparisonOperationT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/GreaterThanComparisonOperationT/GetResultTest.cs
@@ -43,7 +43,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = GreaterThanComparisonOperation.Value.GetResult(args);
+            var value = GreaterThanComparisonOperation.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/GreaterThanOrEqualComparisonOperationT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/GreaterThanOrEqualComparisonOperationT/GetResultTest.cs
@@ -44,7 +44,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.
             Assert.IsFalse(arg1.IsString(null));
             // when
             var result =
-                GreaterThanOrEqualComparisonOperation.Value.GetResult(args);
+                GreaterThanOrEqualComparisonOperation.Value.GetResultType(
+                    null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/LessThanComparisonOperationT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/LessThanComparisonOperationT/GetResultTest.cs
@@ -43,7 +43,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = LessThanComparisonOperation.Value.GetResult(args);
+            var value = LessThanComparisonOperation.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/LessThanOrEqualComparisonOperationT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/LessThanOrEqualComparisonOperationT/GetResultTest.cs
@@ -44,7 +44,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.
             Assert.IsFalse(arg1.IsString(null));
             // when
             var result =
-                LessThanOrEqualComparisonOperation.Value.GetResult(args);
+                LessThanOrEqualComparisonOperation.Value.GetResultType(
+                    null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/LoadImageFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/LoadImageFunctionT/GetResultTest.cs
@@ -43,7 +43,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.LoadImageFunctionT
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = LoadImageFunction.Value.GetResult(args);
+            var value = LoadImageFunction.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsFalse(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/Log10FunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/Log10FunctionT/GetResultTest.cs
@@ -41,7 +41,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.Log10FunctionT
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = Log10Function.Value.GetResult(args);
+            var value = Log10Function.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/Log2FunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/Log2FunctionT/GetResultTest.cs
@@ -42,7 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.Log2FunctionT
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = Log2Function.Value.GetResult(args);
+            var value = Log2Function.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/LogarithmFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/LogarithmFunctionT/GetResultTest.cs
@@ -43,7 +43,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.LogarithmFunctionT
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = LogarithmFunction.Value.GetResult(args);
+            var value = LogarithmFunction.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/LogicalAndOperationT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/LogicalAndOperationT/GetResultTest.cs
@@ -42,7 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.LogicalAndOperationT
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = LogicalAndOperation.Value.GetResult(args);
+            var value = LogicalAndOperation.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/LogicalOrOperationT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/LogicalOrOperationT/GetResultTest.cs
@@ -42,7 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.LogicalOrOperationT
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = LogicalOrOperation.Value.GetResult(args);
+            var value = LogicalOrOperation.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/ModularDivisionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/ModularDivisionT/GetResultTest.cs
@@ -42,7 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.ModularDivisionT
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = ModularDivision.Value.GetResult(args);
+            var value = ModularDivision.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/MultiplicationOperationT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/MultiplicationOperationT/GetResultTest.cs
@@ -42,7 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.MultiplicationOperationT
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = MultiplicationOperation.Value.GetResult(args);
+            var value = MultiplicationOperation.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
@@ -64,7 +65,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.MultiplicationOperationT
             Assert.AreEqual(1, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = MultiplicationOperation.Value.GetResult(args);
+            var value = MultiplicationOperation.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsFalse(result.IsScalar(null));
             Assert.IsTrue(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/NaturalLogarithmFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/NaturalLogarithmFunctionT/GetResultTest.cs
@@ -42,7 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.NaturalLogarithmFunctionT
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = NaturalLogarithmFunction.Value.GetResult(args);
+            var value = NaturalLogarithmFunction.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/NegationOperationT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/NegationOperationT/GetResultTest.cs
@@ -42,7 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.NegationOperationT
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = NegationOperation.Value.GetResult(args);
+            var value = NegationOperation.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
@@ -64,7 +65,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.NegationOperationT
             Assert.AreEqual(1, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = NegationOperation.Value.GetResult(args);
+            var value = NegationOperation.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsFalse(result.IsScalar(null));
             Assert.IsTrue(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/NotEqualComparisonOperationT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/NotEqualComparisonOperationT/GetResultTest.cs
@@ -43,7 +43,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = NotEqualComparisonOperation.Value.GetResult(args);
+            var value = NotEqualComparisonOperation.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/SecantFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/SecantFunctionT/GetResultTest.cs
@@ -42,7 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.SecantFunctionT
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = SecantFunction.Value.GetResult(args);
+            var value = SecantFunction.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/SineFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/SineFunctionT/GetResultTest.cs
@@ -42,7 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.SineFunctionT
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = SineFunction.Value.GetResult(args);
+            var value = SineFunction.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/SizeFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/SizeFunctionT/GetResultTest.cs
@@ -42,7 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.SizeFunctionT
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = SizeFunction.Value.GetResult(args);
+            var value = SizeFunction.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsFalse(result.IsScalar(null));
             Assert.IsTrue(result.IsVector(null));
@@ -66,7 +67,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.SizeFunctionT
             Assert.AreEqual(1, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = SizeFunction.Value.GetResult(args);
+            var value = SizeFunction.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsFalse(result.IsScalar(null));
             Assert.IsTrue(result.IsVector(null));
@@ -90,7 +92,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.SizeFunctionT
             Assert.AreEqual(2, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = SizeFunction.Value.GetResult(args);
+            var value = SizeFunction.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsFalse(result.IsScalar(null));
             Assert.IsTrue(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/TangentFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/TangentFunctionT/GetResultTest.cs
@@ -42,7 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.TangentFunctionT
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = TangentFunction.Value.GetResult(args);
+            var value = TangentFunction.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/UnitStepFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/UnitStepFunctionT/GetResultTest.cs
@@ -42,7 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.UnitStepFunctionT
             Assert.AreEqual(0, arg1.GetTensorRank(null));
             Assert.IsFalse(arg1.IsString(null));
             // when
-            var result = UnitStepFunction.Value.GetResult(args);
+            var value = UnitStepFunction.Value;
+            var result = value.GetResultType(null, args);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/UserDefinedFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/UserDefinedFunctionT/GetResultTest.cs
@@ -43,7 +43,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.UserDefinedFunctionT
             Assert.AreEqual(0, expr.GetResultType(null).GetTensorRank(null));
             Assert.IsFalse(expr.GetResultType(null).IsString(null));
             // when
-            var result = f.GetResult(new IMathObject[0]);
+            var result = f.GetResultType(null, new IMathObject[0]);
             // then
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
@@ -65,7 +65,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.UserDefinedFunctionT
             Assert.AreEqual(1, expr.GetResultType(null).GetTensorRank(null));
             Assert.IsFalse(expr.GetResultType(null).IsString(null));
             // when
-            var result = f.GetResult(new IMathObject[0]);
+            var result = f.GetResultType(null, new IMathObject[0]);
             // then
             Assert.IsFalse(result.IsScalar(null));
             Assert.IsTrue(result.IsVector(null));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/UserDefinedFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/UserDefinedFunctionT/GetResultTest.cs
@@ -37,11 +37,11 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.UserDefinedFunctionT
             var expr = new Literal(1.ToNumber());
             var f = new UserDefinedFunction("f", new string[0], expr);
             // precondition
-            Assert.IsTrue(expr.Result.IsScalar(null));
-            Assert.IsFalse(expr.Result.IsVector(null));
-            Assert.IsFalse(expr.Result.IsMatrix(null));
-            Assert.AreEqual(0, expr.Result.GetTensorRank(null));
-            Assert.IsFalse(expr.Result.IsString(null));
+            Assert.IsTrue(expr.GetResultType(null).IsScalar(null));
+            Assert.IsFalse(expr.GetResultType(null).IsVector(null));
+            Assert.IsFalse(expr.GetResultType(null).IsMatrix(null));
+            Assert.AreEqual(0, expr.GetResultType(null).GetTensorRank(null));
+            Assert.IsFalse(expr.GetResultType(null).IsString(null));
             // when
             var result = f.GetResult(new IMathObject[0]);
             // then
@@ -59,11 +59,11 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.UserDefinedFunctionT
             var expr = new Literal(new Vector(new float[] { 1, 2, 3 }));
             var f = new UserDefinedFunction("f", new string[0], expr);
             // precondition
-            Assert.IsFalse(expr.Result.IsScalar(null));
-            Assert.IsTrue(expr.Result.IsVector(null));
-            Assert.IsFalse(expr.Result.IsMatrix(null));
-            Assert.AreEqual(1, expr.Result.GetTensorRank(null));
-            Assert.IsFalse(expr.Result.IsString(null));
+            Assert.IsFalse(expr.GetResultType(null).IsScalar(null));
+            Assert.IsTrue(expr.GetResultType(null).IsVector(null));
+            Assert.IsFalse(expr.GetResultType(null).IsMatrix(null));
+            Assert.AreEqual(1, expr.GetResultType(null).GetTensorRank(null));
+            Assert.IsFalse(expr.GetResultType(null).IsString(null));
             // when
             var result = f.GetResult(new IMathObject[0]);
             // then

--- a/MetaphysicsIndustries.Solus.Test/MockExpression.cs
+++ b/MetaphysicsIndustries.Solus.Test/MockExpression.cs
@@ -71,7 +71,8 @@ namespace MetaphysicsIndustries.Solus.Test
         }
 
         private IMathObject _result;
-        public override IMathObject Result => _result;
+        public override IMathObject GetResultType(SolusEnvironment env) =>
+            _result;
         public void SetResult(IMathObject value) => _result = value;
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/MockFunction.cs
+++ b/MetaphysicsIndustries.Solus.Test/MockFunction.cs
@@ -46,11 +46,11 @@ namespace MetaphysicsIndustries.Solus.Test
         public override bool ProvidesCustomCall => true;
 
         public Func<IEnumerable<IMathObject>, IMathObject> GetResultF;
-        public override IMathObject GetResult(
-            IEnumerable<IMathObject> args)
+        public override IMathObject GetResultType(SolusEnvironment env,
+            IEnumerable<IMathObject> argTypes)
         {
             if (GetResultF != null)
-                return GetResultF(args);
+                return GetResultF(argTypes);
             throw new NotImplementedException();
         }
 

--- a/MetaphysicsIndustries.Solus.Test/SolusParserT/SolusParserTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/SolusParserT/SolusParserTest.cs
@@ -547,8 +547,8 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             }
             public override bool ProvidesCustomCall => true;
 
-            public override IMathObject GetResult(
-                IEnumerable<IMathObject> args)
+            public override IMathObject GetResultType(SolusEnvironment env,
+                IEnumerable<IMathObject> argTypes)
             {
                 throw new NotImplementedException();
             }
@@ -591,8 +591,8 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             {
             }
 
-            public override IMathObject GetResult(
-                IEnumerable<IMathObject> args)
+            public override IMathObject GetResultType(SolusEnvironment env,
+                IEnumerable<IMathObject> argTypes)
             {
                 throw new NotImplementedException();
             }

--- a/MetaphysicsIndustries.Solus.csproj
+++ b/MetaphysicsIndustries.Solus.csproj
@@ -158,6 +158,9 @@
     <Compile Include="Compiler\IlParam.cs" />
     <Compile Include="Compiler\Instruction.cs" />
     <Compile Include="Compiler\NascentMethod.cs" />
+    <Compile Include="Compiler\VariableIdentity.cs" />
+    <Compile Include="Compiler\VariableIdentityMap.cs" />
+    <Compile Include="Compiler\VariableSource.cs" />
     <Compile Include="Evaluators\AggregateOp.cs" />
     <Compile Include="Evaluators\BasicEvaluator.cs" />
     <Compile Include="Evaluators\BasicEvaluator.Expressions.cs" />


### PR DESCRIPTION
This PR implements user-defined functions in the compiling evaluator. In order to do this, it also changes a number of things about how expression and function result types are determined, making it a bit more flexible.