### PR TITLE
Evaluator 29: Intervals and misc fixes

### DIFF
--- a/Compiler/CompiledExpression.cs
+++ b/Compiler/CompiledExpression.cs
@@ -81,6 +81,13 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 return m.ToMatrix();
             if (result is string s)
                 return s.ToStringValue();
+            if (result is STuple<float, bool, float, bool> st)
+                return new Interval(
+                    st.Value1,
+                    st.Value2,
+                    st.Value3,
+                    st.Value4,
+                    false);
 
             throw new InvalidOperationException(
                 $"Unsupported result type: {result.GetType()}");

--- a/Compiler/ILCompiler.Expressions.Literal.cs
+++ b/Compiler/ILCompiler.Expressions.Literal.cs
@@ -33,6 +33,8 @@ namespace MetaphysicsIndustries.Solus.Compiler
             Literal expr, NascentMethod nm,
             VariableIdentityMap variables)
         {
+            // TODO: work out how to use `variables` in place of null `env`
+
             if (expr.Value.IsIsScalar(null))
             {
                 var value = expr.Value.ToFloat();
@@ -93,6 +95,26 @@ namespace MetaphysicsIndustries.Solus.Compiler
             if (expr.Value.IsIsString(null))
                 return new LoadStringIlExpression(
                     expr.Value.ToStringValue().Value);
+
+            if (expr.Value.IsIsInterval(null))
+            {
+                var ii = expr.Value.ToInterval();
+                var stuple = typeof(STuple<float, bool, float, bool>);
+                var ctor = stuple.GetConstructor(
+                    new[]
+                    {
+                        typeof(float),
+                        typeof(bool),
+                        typeof(float),
+                        typeof(bool)
+                    });
+                var rv = new NewObjIlExpression(ctor,
+                    new LoadConstantIlExpression(ii.LowerBound),
+                    new LoadConstantIlExpression(ii.OpenLowerBound),
+                    new LoadConstantIlExpression(ii.UpperBound),
+                    new LoadConstantIlExpression(ii.OpenUpperBound));
+                return rv;
+            }
 
             throw new NotImplementedException(
                 "currently only implemented for numbers, vectors, " +

--- a/Compiler/ILCompiler.Expressions.cs
+++ b/Compiler/ILCompiler.Expressions.cs
@@ -51,6 +51,8 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 $"Unsupported expression type: \"{expr}\"", nameof(expr));
         }
 
+        // TODO: copy-paste IlCompiler.Expressions.*.cs here
+
         public IlExpression ConvertToIlExpression(IntervalExpression expr,
             NascentMethod nm, VariableIdentityMap variables)
         {

--- a/Compiler/ILCompiler.Expressions.cs
+++ b/Compiler/ILCompiler.Expressions.cs
@@ -45,8 +45,29 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 return ConvertToIlExpression(ve, nm, variables);
             if (expr is MatrixExpression me)
                 return ConvertToIlExpression(me, nm, variables);
+            if (expr is IntervalExpression ie)
+                return ConvertToIlExpression(ie, nm, variables);
             throw new ArgumentException(
                 $"Unsupported expression type: \"{expr}\"", nameof(expr));
+        }
+
+        public IlExpression ConvertToIlExpression(IntervalExpression expr,
+            NascentMethod nm, VariableIdentityMap variables)
+        {
+            var lower = ConvertToIlExpression(expr.LowerBound, nm, variables);
+            var isLowerOpen = new LoadConstantIlExpression(expr.OpenLowerBound);
+            var upper = ConvertToIlExpression(expr.UpperBound, nm, variables);
+            var isUpperOpen = new LoadConstantIlExpression(expr.OpenUpperBound);
+            // TODO: IsIntegerInterval ?
+            var stuple = typeof(STuple<float, bool, float, bool>);
+            var ctor = stuple.GetConstructor(
+                new[]
+                {
+                    typeof(float), typeof(bool), typeof(float), typeof(bool)
+                });
+            var rv = new NewObjIlExpression(ctor,
+                lower, isLowerOpen, upper, isUpperOpen);
+            return rv;
         }
     }
 }

--- a/Compiler/ILCompiler.cs
+++ b/Compiler/ILCompiler.cs
@@ -186,6 +186,8 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 return typeof(float[,]);
             if (value.IsIsFunction(typeEnv))
                 return typeof(MethodInfo);
+            if (value.IsIsInterval(typeEnv))
+                return typeof(STuple<float, bool, float, bool>);
             throw new NotImplementedException(
                 $"Unrecognized type, {value.GetType()}");
         }

--- a/Compiler/IlExpressions/LoadConstantIlExpression.cs
+++ b/Compiler/IlExpressions/LoadConstantIlExpression.cs
@@ -32,6 +32,8 @@ namespace MetaphysicsIndustries.Solus.Compiler.IlExpressions
             Instruction = Instruction.LoadConstant(value);
         public LoadConstantIlExpression(long value) =>
             Instruction = Instruction.LoadConstant(value);
+        public LoadConstantIlExpression(bool value) =>
+            Instruction = Instruction.LoadConstant(value ? 1L : 0L);
 
         public Instruction Instruction { get; }
 

--- a/Expressions/VariableAccess.cs
+++ b/Expressions/VariableAccess.cs
@@ -84,8 +84,18 @@ namespace MetaphysicsIndustries.Solus.Expressions
             visitor.Visit(this);
         }
 
-        public override IMathObject GetResultType(SolusEnvironment env) =>
-            _result;
+        public override IMathObject GetResultType(SolusEnvironment env)
+        {
+            if (env.ContainsVariable(VariableName))
+            {
+                var value = env.GetVariable(VariableName);
+                if (value.IsIsExpression(env))
+                    return ((Expression)value).GetResultType(env);
+                return value;
+            }
+
+            return _result;
+        }
 
         private class ResultC : IMathObject
         {

--- a/MathObjectHelper.cs
+++ b/MathObjectHelper.cs
@@ -104,6 +104,9 @@ namespace MetaphysicsIndustries.Solus
         public static Function ToFunction(this IMathObject mo) =>
             (Function)mo;
 
+        public static Interval ToInterval(this IMathObject mo) =>
+            (Interval)mo;
+
         public static Types GetMathType(this IMathObject mo,
             SolusEnvironment env=null)
         {

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/ExpressionsT/FunctionCallT/EvalFunctionCallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/ExpressionsT/FunctionCallT/EvalFunctionCallTest.cs
@@ -39,14 +39,13 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
         public void FunctionCallYieldsReturnValue()
         {
             // given
-            var mf = new MockFunction(new[] { Types.Scalar }, "f")
-            {
-                CallF = args => args.First()
-            };
-            var expr = new FunctionCall(mf, new Literal(5));
+            var udf = new UserDefinedFunction("f", new[] { "a" },
+                new VariableAccess("a"));
+            var expr = new FunctionCall(udf, new Literal(5));
             var eval = Util.CreateEvaluator<T>();
+            var env = new SolusEnvironment();
             // when
-            var result0 = eval.Eval(expr, null);
+            var result0 = eval.Eval(expr, env);
             // then
             Assert.IsNotNull(result0);
             Assert.IsTrue(result0.IsConcrete);
@@ -60,15 +59,13 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
         public void FunctionCallWithVariableTargetYieldsValue()
         {
             // given
-            var mf = new MockFunction(new[] { Types.Scalar }, "f")
-            {
-                CallF = args => args.First()
-            };
+            var udf = new UserDefinedFunction("f", new[] { "a" },
+                new VariableAccess("a"));
             var expr = new FunctionCall(new VariableAccess("f"),
                 new Expression[] { new Literal(5) });
             var eval = Util.CreateEvaluator<T>();
             var env = new SolusEnvironment();
-            env.SetVariable("f", mf);
+            env.SetVariable("f", udf);
             // when
             var result0 = eval.Eval(expr, env);
             // then

--- a/MetaphysicsIndustries.Solus.Test/TransformersT/ApplyVariablesTransformT/ApplyVariablesTransformTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/TransformersT/ApplyVariablesTransformT/ApplyVariablesTransformTest.cs
@@ -74,6 +74,23 @@ namespace MetaphysicsIndustries.Solus.Test.TransformersT.
         }
 
         [Test]
+        public void TransformVariableWithNonExpressionYieldsOther()
+        {
+            // given
+            var expr = new VariableAccess("a");
+            var value = 3.ToNumber();
+            var tf = new ApplyVariablesTransform();
+            var env = new SolusEnvironment();
+            env.SetVariable("a", value);
+            // when
+            var result = tf.Transform(expr, env);
+            // then
+            Assert.IsInstanceOf<Literal>(result);
+            var literal = (Literal)result;
+            Assert.AreEqual(literal.Value, value);
+        }
+
+        [Test]
         public void TransformMatrixYieldsTransformed()
         {
             // given

--- a/STuple.cs
+++ b/STuple.cs
@@ -51,4 +51,20 @@ namespace MetaphysicsIndustries.Solus
         public T2 Value2;
         public T3 Value3;
     }
+
+    public struct STuple<T1, T2, T3, T4>
+    {
+        public STuple(T1 value1, T2 value2, T3 value3, T4 value4)
+        {
+            Value1 = value1;
+            Value2 = value2;
+            Value3 = value3;
+            Value4 = value4;
+        }
+
+        public readonly T1 Value1;
+        public readonly T2 Value2;
+        public readonly T3 Value3;
+        public readonly T4 Value4;
+    }
 }

--- a/SolusEnvironment.cs
+++ b/SolusEnvironment.cs
@@ -29,6 +29,24 @@ namespace MetaphysicsIndustries.Solus
 {
     public class SolusEnvironment
     {
+        /// <summary>
+        /// An environment is a mapping between variable names and values.
+        /// The names are string and the values are of type IMathObject.
+        /// Often, the values are expressions, but this is not necessary. Any
+        /// IMathObject is a valid value to set for a variable.
+        ///
+        /// By default, an environment will include mappings for various
+        /// typical builtins, like trig functions.
+        ///
+        /// An environment can be a child of another environment. If a
+        /// variable is not defined in the child environment, then the parent
+        /// will be search. This process can be repeated recursively.
+        /// </summary>
+        /// <param name="useDefaults">
+        /// Whether to include the default name mappings.</param>
+        /// <param name="parent">
+        /// The next environment for recursive lookup
+        /// </param>
         public SolusEnvironment(bool useDefaults = true,
             SolusEnvironment parent = null)
         {


### PR DESCRIPTION
This PR adds support for intervals to the compiling evaluator. It also fixes some unit tests and minor variable handling.