### PR TITLE
Clean up tests

### DIFF
--- a/MetaphysicsIndustries.Solus.Test/CommandSetT/CommandSetTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CommandSetT/CommandSetTest.cs
@@ -36,9 +36,9 @@ namespace MetaphysicsIndustries.Solus.Test.CommandSetT
             // then
             Assert.IsNotNull(result);
             Assert.IsInstanceOf<CommandSet>(result);
-            Assert.AreEqual(0, result.CountCommands());
-            Assert.AreEqual(new List<string>(),
-                new List<string>(result.GetCommandNames()));
+            Assert.That(result.CountCommands(), Is.EqualTo(0));
+            Assert.That(new List<string>(result.GetCommandNames()),
+                Is.EqualTo(new List<string>()));
         }
 
         class DummyCommand : Command
@@ -63,15 +63,15 @@ namespace MetaphysicsIndustries.Solus.Test.CommandSetT
             // given
             var cs = new CommandSet();
             // precondition
-            Assert.AreEqual(0, cs.CountCommands());
-            Assert.AreEqual(new List<string>(),
-                new List<string>(cs.GetCommandNames()));
+            Assert.That(cs.CountCommands(), Is.EqualTo(0));
+            Assert.That(new List<string>(cs.GetCommandNames()),
+                Is.EqualTo(new List<string>()));
             // when
             cs.AddCommand(new DummyCommand());
             // then
-            Assert.AreEqual(1, cs.CountCommands());
-            Assert.AreEqual(new List<string> {"dummy"},
-                new List<string>(cs.GetCommandNames()));
+            Assert.That(cs.CountCommands(), Is.EqualTo(1));
+            Assert.That(new List<string>(cs.GetCommandNames()),
+                Is.EqualTo(new List<string> {"dummy"}));
         }
 
         [Test]
@@ -82,13 +82,13 @@ namespace MetaphysicsIndustries.Solus.Test.CommandSetT
             var dc = new DummyCommand();
             cs.AddCommand(dc);
             // precondition
-            Assert.AreEqual(1, cs.CountCommands());
-            Assert.AreEqual(new List<string> {"dummy"},
-                new List<string>(cs.GetCommandNames()));
+            Assert.That(cs.CountCommands(), Is.EqualTo(1));
+            Assert.That(new List<string>(cs.GetCommandNames()),
+                Is.EqualTo(new List<string> {"dummy"}));
             // when
             var result = cs.GetCommand("dummy");
             // then
-            Assert.AreSame(dc, result);
+            Assert.That(result, Is.SameAs(dc));
         }
 
         [Test]
@@ -101,12 +101,12 @@ namespace MetaphysicsIndustries.Solus.Test.CommandSetT
             cs.AddCommand(dc1);
             cs.AddCommand(dc2);
             // precondition
-            Assert.AreEqual(2, cs.CountCommands());
+            Assert.That(cs.CountCommands(), Is.EqualTo(2));
             // when
             var result = new HashSet<string>(cs.GetCommandNames());
             // then
-            Assert.AreEqual(new HashSet<string> {"dummy", "dummy2"},
-                result);
+            Assert.That(result,
+                Is.EqualTo(new HashSet<string> {"dummy", "dummy2"}));
         }
 
         [Test]
@@ -116,14 +116,14 @@ namespace MetaphysicsIndustries.Solus.Test.CommandSetT
             var cs = new CommandSet();
             var dc = new DummyCommand();
             // precondition
-            Assert.AreEqual("dummy", dc.Name);
-            Assert.AreEqual(0, cs.CountCommands());
+            Assert.That(dc.Name, Is.EqualTo("dummy"));
+            Assert.That(cs.CountCommands(), Is.EqualTo(0));
             // when
             cs.SetCommand("something", dc);
             // then
-            Assert.AreEqual(1, cs.CountCommands());
-            Assert.AreEqual(new HashSet<string> {"something"},
-                new HashSet<string>(cs.GetCommandNames()));
+            Assert.That(cs.CountCommands(), Is.EqualTo(1));
+            Assert.That(new HashSet<string>(cs.GetCommandNames()),
+                Is.EqualTo(new HashSet<string> {"something"}));
         }
 
         [Test]
@@ -134,19 +134,19 @@ namespace MetaphysicsIndustries.Solus.Test.CommandSetT
             var dc = new DummyCommand();
             cs.AddCommand(dc);
             // precondition
-            Assert.AreEqual("dummy", dc.Name);
-            Assert.AreEqual(1, cs.CountCommands());
-            Assert.AreEqual(new HashSet<string> {"dummy"},
-                new HashSet<string>(cs.GetCommandNames()));
+            Assert.That(dc.Name, Is.EqualTo("dummy"));
+            Assert.That(cs.CountCommands(), Is.EqualTo(1));
+            Assert.That(new HashSet<string>(cs.GetCommandNames()),
+                Is.EqualTo(new HashSet<string> {"dummy"}));
             // when
             cs.SetCommand("something", dc);
             // then
-            Assert.AreEqual(2, cs.CountCommands());
-            Assert.AreEqual(new HashSet<string> {"dummy", "something"},
-                new HashSet<string>(cs.GetCommandNames()));
+            Assert.That(cs.CountCommands(), Is.EqualTo(2));
+            Assert.That(new HashSet<string>(cs.GetCommandNames()),
+                Is.EqualTo(new HashSet<string> {"dummy", "something"}));
             // and
-            Assert.AreSame(cs.GetCommand("dummy"),
-                cs.GetCommand("something"));
+            Assert.That(cs.GetCommand("something"),
+                Is.SameAs(cs.GetCommand("dummy")));
         }
 
         [Test]
@@ -155,9 +155,9 @@ namespace MetaphysicsIndustries.Solus.Test.CommandSetT
             // given
             var cs = new CommandSet();
             // precondition
-            Assert.AreEqual(0, cs.CountCommands());
-            Assert.AreEqual(new HashSet<string>(),
-                new HashSet<string>(cs.GetCommandNames()));
+            Assert.That(cs.CountCommands(), Is.EqualTo(0));
+            Assert.That(new HashSet<string>(cs.GetCommandNames()),
+                Is.EqualTo(new HashSet<string>()));
             // when
             var result = cs.ContainsCommand("something");
             // then
@@ -171,9 +171,9 @@ namespace MetaphysicsIndustries.Solus.Test.CommandSetT
             var cs = new CommandSet();
             cs.AddCommand(new DummyCommand());
             // precondition
-            Assert.AreEqual(1, cs.CountCommands());
-            Assert.AreEqual(new HashSet<string> {"dummy"},
-                new HashSet<string>(cs.GetCommandNames()));
+            Assert.That(cs.CountCommands(), Is.EqualTo(1));
+            Assert.That(new HashSet<string>(cs.GetCommandNames()),
+                Is.EqualTo(new HashSet<string> {"dummy"}));
             // when
             var result = cs.ContainsCommand("dummy");
             // then
@@ -188,9 +188,9 @@ namespace MetaphysicsIndustries.Solus.Test.CommandSetT
             var dc = new DummyCommand("dummy");
             cs.SetCommand("something", new DummyCommand());
             // precondition
-            Assert.AreEqual(1, cs.CountCommands());
-            Assert.AreEqual(new HashSet<string> {"something"},
-                new HashSet<string>(cs.GetCommandNames()));
+            Assert.That(cs.CountCommands(), Is.EqualTo(1));
+            Assert.That(new HashSet<string>(cs.GetCommandNames()),
+                Is.EqualTo(new HashSet<string> {"something"}));
             // expect
             Assert.IsFalse(cs.ContainsCommand("dummy"));
             Assert.IsTrue(cs.ContainsCommand("something"));
@@ -204,16 +204,16 @@ namespace MetaphysicsIndustries.Solus.Test.CommandSetT
             var dc = new DummyCommand();
             cs.AddCommand(dc);
             // precondition
-            Assert.AreEqual("dummy", dc.Name);
-            Assert.AreEqual(1, cs.CountCommands());
-            Assert.AreEqual(new HashSet<string> {"dummy"},
-                new HashSet<string>(cs.GetCommandNames()));
+            Assert.That(dc.Name, Is.EqualTo("dummy"));
+            Assert.That(cs.CountCommands(), Is.EqualTo(1));
+            Assert.That(new HashSet<string>(cs.GetCommandNames()),
+                Is.EqualTo(new HashSet<string> {"dummy"}));
             // when
             cs.RemoveCommand("dummy");
             // then
-            Assert.AreEqual(0, cs.CountCommands());
-            Assert.AreEqual(new HashSet<string>(),
-                new HashSet<string>(cs.GetCommandNames()));
+            Assert.That(cs.CountCommands(), Is.EqualTo(0));
+            Assert.That(new HashSet<string>(cs.GetCommandNames()),
+                Is.EqualTo(new HashSet<string>()));
         }
 
         [Test]
@@ -224,17 +224,17 @@ namespace MetaphysicsIndustries.Solus.Test.CommandSetT
             var dc = new DummyCommand();
             cs.AddCommand(dc);
             // precondition
-            Assert.AreEqual("dummy", dc.Name);
-            Assert.AreEqual(1, cs.CountCommands());
-            Assert.AreEqual(new HashSet<string> {"dummy"},
-                new HashSet<string>(cs.GetCommandNames()));
+            Assert.That(dc.Name, Is.EqualTo("dummy"));
+            Assert.That(cs.CountCommands(), Is.EqualTo(1));
+            Assert.That(new HashSet<string>(cs.GetCommandNames()),
+                Is.EqualTo(new HashSet<string> {"dummy"}));
             Assert.IsFalse(cs.ContainsCommand("something"));
             // when
             cs.RemoveCommand("something");
             // then
-            Assert.AreEqual(1, cs.CountCommands());
-            Assert.AreEqual(new HashSet<string> {"dummy"},
-                new HashSet<string>(cs.GetCommandNames()));
+            Assert.That(cs.CountCommands(), Is.EqualTo(1));
+            Assert.That(new HashSet<string>(cs.GetCommandNames()),
+                Is.EqualTo(new HashSet<string> {"dummy"}));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CommandsT/HelpCommandT/ConstructListTextTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CommandsT/HelpCommandT/ConstructListTextTest.cs
@@ -43,7 +43,7 @@ namespace MetaphysicsIndustries.Solus.Test.CommandsT.HelpCommandT
             // when
             var result = HelpCommand.ConstructListText(env, cs);
             // then
-            Assert.AreEqual(@"Commands:
+            Assert.That(result, Is.EqualTo(@"Commands:
   delete func_assign help var_assign vars 
 
 Functions:
@@ -55,7 +55,7 @@ Macros:
 
 Additional topics:
   solus t 
-", result);
+"));
         }
 
         [Test]
@@ -75,7 +75,7 @@ Additional topics:
             // when
             var result = HelpCommand.ConstructListText(env, cs);
             // then
-            Assert.AreEqual(@"Commands:
+            Assert.That(result, Is.EqualTo(@"Commands:
   delete func_assign help var_assign vars 
 
 Functions:
@@ -87,7 +87,7 @@ Macros:
 
 Additional topics:
   solus t 
-", result);
+"));
         }
 
         [Test]
@@ -107,7 +107,7 @@ Additional topics:
             // when
             var result = HelpCommand.ConstructListText(env, cs);
             // then
-            Assert.AreEqual(@"Commands:
+            Assert.That(result, Is.EqualTo(@"Commands:
   delete func_assign help var_assign vars 
 
 Functions:
@@ -119,7 +119,7 @@ Macros:
 
 Additional topics:
   solus t 
-", result);
+"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CommandsT/HelpCommandT/ConstructTextTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CommandsT/HelpCommandT/ConstructTextTest.cs
@@ -38,11 +38,11 @@ namespace MetaphysicsIndustries.Solus.Test.CommandsT.HelpCommandT
             f.DocStringV = "asdf";
             env.SetVariable(f.DisplayName, f);
             // precondition
-            Assert.AreEqual("asdf", f.DocString);
+            Assert.That(f.DocString, Is.EqualTo("asdf"));
             // when
             var result = HelpCommand.Value.ConstructText(env, "f");
             // then
-            Assert.AreEqual("asdf", result);
+            Assert.That(result, Is.EqualTo("asdf"));
         }
 
         [Test]
@@ -54,11 +54,11 @@ namespace MetaphysicsIndustries.Solus.Test.CommandsT.HelpCommandT
             f.DocStringV = "asdf";
             env.SetVariable("f", f);
             // prcondition
-            Assert.AreEqual("asdf", f.DocString);
+            Assert.That(f.DocString, Is.EqualTo("asdf"));
             // when
             var result = HelpCommand.Value.ConstructText(env, "f");
             // then
-            Assert.AreEqual("asdf", result);
+            Assert.That(result, Is.EqualTo("asdf"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/AddIlExpressionT/AddIlExpressionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/AddIlExpressionT/AddIlExpressionTest.cs
@@ -42,8 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             // then
             Assert.IsNotNull(result);
             Assert.IsInstanceOf<AddIlExpression>(result);
-            Assert.AreSame(left, result.Left);
-            Assert.AreSame(right, result.Right);
+            Assert.That(result.Left, Is.SameAs(left));
+            Assert.That(result.Right, Is.SameAs(right));
         }
 
         [Test]
@@ -55,9 +55,8 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var ex = Assert.Throws<ValueException>(
                 () => new AddIlExpression(null, right));
             // and
-            Assert.AreEqual(
-                "Value cannot be null: left",
-                ex.Message);
+            Assert.That(
+                ex.Message, Is.EqualTo("Value cannot be null: left"));
         }
 
         [Test]
@@ -69,9 +68,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var ex = Assert.Throws<ValueException>(
                 () => new AddIlExpression(left, null));
             // and
-            Assert.AreEqual(
-                "Value cannot be null: right",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Value cannot be null: right"));
         }
 
         [Test]
@@ -81,9 +80,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var ex = Assert.Throws<ValueException>(
                 () => new AddIlExpression(null, null));
             // and
-            Assert.AreEqual(
-                "Value cannot be null: left",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Value cannot be null: left"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/AddIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/AddIlExpressionT/GetInstructionsTest.cs
@@ -42,14 +42,14 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
                 new MockIlExpression(il => il.Add(i2)));
             var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, nm.Instructions.Count);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(0));
             // when
             expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(3, nm.Instructions.Count);
-            Assert.AreEqual(i1, nm.Instructions[0]);
-            Assert.AreEqual(i2, nm.Instructions[1]);
-            Assert.AreEqual(Instruction.Add(), nm.Instructions[2]);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(3));
+            Assert.That(nm.Instructions[0], Is.EqualTo(i1));
+            Assert.That(nm.Instructions[1], Is.EqualTo(i2));
+            Assert.That(nm.Instructions[2], Is.EqualTo(Instruction.Add()));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/AndIlExpressionT/AndIlExpressionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/AndIlExpressionT/AndIlExpressionTest.cs
@@ -42,8 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             // then
             Assert.IsNotNull(result);
             Assert.IsInstanceOf<AndIlExpression>(result);
-            Assert.AreSame(left, result.Left);
-            Assert.AreSame(right, result.Right);
+            Assert.That(result.Left, Is.SameAs(left));
+            Assert.That(result.Right, Is.SameAs(right));
         }
 
         [Test]
@@ -55,9 +55,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var ex = Assert.Throws<ValueException>(
                 () => new AndIlExpression(null, right));
             // and
-            Assert.AreEqual(
-                "Value cannot be null: left",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Value cannot be null: left"));
         }
 
         [Test]
@@ -69,9 +69,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var ex = Assert.Throws<ValueException>(
                 () => new AndIlExpression(left, null));
             // and
-            Assert.AreEqual(
-                "Value cannot be null: right",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Value cannot be null: right"));
         }
 
         [Test]
@@ -81,9 +81,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var ex = Assert.Throws<ValueException>(
                 () => new AndIlExpression(null, null));
             // and
-            Assert.AreEqual(
-                "Value cannot be null: left",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Value cannot be null: left"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/AndIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/AndIlExpressionT/GetInstructionsTest.cs
@@ -41,14 +41,14 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
                 new MockIlExpression(il => il.Add(i2)));
             var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, nm.Instructions.Count);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(0));
             // when
             expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(3, nm.Instructions.Count);
-            Assert.AreEqual(i1, nm.Instructions[0]);
-            Assert.AreEqual(i2, nm.Instructions[1]);
-            Assert.AreEqual(Instruction.And(), nm.Instructions[2]);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(3));
+            Assert.That(nm.Instructions[0], Is.EqualTo(i1));
+            Assert.That(nm.Instructions[1], Is.EqualTo(i2));
+            Assert.That(nm.Instructions[2], Is.EqualTo(Instruction.And()));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/BrFalseIlExpressionT/BrFalseIlExpressionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/BrFalseIlExpressionT/BrFalseIlExpressionTest.cs
@@ -41,7 +41,7 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             // then
             Assert.IsNotNull(result);
             Assert.IsInstanceOf<BrFalseIlExpression>(result);
-            Assert.AreSame(target, result.Target);
+            Assert.That(result.Target, Is.SameAs(target));
         }
 
         [Test]
@@ -51,9 +51,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var ex = Assert.Throws<ValueException>(
                 () => new BrFalseIlExpression(null));
             // and
-            Assert.AreEqual(
-                "Value cannot be null: target",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Value cannot be null: target"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/BrFalseIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/BrFalseIlExpressionT/GetInstructionsTest.cs
@@ -41,19 +41,20 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
                 new MockIlExpression(il => il.Add(i1)));
             var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, nm.Instructions.Count);
-            Assert.AreEqual(0, nm.GetAllLabels().Count());
+            Assert.That(nm.Instructions.Count, Is.EqualTo(0));
+            Assert.That(nm.GetAllLabels().Count(), Is.EqualTo(0));
             // when
             expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(1, nm.Instructions.Count);
-            Assert.AreEqual(OpCodes.Brfalse, nm.Instructions[0].OpCode);
-            Assert.AreEqual(Instruction.ArgumentType.Label,
-                nm.Instructions[0].ArgType);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(1));
+            Assert.That(nm.Instructions[0].OpCode,
+                Is.EqualTo(OpCodes.Brfalse));
+            Assert.That(nm.Instructions[0].ArgType,
+                Is.EqualTo(Instruction.ArgumentType.Label));
             Assert.IsNotNull(nm.Instructions[0].LabelArg);
-            Assert.AreEqual(1, nm.GetAllLabels().Count());
-            Assert.AreSame(nm.GetAllLabels().First(),
-                nm.Instructions[0].LabelArg);
+            Assert.That(nm.GetAllLabels().Count(), Is.EqualTo(1));
+            Assert.That(nm.Instructions[0].LabelArg,
+                Is.SameAs(nm.GetAllLabels().First()));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/BrTrueIlExpressionT/BrTrueIlExpressionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/BrTrueIlExpressionT/BrTrueIlExpressionTest.cs
@@ -41,7 +41,7 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             // then
             Assert.IsNotNull(result);
             Assert.IsInstanceOf<BrTrueIlExpression>(result);
-            Assert.AreSame(target, result.Target);
+            Assert.That(result.Target, Is.SameAs(target));
         }
 
         [Test]
@@ -51,9 +51,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var ex = Assert.Throws<ValueException>(
                 () => new BrTrueIlExpression(null));
             // and
-            Assert.AreEqual(
-                "Value cannot be null: target",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Value cannot be null: target"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/BrTrueIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/BrTrueIlExpressionT/GetInstructionsTest.cs
@@ -41,19 +41,19 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
                 new MockIlExpression(il => il.Add(i1)));
             var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, nm.Instructions.Count);
-            Assert.AreEqual(0, nm.GetAllLabels().Count());
+            Assert.That(nm.Instructions.Count, Is.EqualTo(0));
+            Assert.That(nm.GetAllLabels().Count(), Is.EqualTo(0));
             // when
             expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(1, nm.Instructions.Count);
-            Assert.AreEqual(OpCodes.Brtrue, nm.Instructions[0].OpCode);
-            Assert.AreEqual(Instruction.ArgumentType.Label,
-                nm.Instructions[0].ArgType);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(1));
+            Assert.That(nm.Instructions[0].OpCode, Is.EqualTo(OpCodes.Brtrue));
+            Assert.That(nm.Instructions[0].ArgType,
+                Is.EqualTo(Instruction.ArgumentType.Label));
             Assert.IsNotNull(nm.Instructions[0].LabelArg);
-            Assert.AreEqual(1, nm.GetAllLabels().Count());
-            Assert.AreSame(nm.GetAllLabels().First(),
-                nm.Instructions[0].LabelArg);
+            Assert.That(nm.GetAllLabels().Count(), Is.EqualTo(1));
+            Assert.That(nm.Instructions[0].LabelArg,
+                Is.SameAs(nm.GetAllLabels().First()));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/BranchIlExpressionT/BranchIlExpressionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/BranchIlExpressionT/BranchIlExpressionTest.cs
@@ -41,7 +41,7 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             // then
             Assert.IsNotNull(result);
             Assert.IsInstanceOf<BranchIlExpression>(result);
-            Assert.AreSame(target, result.Target);
+            Assert.That(result.Target, Is.SameAs(target));
         }
 
         [Test]
@@ -51,9 +51,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var ex = Assert.Throws<ValueException>(
                 () => new BranchIlExpression(null));
             // and
-            Assert.AreEqual(
-                "Value cannot be null: target",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Value cannot be null: target"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/BranchIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/BranchIlExpressionT/GetInstructionsTest.cs
@@ -41,19 +41,19 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
                 new MockIlExpression(il => il.Add(i1)));
             var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, nm.Instructions.Count);
-            Assert.AreEqual(0, nm.GetAllLabels().Count());
+            Assert.That(nm.Instructions.Count, Is.EqualTo(0));
+            Assert.That(nm.GetAllLabels().Count(), Is.EqualTo(0));
             // when
             expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(1, nm.Instructions.Count);
-            Assert.AreEqual(OpCodes.Br, nm.Instructions[0].OpCode);
-            Assert.AreEqual(Instruction.ArgumentType.Label,
-                nm.Instructions[0].ArgType);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(1));
+            Assert.That(nm.Instructions[0].OpCode, Is.EqualTo(OpCodes.Br));
+            Assert.That(nm.Instructions[0].ArgType,
+                Is.EqualTo(Instruction.ArgumentType.Label));
             Assert.IsNotNull(nm.Instructions[0].LabelArg);
-            Assert.AreEqual(1, nm.GetAllLabels().Count());
-            Assert.AreSame(nm.GetAllLabels().First(),
-                nm.Instructions[0].LabelArg);
+            Assert.That(nm.GetAllLabels().Count(), Is.EqualTo(1));
+            Assert.That(nm.Instructions[0].LabelArg,
+                Is.SameAs(nm.GetAllLabels().First()));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/CallIlExpressionT/CallIlExpressionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/CallIlExpressionT/CallIlExpressionTest.cs
@@ -47,8 +47,8 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             // then
             Assert.IsNotNull(result);
             Assert.IsInstanceOf<CallIlExpression>(result);
-            Assert.AreSame(method.Method, result.Method);
-            Assert.AreSame(args, result.Args);
+            Assert.That(result.Method, Is.SameAs(method.Method));
+            Assert.That(result.Args, Is.SameAs(args));
         }
 
         [Test]
@@ -60,9 +60,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var ex = Assert.Throws<ValueException>(
                 () => new CallIlExpression((Delegate)null, args));
             // and
-            Assert.AreEqual(
-                "Value cannot be null: method",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Value cannot be null: method"));
         }
 
         [Test]
@@ -74,9 +74,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var ex = Assert.Throws<ValueException>(
                 () => new CallIlExpression(method, null));
             // and
-            Assert.AreEqual(
-                "Value cannot be null: args",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Value cannot be null: args"));
         }
 
         [Test]
@@ -86,9 +86,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var ex = Assert.Throws<ValueException>(
                 () => new CallIlExpression((Delegate)null, null));
             // and
-            Assert.AreEqual(
-                "Value cannot be null: method",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Value cannot be null: method"));
         }
 
         [Test]
@@ -104,8 +104,8 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             // then
             Assert.IsNotNull(result);
             Assert.IsInstanceOf<CallIlExpression>(result);
-            Assert.AreSame(method, result.Method);
-            Assert.AreSame(args, result.Args);
+            Assert.That(result.Method, Is.SameAs(method));
+            Assert.That(result.Args, Is.SameAs(args));
         }
 
         [Test]
@@ -117,9 +117,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var ex = Assert.Throws<ValueException>(
                 () => new CallIlExpression((MethodInfo)null, args));
             // and
-            Assert.AreEqual(
-                "Value cannot be null: method",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Value cannot be null: method"));
         }
 
         [Test]
@@ -133,9 +133,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var ex = Assert.Throws<ValueException>(
                 () => new CallIlExpression(method, null));
             // and
-            Assert.AreEqual(
-                "Value cannot be null: args",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Value cannot be null: args"));
         }
 
         [Test]
@@ -145,9 +145,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var ex = Assert.Throws<ValueException>(
                 () => new CallIlExpression((MethodInfo)null, null));
             // and
-            Assert.AreEqual(
-                "Value cannot be null: method",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Value cannot be null: method"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/CallIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/CallIlExpressionT/GetInstructionsTest.cs
@@ -46,15 +46,16 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var expr = new CallIlExpression(method, args);
             var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, nm.Instructions.Count);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(0));
             // when
             expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(1, nm.Instructions.Count);
-            Assert.AreEqual(Instruction.ArgumentType.Method,
-                nm.Instructions[0].ArgType);
-            Assert.AreEqual(method.Method, nm.Instructions[0].MethodArg);
-            Assert.AreEqual(OpCodes.Call, nm.Instructions[0].OpCode);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(1));
+            Assert.That(nm.Instructions[0].ArgType,
+                Is.EqualTo(Instruction.ArgumentType.Method));
+            Assert.That(nm.Instructions[0].MethodArg,
+                Is.EqualTo(method.Method));
+            Assert.That(nm.Instructions[0].OpCode, Is.EqualTo(OpCodes.Call));
         }
 
         [Test]
@@ -71,18 +72,22 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var expr = new CallIlExpression(method, args);
             var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, nm.Instructions.Count);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(0));
             // when
             expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(4, nm.Instructions.Count);
-            Assert.AreEqual(Instruction.LoadConstant(1), nm.Instructions[0]);
-            Assert.AreEqual(Instruction.LoadConstant(2), nm.Instructions[1]);
-            Assert.AreEqual(Instruction.LoadConstant(3), nm.Instructions[2]);
-            Assert.AreEqual(Instruction.ArgumentType.Method,
-                nm.Instructions[3].ArgType);
-            Assert.AreEqual(method.Method, nm.Instructions[3].MethodArg);
-            Assert.AreEqual(OpCodes.Call, nm.Instructions[3].OpCode);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(4));
+            Assert.That(nm.Instructions[0],
+                Is.EqualTo(Instruction.LoadConstant(1)));
+            Assert.That(nm.Instructions[1],
+                Is.EqualTo(Instruction.LoadConstant(2)));
+            Assert.That(nm.Instructions[2],
+                Is.EqualTo(Instruction.LoadConstant(3)));
+            Assert.That(nm.Instructions[3].ArgType,
+                Is.EqualTo(Instruction.ArgumentType.Method));
+            Assert.That(nm.Instructions[3].MethodArg,
+                Is.EqualTo(method.Method));
+            Assert.That(nm.Instructions[3].OpCode, Is.EqualTo(OpCodes.Call));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/CompareEqualIlExpressionT/CompareEqualIlExpressionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/CompareEqualIlExpressionT/CompareEqualIlExpressionTest.cs
@@ -42,8 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             // then
             Assert.IsNotNull(result);
             Assert.IsInstanceOf<CompareEqualIlExpression>(result);
-            Assert.AreSame(left, result.Left);
-            Assert.AreSame(right, result.Right);
+            Assert.That(result.Left, Is.SameAs(left));
+            Assert.That(result.Right, Is.SameAs(right));
         }
 
         [Test]
@@ -55,9 +55,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var ex = Assert.Throws<ValueException>(
                 () => new CompareEqualIlExpression(null, right));
             // and
-            Assert.AreEqual(
-                "Value cannot be null: left",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Value cannot be null: left"));
         }
 
         [Test]
@@ -69,9 +69,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var ex = Assert.Throws<ValueException>(
                 () => new CompareEqualIlExpression(left, null));
             // and
-            Assert.AreEqual(
-                "Value cannot be null: right",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Value cannot be null: right"));
         }
 
         [Test]
@@ -81,9 +81,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var ex = Assert.Throws<ValueException>(
                 () => new CompareEqualIlExpression(null, null));
             // and
-            Assert.AreEqual(
-                "Value cannot be null: left",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Value cannot be null: left"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/CompareEqualIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/CompareEqualIlExpressionT/GetInstructionsTest.cs
@@ -41,15 +41,15 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
                 new MockIlExpression(il => il.Add(i2)));
             var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, nm.Instructions.Count);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(0));
             // when
             expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(3, nm.Instructions.Count);
-            Assert.AreEqual(i1, nm.Instructions[0]);
-            Assert.AreEqual(i2, nm.Instructions[1]);
-            Assert.AreEqual(Instruction.CompareEqual(),
-                nm.Instructions[2]);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(3));
+            Assert.That(nm.Instructions[0], Is.EqualTo(i1));
+            Assert.That(nm.Instructions[1], Is.EqualTo(i2));
+            Assert.That(nm.Instructions[2],
+                Is.EqualTo(Instruction.CompareEqual()));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/CompareGreaterThanIlExpressionT/CompareGreaterThanIlExpressionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/CompareGreaterThanIlExpressionT/CompareGreaterThanIlExpressionTest.cs
@@ -42,8 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             // then
             Assert.IsNotNull(result);
             Assert.IsInstanceOf<CompareGreaterThanIlExpression>(result);
-            Assert.AreSame(left, result.Left);
-            Assert.AreSame(right, result.Right);
+            Assert.That(result.Left, Is.SameAs(left));
+            Assert.That(result.Right, Is.SameAs(right));
         }
 
         [Test]
@@ -55,9 +55,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var ex = Assert.Throws<ValueException>(
                 () => new CompareGreaterThanIlExpression(null, right));
             // and
-            Assert.AreEqual(
-                "Value cannot be null: left",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Value cannot be null: left"));
         }
 
         [Test]
@@ -69,9 +69,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var ex = Assert.Throws<ValueException>(
                 () => new CompareGreaterThanIlExpression(left, null));
             // and
-            Assert.AreEqual(
-                "Value cannot be null: right",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Value cannot be null: right"));
         }
 
         [Test]
@@ -81,9 +81,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var ex = Assert.Throws<ValueException>(
                 () => new CompareGreaterThanIlExpression(null, null));
             // and
-            Assert.AreEqual(
-                "Value cannot be null: left",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Value cannot be null: left"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/CompareGreaterThanIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/CompareGreaterThanIlExpressionT/GetInstructionsTest.cs
@@ -42,15 +42,15 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
                 new MockIlExpression(il => il.Add(i2)));
             var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, nm.Instructions.Count);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(0));
             // when
             expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(3, nm.Instructions.Count);
-            Assert.AreEqual(i1, nm.Instructions[0]);
-            Assert.AreEqual(i2, nm.Instructions[1]);
-            Assert.AreEqual(Instruction.CompareGreaterThan(),
-                nm.Instructions[2]);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(3));
+            Assert.That(nm.Instructions[0], Is.EqualTo(i1));
+            Assert.That(nm.Instructions[1], Is.EqualTo(i2));
+            Assert.That(nm.Instructions[2],
+                Is.EqualTo(Instruction.CompareGreaterThan()));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/CompareLessThanIlExpressionT/CompareLessThanIlExpressionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/CompareLessThanIlExpressionT/CompareLessThanIlExpressionTest.cs
@@ -42,8 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             // then
             Assert.IsNotNull(result);
             Assert.IsInstanceOf<CompareLessThanIlExpression>(result);
-            Assert.AreSame(left, result.Left);
-            Assert.AreSame(right, result.Right);
+            Assert.That(result.Left, Is.SameAs(left));
+            Assert.That(result.Right, Is.SameAs(right));
         }
 
         [Test]
@@ -55,9 +55,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var ex = Assert.Throws<ValueException>(
                 () => new CompareLessThanIlExpression(null, right));
             // and
-            Assert.AreEqual(
-                "Value cannot be null: left",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Value cannot be null: left"));
         }
 
         [Test]
@@ -69,9 +69,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var ex = Assert.Throws<ValueException>(
                 () => new CompareLessThanIlExpression(left, null));
             // and
-            Assert.AreEqual(
-                "Value cannot be null: right",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Value cannot be null: right"));
         }
 
         [Test]
@@ -81,9 +81,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var ex = Assert.Throws<ValueException>(
                 () => new CompareLessThanIlExpression(null, null));
             // and
-            Assert.AreEqual(
-                "Value cannot be null: left",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Value cannot be null: left"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/CompareLessThanIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/CompareLessThanIlExpressionT/GetInstructionsTest.cs
@@ -42,15 +42,15 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
                 new MockIlExpression(il => il.Add(i2)));
             var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, nm.Instructions.Count);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(0));
             // when
             expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(3, nm.Instructions.Count);
-            Assert.AreEqual(i1, nm.Instructions[0]);
-            Assert.AreEqual(i2, nm.Instructions[1]);
-            Assert.AreEqual(Instruction.CompareLessThan(),
-                nm.Instructions[2]);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(3));
+            Assert.That(nm.Instructions[0], Is.EqualTo(i1));
+            Assert.That(nm.Instructions[1], Is.EqualTo(i2));
+            Assert.That(nm.Instructions[2],
+                Is.EqualTo(Instruction.CompareLessThan()));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/ConvertI4IlExpressionT/ConvertI4IlExpressionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/ConvertI4IlExpressionT/ConvertI4IlExpressionTest.cs
@@ -40,7 +40,7 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             // then
             Assert.IsNotNull(result);
             Assert.IsInstanceOf<ConvertI4IlExpression>(result);
-            Assert.AreSame(argument, result.Argument);
+            Assert.That(result.Argument, Is.SameAs(argument));
         }
 
         [Test]

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/ConvertI4IlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/ConvertI4IlExpressionT/GetInstructionsTest.cs
@@ -39,13 +39,14 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
                 new MockIlExpression(il => il.Add(i1)));
             var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, nm.Instructions.Count);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(0));
             // when
             expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(2, nm.Instructions.Count);
-            Assert.AreEqual(i1, nm.Instructions[0]);
-            Assert.AreEqual(Instruction.ConvertI4(), nm.Instructions[1]);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(2));
+            Assert.That(nm.Instructions[0], Is.EqualTo(i1));
+            Assert.That(nm.Instructions[1],
+                Is.EqualTo(Instruction.ConvertI4()));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/ConvertR4IlExpressionT/ConvertR4IlExpressionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/ConvertR4IlExpressionT/ConvertR4IlExpressionTest.cs
@@ -40,7 +40,7 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             // then
             Assert.IsNotNull(result);
             Assert.IsInstanceOf<ConvertR4IlExpression>(result);
-            Assert.AreSame(argument, result.Argument);
+            Assert.That(result.Argument, Is.SameAs(argument));
         }
 
         [Test]

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/ConvertR4IlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/ConvertR4IlExpressionT/GetInstructionsTest.cs
@@ -39,13 +39,14 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
                 new MockIlExpression(il => il.Add(i1)));
             var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, nm.Instructions.Count);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(0));
             // when
             expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(2, nm.Instructions.Count);
-            Assert.AreEqual(i1, nm.Instructions[0]);
-            Assert.AreEqual(Instruction.ConvertR4(), nm.Instructions[1]);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(2));
+            Assert.That(nm.Instructions[0], Is.EqualTo(i1));
+            Assert.That(nm.Instructions[1],
+                Is.EqualTo(Instruction.ConvertR4()));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/DivIlExpressionT/DivIlExpressionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/DivIlExpressionT/DivIlExpressionTest.cs
@@ -41,8 +41,8 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             // then
             Assert.IsNotNull(result);
             Assert.IsInstanceOf<DivIlExpression>(result);
-            Assert.AreSame(dividend, result.Dividend);
-            Assert.AreSame(divisor, result.Divisor);
+            Assert.That(result.Dividend, Is.SameAs(dividend));
+            Assert.That(result.Divisor, Is.SameAs(divisor));
         }
 
         [Test]
@@ -56,7 +56,7 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             Assert.IsNotNull(result);
             Assert.IsInstanceOf<DivIlExpression>(result);
             Assert.IsNull(result.Dividend);
-            Assert.AreSame(divisor, result.Divisor);
+            Assert.That(result.Divisor, Is.SameAs(divisor));
         }
 
         [Test]
@@ -69,7 +69,7 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             // then
             Assert.IsNotNull(result);
             Assert.IsInstanceOf<DivIlExpression>(result);
-            Assert.AreSame(dividend, result.Dividend);
+            Assert.That(result.Dividend, Is.SameAs(dividend));
             Assert.IsNull(result.Divisor);
         }
 

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/DivIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/DivIlExpressionT/GetInstructionsTest.cs
@@ -41,14 +41,14 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
                 new MockIlExpression(il => il.Add(i2)));
             var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, nm.Instructions.Count);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(0));
             // when
             expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(3, nm.Instructions.Count);
-            Assert.AreEqual(i1, nm.Instructions[0]);
-            Assert.AreEqual(i2, nm.Instructions[1]);
-            Assert.AreEqual(Instruction.Div(), nm.Instructions[2]);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(3));
+            Assert.That(nm.Instructions[0], Is.EqualTo(i1));
+            Assert.That(nm.Instructions[1], Is.EqualTo(i2));
+            Assert.That(nm.Instructions[2], Is.EqualTo(Instruction.Div()));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/DupIlExpressionT/DupIlExpressionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/DupIlExpressionT/DupIlExpressionTest.cs
@@ -40,7 +40,7 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             // then
             Assert.IsNotNull(result);
             Assert.IsInstanceOf<DupIlExpression>(result);
-            Assert.AreSame(target, result.Target);
+            Assert.That(result.Target, Is.SameAs(target));
         }
 
         [Test]

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/DupIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/DupIlExpressionT/GetInstructionsTest.cs
@@ -40,12 +40,12 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
                 new MockIlExpression(il => il.Add(i1)));
             var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, nm.Instructions.Count);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(0));
             // when
             expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(1, nm.Instructions.Count);
-            Assert.AreEqual(Instruction.Dup(), nm.Instructions[0]);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(1));
+            Assert.That(nm.Instructions[0], Is.EqualTo(Instruction.Dup()));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/IlExpressionSequenceT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/IlExpressionSequenceT/GetInstructionsTest.cs
@@ -44,9 +44,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             // when
             expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(2, nm.Instructions.Count);
-            Assert.AreEqual(Instruction.Add(), nm.Instructions[0]);
-            Assert.AreEqual(Instruction.Div(), nm.Instructions[1]);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(2));
+            Assert.That(nm.Instructions[0], Is.EqualTo(Instruction.Add()));
+            Assert.That(nm.Instructions[1], Is.EqualTo(Instruction.Div()));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/IlExpressionSequenceT/IlExpressionSequenceTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/IlExpressionSequenceT/IlExpressionSequenceTest.cs
@@ -37,7 +37,7 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             // then
             Assert.NotNull(result);
             Assert.NotNull(result.Expressions);
-            Assert.AreEqual(0, result.Expressions.Length);
+            Assert.That(result.Expressions.Length, Is.EqualTo(0));
         }
 
         [Test]
@@ -52,9 +52,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
                 expr2);
             // then
             Assert.NotNull(result.Expressions);
-            Assert.AreEqual(2, result.Expressions.Length);
-            Assert.AreSame(expr1, result.Expressions[0]);
-            Assert.AreSame(expr2, result.Expressions[1]);
+            Assert.That(result.Expressions.Length, Is.EqualTo(2));
+            Assert.That(result.Expressions[0], Is.SameAs(expr1));
+            Assert.That(result.Expressions[1], Is.SameAs(expr2));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/LoadConstantIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/LoadConstantIlExpressionT/GetInstructionsTest.cs
@@ -38,15 +38,16 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var expr = new LoadConstantIlExpression(1.0d);
             var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, nm.Instructions.Count);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(0));
             // when
             expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(1, nm.Instructions.Count);
-            Assert.AreEqual(Instruction.LoadConstant(1.0d),
-                nm.Instructions[0]);
-            Assert.AreEqual(expr.Instruction, nm.Instructions[0]);
-            Assert.AreEqual(OpCodes.Ldc_R8, nm.Instructions[0].OpCode);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(1));
+            Assert.That(nm.Instructions[0],
+                Is.EqualTo(Instruction.LoadConstant(1.0d)));
+            Assert.That(nm.Instructions[0], Is.EqualTo(expr.Instruction));
+            Assert.That(nm.Instructions[0].OpCode,
+                Is.EqualTo(OpCodes.Ldc_R8));
         }
 
         [Test]
@@ -56,15 +57,16 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var expr = new LoadConstantIlExpression(1.0f);
             var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, nm.Instructions.Count);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(0));
             // when
             expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(1, nm.Instructions.Count);
-            Assert.AreEqual(Instruction.LoadConstant(1.0f),
-                nm.Instructions[0]);
-            Assert.AreEqual(expr.Instruction, nm.Instructions[0]);
-            Assert.AreEqual(OpCodes.Ldc_R4, nm.Instructions[0].OpCode);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(1));
+            Assert.That(nm.Instructions[0],
+                Is.EqualTo(Instruction.LoadConstant(1.0f)));
+            Assert.That(nm.Instructions[0], Is.EqualTo(expr.Instruction));
+            Assert.That(nm.Instructions[0].OpCode,
+                Is.EqualTo(OpCodes.Ldc_R4));
         }
 
         [Test]
@@ -74,15 +76,16 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var expr = new LoadConstantIlExpression(129);
             var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, nm.Instructions.Count);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(0));
             // when
             expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(1, nm.Instructions.Count);
-            Assert.AreEqual(Instruction.LoadConstant(129),
-                nm.Instructions[0]);
-            Assert.AreEqual(expr.Instruction, nm.Instructions[0]);
-            Assert.AreEqual(OpCodes.Ldc_I4, nm.Instructions[0].OpCode);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(1));
+            Assert.That(nm.Instructions[0],
+                Is.EqualTo(Instruction.LoadConstant(129)));
+            Assert.That(nm.Instructions[0], Is.EqualTo(expr.Instruction));
+            Assert.That(nm.Instructions[0].OpCode,
+                Is.EqualTo(OpCodes.Ldc_I4));
         }
 
         [Test]
@@ -92,15 +95,16 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var expr = new LoadConstantIlExpression(0);
             var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, nm.Instructions.Count);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(0));
             // when
             expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(1, nm.Instructions.Count);
-            Assert.AreEqual(Instruction.LoadConstant(0),
-                nm.Instructions[0]);
-            Assert.AreEqual(expr.Instruction, nm.Instructions[0]);
-            Assert.AreEqual(OpCodes.Ldc_I4_0, nm.Instructions[0].OpCode);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(1));
+            Assert.That(nm.Instructions[0],
+                Is.EqualTo(Instruction.LoadConstant(0)));
+            Assert.That(nm.Instructions[0], Is.EqualTo(expr.Instruction));
+            Assert.That(nm.Instructions[0].OpCode,
+                Is.EqualTo(OpCodes.Ldc_I4_0));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/LoadConstantIlExpressionT/LoadConstantIlExpressionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/LoadConstantIlExpressionT/LoadConstantIlExpressionTest.cs
@@ -37,7 +37,7 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var result = new LoadConstantIlExpression(1.0d);
             // then
             Assert.IsNotNull(result);
-            Assert.AreEqual(1.0d, result.Instruction.DoubleArg);
+            Assert.That(result.Instruction.DoubleArg, Is.EqualTo(1.0d));
         }
 
         [Test]
@@ -47,7 +47,7 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var result = new LoadConstantIlExpression(1.0f);
             // then
             Assert.IsNotNull(result);
-            Assert.AreEqual(1.0f, result.Instruction.FloatArg);
+            Assert.That(result.Instruction.FloatArg, Is.EqualTo(1.0f));
         }
 
         private static readonly OpCode[] OpCodeValues =
@@ -84,8 +84,8 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var result = new LoadConstantIlExpression(arg);
             // then
             Assert.IsNotNull(result);
-            Assert.AreEqual(0, result.Instruction.IntArg);
-            Assert.AreEqual(opcode, result.Instruction.OpCode);
+            Assert.That(result.Instruction.IntArg, Is.EqualTo(0));
+            Assert.That(result.Instruction.OpCode, Is.EqualTo(opcode));
         }
 
         [Test]
@@ -99,8 +99,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var result = new LoadConstantIlExpression(arg);
             // then
             Assert.IsNotNull(result);
-            Assert.AreEqual(arg, result.Instruction.IntArg);
-            Assert.AreEqual(OpCodes.Ldc_I4_S, result.Instruction.OpCode);
+            Assert.That(result.Instruction.IntArg, Is.EqualTo(arg));
+            Assert.That(result.Instruction.OpCode,
+                Is.EqualTo(OpCodes.Ldc_I4_S));
         }
 
         [Test]
@@ -114,8 +115,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var result = new LoadConstantIlExpression(arg);
             // then
             Assert.IsNotNull(result);
-            Assert.AreEqual(arg, result.Instruction.IntArg);
-            Assert.AreEqual(OpCodes.Ldc_I4, result.Instruction.OpCode);
+            Assert.That(result.Instruction.IntArg, Is.EqualTo(arg));
+            Assert.That(result.Instruction.OpCode,
+                Is.EqualTo(OpCodes.Ldc_I4));
         }
 
         [Test]
@@ -127,8 +129,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var result = new LoadConstantIlExpression(arg);
             // then
             Assert.IsNotNull(result);
-            Assert.AreEqual(arg, result.Instruction.IntArg);
-            Assert.AreEqual(OpCodes.Ldc_I8, result.Instruction.OpCode);
+            Assert.That(result.Instruction.IntArg, Is.EqualTo(arg));
+            Assert.That(result.Instruction.OpCode,
+                Is.EqualTo(OpCodes.Ldc_I8));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/LoadLocalIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/LoadLocalIlExpressionT/GetInstructionsTest.cs
@@ -55,14 +55,14 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var expr = new LoadLocalIlExpression(local);
             var opcode = OpCodeValues[arg];
             // precondition
-            Assert.AreEqual(0, nm.Instructions.Count);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(0));
             // when
             expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(1, nm.Instructions.Count);
-            Assert.AreEqual(Instruction.LoadLocalVariable(arg),
-                nm.Instructions[0]);
-            Assert.AreEqual(opcode, nm.Instructions[0].OpCode);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(1));
+            Assert.That(nm.Instructions[0],
+                Is.EqualTo(Instruction.LoadLocalVariable(arg)));
+            Assert.That(nm.Instructions[0].OpCode, Is.EqualTo(opcode));
         }
 
         [Test]
@@ -78,14 +78,15 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
                 local = nm.CreateLocal();
             var expr = new LoadLocalIlExpression(local);
             // precondition
-            Assert.AreEqual(0, nm.Instructions.Count);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(0));
             // when
             expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(1, nm.Instructions.Count);
-            Assert.AreEqual(Instruction.LoadLocalVariable(arg),
-                nm.Instructions[0]);
-            Assert.AreEqual(OpCodes.Ldloc_S, nm.Instructions[0].OpCode);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(1));
+            Assert.That(nm.Instructions[0],
+                Is.EqualTo(Instruction.LoadLocalVariable(arg)));
+            Assert.That(nm.Instructions[0].OpCode,
+                Is.EqualTo(OpCodes.Ldloc_S));
         }
 
         [Test]
@@ -101,14 +102,14 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
                 local = nm.CreateLocal();
             var expr = new LoadLocalIlExpression(local);
             // precondition
-            Assert.AreEqual(0, nm.Instructions.Count);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(0));
             // when
             expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(1, nm.Instructions.Count);
-            Assert.AreEqual(Instruction.LoadLocalVariable(arg),
-                nm.Instructions[0]);
-            Assert.AreEqual(OpCodes.Ldloc, nm.Instructions[0].OpCode);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(1));
+            Assert.That(nm.Instructions[0],
+                Is.EqualTo(Instruction.LoadLocalVariable(arg)));
+            Assert.That(nm.Instructions[0].OpCode, Is.EqualTo(OpCodes.Ldloc));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/LoadLocalIlExpressionT/LoadLocalIlExpressionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/LoadLocalIlExpressionT/LoadLocalIlExpressionTest.cs
@@ -39,7 +39,7 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var result = new LoadLocalIlExpression(local);
             // then
             Assert.IsNotNull(result);
-            Assert.AreSame(local, result.Local);
+            Assert.That(result.Local, Is.SameAs(local));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/LoadStringIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/LoadStringIlExpressionT/GetInstructionsTest.cs
@@ -38,17 +38,17 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var expr = new LoadStringIlExpression("abc123");
             var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, nm.Instructions.Count);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(0));
             // when
             expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(1, nm.Instructions.Count);
-            Assert.AreEqual(Instruction.LoadString("abc123"),
-                nm.Instructions[0]);
-            Assert.AreEqual(OpCodes.Ldstr, nm.Instructions[0].OpCode);
-            Assert.AreEqual(Instruction.ArgumentType.String,
-                nm.Instructions[0].ArgType);
-            Assert.AreEqual("abc123", nm.Instructions[0].StringArg);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(1));
+            Assert.That(nm.Instructions[0],
+                Is.EqualTo(Instruction.LoadString("abc123")));
+            Assert.That(nm.Instructions[0].OpCode, Is.EqualTo(OpCodes.Ldstr));
+            Assert.That(nm.Instructions[0].ArgType,
+                Is.EqualTo(Instruction.ArgumentType.String));
+            Assert.That(nm.Instructions[0].StringArg, Is.EqualTo("abc123"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/LoadStringIlExpressionT/LoadStringIlExpressionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/LoadStringIlExpressionT/LoadStringIlExpressionTest.cs
@@ -39,7 +39,7 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var result = new LoadStringIlExpression("abc");
             // then
             Assert.IsNotNull(result);
-            Assert.AreEqual("abc", result.Value);
+            Assert.That(result.Value, Is.EqualTo("abc"));
         }
 
         [Test]
@@ -49,9 +49,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var ex = Assert.Throws<ValueException>(
                 () => new LoadStringIlExpression(null));
             // and
-            Assert.AreEqual(
-                "Value cannot be null: value",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Value cannot be null: value"));
         }
 
     }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/MulIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/MulIlExpressionT/GetInstructionsTest.cs
@@ -41,14 +41,14 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
                 new MockIlExpression(il => il.Add(i2)));
             var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, nm.Instructions.Count);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(0));
             // when
             expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(3, nm.Instructions.Count);
-            Assert.AreEqual(i1, nm.Instructions[0]);
-            Assert.AreEqual(i2, nm.Instructions[1]);
-            Assert.AreEqual(Instruction.Mul(), nm.Instructions[2]);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(3));
+            Assert.That(nm.Instructions[0], Is.EqualTo(i1));
+            Assert.That(nm.Instructions[1], Is.EqualTo(i2));
+            Assert.That(nm.Instructions[2], Is.EqualTo(Instruction.Mul()));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/MulIlExpressionT/MulIlExpressionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/MulIlExpressionT/MulIlExpressionTest.cs
@@ -42,8 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             // then
             Assert.IsNotNull(result);
             Assert.IsInstanceOf<MulIlExpression>(result);
-            Assert.AreSame(left, result.Left);
-            Assert.AreSame(right, result.Right);
+            Assert.That(result.Left, Is.SameAs(left));
+            Assert.That(result.Right, Is.SameAs(right));
         }
 
         [Test]
@@ -55,9 +55,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var ex = Assert.Throws<ValueException>(
                 () => new MulIlExpression(null, right));
             // and
-            Assert.AreEqual(
-                "Value cannot be null: left",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Value cannot be null: left"));
         }
 
         [Test]
@@ -69,9 +69,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var ex = Assert.Throws<ValueException>(
                 () => new MulIlExpression(left, null));
             // and
-            Assert.AreEqual(
-                "Value cannot be null: right",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Value cannot be null: right"));
         }
 
         [Test]
@@ -81,9 +81,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var ex = Assert.Throws<ValueException>(
                 () => new MulIlExpression(null, null));
             // and
-            Assert.AreEqual(
-                "Value cannot be null: left",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Value cannot be null: left"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/NegIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/NegIlExpressionT/GetInstructionsTest.cs
@@ -39,13 +39,13 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
                 new MockIlExpression(il => il.Add(i1)));
             var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, nm.Instructions.Count);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(0));
             // when
             expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(2, nm.Instructions.Count);
-            Assert.AreEqual(i1, nm.Instructions[0]);
-            Assert.AreEqual(Instruction.Neg(), nm.Instructions[1]);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(2));
+            Assert.That(nm.Instructions[0], Is.EqualTo(i1));
+            Assert.That(nm.Instructions[1], Is.EqualTo(Instruction.Neg()));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/NegIlExpressionT/NegIlExpressionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/NegIlExpressionT/NegIlExpressionTest.cs
@@ -41,7 +41,7 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             // then
             Assert.IsNotNull(result);
             Assert.IsInstanceOf<NegIlExpression>(result);
-            Assert.AreSame(argument, result.Argument);
+            Assert.That(result.Argument, Is.SameAs(argument));
         }
 
         [Test]
@@ -51,9 +51,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var ex = Assert.Throws<ValueException>(
                 () => new NegIlExpression(null));
             // and
-            Assert.AreEqual(
-                "Value cannot be null: argument",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Value cannot be null: argument"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/NewObjIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/NewObjIlExpressionT/GetInstructionsTest.cs
@@ -47,15 +47,15 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var expr = new NewObjIlExpression(ctor, args);
             var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, nm.Instructions.Count);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(0));
             // when
             expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(1, nm.Instructions.Count);
-            Assert.AreEqual(Instruction.ArgumentType.Constructor,
-                nm.Instructions[0].ArgType);
-            Assert.AreSame(ctor, nm.Instructions[0].ConstructorArg);
-            Assert.AreEqual(OpCodes.Newobj, nm.Instructions[0].OpCode);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(1));
+            Assert.That(nm.Instructions[0].ArgType,
+                Is.EqualTo(Instruction.ArgumentType.Constructor));
+            Assert.That(nm.Instructions[0].ConstructorArg, Is.SameAs(ctor));
+            Assert.That(nm.Instructions[0].OpCode, Is.EqualTo(OpCodes.Newobj));
         }
 
         [Test]
@@ -71,18 +71,21 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var expr = new NewObjIlExpression(ctor, args);
             var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, nm.Instructions.Count);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(0));
             // when
             expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(4, nm.Instructions.Count);
-            Assert.AreEqual(Instruction.LoadConstant(1), nm.Instructions[0]);
-            Assert.AreEqual(Instruction.LoadConstant(2), nm.Instructions[1]);
-            Assert.AreEqual(Instruction.LoadConstant(3), nm.Instructions[2]);
-            Assert.AreEqual(Instruction.ArgumentType.Constructor,
-                nm.Instructions[3].ArgType);
-            Assert.AreSame(ctor, nm.Instructions[3].ConstructorArg);
-            Assert.AreEqual(OpCodes.Newobj, nm.Instructions[3].OpCode);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(4));
+            Assert.That(nm.Instructions[0],
+                Is.EqualTo(Instruction.LoadConstant(1)));
+            Assert.That(nm.Instructions[1],
+                Is.EqualTo(Instruction.LoadConstant(2)));
+            Assert.That(nm.Instructions[2],
+                Is.EqualTo(Instruction.LoadConstant(3)));
+            Assert.That(nm.Instructions[3].ArgType,
+                Is.EqualTo(Instruction.ArgumentType.Constructor));
+            Assert.That(nm.Instructions[3].ConstructorArg, Is.SameAs(ctor));
+            Assert.That(nm.Instructions[3].OpCode, Is.EqualTo(OpCodes.Newobj));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/NewObjIlExpressionT/NewObjIlExpressionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/NewObjIlExpressionT/NewObjIlExpressionTest.cs
@@ -45,8 +45,8 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             // then
             Assert.IsNotNull(result);
             Assert.IsInstanceOf<NewObjIlExpression>(result);
-            Assert.AreSame(ctor, result.Constructor);
-            Assert.AreSame(args, result.Arguments);
+            Assert.That(result.Constructor, Is.SameAs(ctor));
+            Assert.That(result.Arguments, Is.SameAs(args));
         }
 
         [Test]
@@ -58,9 +58,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var ex = Assert.Throws<ValueException>(
                 () => new NewObjIlExpression(null, args));
             // and
-            Assert.AreEqual(
-                "Value cannot be null: constructor",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Value cannot be null: constructor"));
         }
 
         [Test]
@@ -72,9 +72,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var ex = Assert.Throws<ValueException>(
                 () => new NewObjIlExpression(ctor, null));
             // and
-            Assert.AreEqual(
-                "Value cannot be null: arguments",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Value cannot be null: arguments"));
         }
 
         [Test]
@@ -84,9 +84,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var ex = Assert.Throws<ValueException>(
                 () => new NewObjIlExpression(null, null));
             // and
-            Assert.AreEqual(
-                "Value cannot be null: constructor",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Value cannot be null: constructor"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/NopIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/NopIlExpressionT/GetInstructionsTest.cs
@@ -37,12 +37,12 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var expr = new NopIlExpression();
             var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, nm.Instructions.Count);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(0));
             // when
             expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(1, nm.Instructions.Count);
-            Assert.AreEqual(Instruction.Nop(), nm.Instructions[0]);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(1));
+            Assert.That(nm.Instructions[0], Is.EqualTo(Instruction.Nop()));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/OrIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/OrIlExpressionT/GetInstructionsTest.cs
@@ -41,14 +41,14 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
                 new MockIlExpression(il => il.Add(i2)));
             var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, nm.Instructions.Count);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(0));
             // when
             expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(3, nm.Instructions.Count);
-            Assert.AreEqual(i1, nm.Instructions[0]);
-            Assert.AreEqual(i2, nm.Instructions[1]);
-            Assert.AreEqual(Instruction.Or(), nm.Instructions[2]);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(3));
+            Assert.That(nm.Instructions[0], Is.EqualTo(i1));
+            Assert.That(nm.Instructions[1], Is.EqualTo(i2));
+            Assert.That(nm.Instructions[2], Is.EqualTo(Instruction.Or()));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/OrIlExpressionT/OrIlExpressionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/OrIlExpressionT/OrIlExpressionTest.cs
@@ -42,8 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             // then
             Assert.IsNotNull(result);
             Assert.IsInstanceOf<OrIlExpression>(result);
-            Assert.AreSame(left, result.Left);
-            Assert.AreSame(right, result.Right);
+            Assert.That(result.Left, Is.SameAs(left));
+            Assert.That(result.Right, Is.SameAs(right));
         }
 
         [Test]
@@ -55,9 +55,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var ex = Assert.Throws<ValueException>(
                 () => new OrIlExpression(null, right));
             // and
-            Assert.AreEqual(
-                "Value cannot be null: left",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Value cannot be null: left"));
         }
 
         [Test]
@@ -69,9 +69,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var ex = Assert.Throws<ValueException>(
                 () => new OrIlExpression(left, null));
             // and
-            Assert.AreEqual(
-                "Value cannot be null: right",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Value cannot be null: right"));
         }
 
         [Test]
@@ -81,9 +81,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var ex = Assert.Throws<ValueException>(
                 () => new OrIlExpression(null, null));
             // and
-            Assert.AreEqual(
-                "Value cannot be null: left",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Value cannot be null: left"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/PopIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/PopIlExpressionT/GetInstructionsTest.cs
@@ -37,12 +37,12 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var expr = new PopIlExpression();
             var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, nm.Instructions.Count);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(0));
             // when
             expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(1, nm.Instructions.Count);
-            Assert.AreEqual(Instruction.Pop(), nm.Instructions[0]);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(1));
+            Assert.That(nm.Instructions[0], Is.EqualTo(Instruction.Pop()));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/RawInstructionsT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/RawInstructionsT/GetInstructionsTest.cs
@@ -41,9 +41,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             // when
             expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(2, nm.Instructions.Count);
-            Assert.AreEqual(Instruction.Add(), nm.Instructions[0]);
-            Assert.AreEqual(Instruction.Div(), nm.Instructions[1]);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(2));
+            Assert.That(nm.Instructions[0], Is.EqualTo(Instruction.Add()));
+            Assert.That(nm.Instructions[1], Is.EqualTo(Instruction.Div()));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/RawInstructionsT/RawInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/RawInstructionsT/RawInstructionsTest.cs
@@ -38,7 +38,7 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             // then
             Assert.NotNull(result);
             Assert.NotNull(result.Instructions);
-            Assert.AreEqual(0, result.Instructions.Length);
+            Assert.That(result.Instructions.Length, Is.EqualTo(0));
         }
 
         [Test]
@@ -50,9 +50,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
                 Instruction.Div());
             // then
             Assert.NotNull(result.Instructions);
-            Assert.AreEqual(2, result.Instructions.Length);
-            Assert.AreEqual(Instruction.Add(), result.Instructions[0]);
-            Assert.AreEqual(Instruction.Div(), result.Instructions[1]);
+            Assert.That(result.Instructions.Length, Is.EqualTo(2));
+            Assert.That(result.Instructions[0], Is.EqualTo(Instruction.Add()));
+            Assert.That(result.Instructions[1], Is.EqualTo(Instruction.Div()));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/RemIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/RemIlExpressionT/GetInstructionsTest.cs
@@ -41,14 +41,14 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
                 new MockIlExpression(il => il.Add(i2)));
             var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, nm.Instructions.Count);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(0));
             // when
             expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(3, nm.Instructions.Count);
-            Assert.AreEqual(i1, nm.Instructions[0]);
-            Assert.AreEqual(i2, nm.Instructions[1]);
-            Assert.AreEqual(Instruction.Rem(), nm.Instructions[2]);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(3));
+            Assert.That(nm.Instructions[0], Is.EqualTo(i1));
+            Assert.That(nm.Instructions[1], Is.EqualTo(i2));
+            Assert.That(nm.Instructions[2], Is.EqualTo(Instruction.Rem()));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/RemIlExpressionT/RemIlExpressionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/RemIlExpressionT/RemIlExpressionTest.cs
@@ -41,8 +41,8 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             // then
             Assert.IsNotNull(result);
             Assert.IsInstanceOf<RemIlExpression>(result);
-            Assert.AreSame(dividend, result.Dividend);
-            Assert.AreSame(divisor, result.Divisor);
+            Assert.That(result.Dividend, Is.SameAs(dividend));
+            Assert.That(result.Divisor, Is.SameAs(divisor));
         }
 
         [Test]
@@ -56,7 +56,7 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             Assert.IsNotNull(result);
             Assert.IsInstanceOf<RemIlExpression>(result);
             Assert.IsNull(result.Dividend);
-            Assert.AreSame(divisor, result.Divisor);
+            Assert.That(result.Divisor, Is.SameAs(divisor));
         }
 
         [Test]
@@ -69,7 +69,7 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             // then
             Assert.IsNotNull(result);
             Assert.IsInstanceOf<RemIlExpression>(result);
-            Assert.AreSame(dividend, result.Dividend);
+            Assert.That(result.Dividend, Is.SameAs(dividend));
             Assert.IsNull(result.Divisor);
         }
 

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/SubIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/SubIlExpressionT/GetInstructionsTest.cs
@@ -41,14 +41,14 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
                 new MockIlExpression(il => il.Add(i2)));
             var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, nm.Instructions.Count);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(0));
             // when
             expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(3, nm.Instructions.Count);
-            Assert.AreEqual(i1, nm.Instructions[0]);
-            Assert.AreEqual(i2, nm.Instructions[1]);
-            Assert.AreEqual(Instruction.Sub(), nm.Instructions[2]);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(3));
+            Assert.That(nm.Instructions[0], Is.EqualTo(i1));
+            Assert.That(nm.Instructions[1], Is.EqualTo(i2));
+            Assert.That(nm.Instructions[2], Is.EqualTo(Instruction.Sub()));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/SubIlExpressionT/SubIlExpressionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/SubIlExpressionT/SubIlExpressionTest.cs
@@ -42,8 +42,8 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             // then
             Assert.IsNotNull(result);
             Assert.IsInstanceOf<SubIlExpression>(result);
-            Assert.AreSame(left, result.Left);
-            Assert.AreSame(right, result.Right);
+            Assert.That(result.Left, Is.SameAs(left));
+            Assert.That(result.Right, Is.SameAs(right));
         }
 
         [Test]
@@ -55,9 +55,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var ex = Assert.Throws<ValueException>(
                 () => new SubIlExpression(null, right));
             // and
-            Assert.AreEqual(
-                "Value cannot be null: left",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Value cannot be null: left"));
         }
 
         [Test]
@@ -69,9 +69,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var ex = Assert.Throws<ValueException>(
                 () => new SubIlExpression(left, null));
             // and
-            Assert.AreEqual(
-                "Value cannot be null: right",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Value cannot be null: right"));
         }
 
         [Test]
@@ -81,9 +81,9 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var ex = Assert.Throws<ValueException>(
                 () => new SubIlExpression(null, null));
             // and
-            Assert.AreEqual(
-                "Value cannot be null: left",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Value cannot be null: left"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/ThrowIlExpressionT/GetInstructionsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/ThrowIlExpressionT/GetInstructionsTest.cs
@@ -39,13 +39,13 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
                 new MockIlExpression(il => il.Add(i1)));
             var nm = new NascentMethod();
             // precondition
-            Assert.AreEqual(0, nm.Instructions.Count);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(0));
             // when
             expr.GetInstructions(nm);
             // then
-            Assert.AreEqual(2, nm.Instructions.Count);
-            Assert.AreEqual(i1, nm.Instructions[0]);
-            Assert.AreEqual(Instruction.Throw(), nm.Instructions[1]);
+            Assert.That(nm.Instructions.Count, Is.EqualTo(2));
+            Assert.That(nm.Instructions[0], Is.EqualTo(i1));
+            Assert.That(nm.Instructions[1], Is.EqualTo(Instruction.Throw()));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/ThrowIlExpressionT/ThrowIlExpressionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/CompilerT/IlExpressionsT/ThrowIlExpressionT/ThrowIlExpressionTest.cs
@@ -41,7 +41,7 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             // then
             Assert.IsNotNull(result);
             Assert.IsInstanceOf<ThrowIlExpression>(result);
-            Assert.AreSame(argument, result.Argument);
+            Assert.That(result.Argument, Is.SameAs(argument));
         }
 
         [Test]
@@ -51,9 +51,8 @@ namespace MetaphysicsIndustries.Solus.Test.CompilerT.IlExpressionsT.
             var ex = Assert.Throws<ValueException>(
                 () => new ThrowIlExpression(null));
             // and
-            Assert.AreEqual(
-                "Value cannot be null: argument",
-                ex.Message);
+            Assert.That(
+                ex.Message, Is.EqualTo("Value cannot be null: argument"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EnvironmentT/ChildTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EnvironmentT/ChildTest.cs
@@ -37,15 +37,15 @@ namespace MetaphysicsIndustries.Solus.Test.EnvironmentT
             var parent = new SolusEnvironment(useDefaults: false);
             parent.SetVariable("a", new Literal(1));
             // precondition
-            Assert.AreEqual(1, parent.CountVariables());
+            Assert.That(parent.CountVariables(), Is.EqualTo(1));
             Assert.Contains("a", parent.GetVariableNames().ToList());
             // when
             var child = parent.CreateChildEnvironment();
             // then
-            Assert.AreEqual(1, parent.CountVariables());
+            Assert.That(parent.CountVariables(), Is.EqualTo(1));
             Assert.Contains("a", parent.GetVariableNames().ToList());
 
-            Assert.AreEqual(1, child.CountVariables());
+            Assert.That(child.CountVariables(), Is.EqualTo(1));
             Assert.Contains("a", child.GetVariableNames().ToList());
         }
 
@@ -57,8 +57,8 @@ namespace MetaphysicsIndustries.Solus.Test.EnvironmentT
             parent.SetVariable("a", new Literal(1));
             var child = parent.CreateChildEnvironment();
             // precondition
-            Assert.AreEqual(1, parent.CountVariables());
-            Assert.AreEqual(1, child.CountVariables());
+            Assert.That(parent.CountVariables(), Is.EqualTo(1));
+            Assert.That(child.CountVariables(), Is.EqualTo(1));
             Assert.IsNotNull(parent.GetVariable("a"));
             Assert.IsNotNull(child.GetVariable("a"));
             Assert.IsNull(parent.GetVariable("b"));
@@ -66,8 +66,8 @@ namespace MetaphysicsIndustries.Solus.Test.EnvironmentT
             // when
             parent.SetVariable("b", new Literal(2));
             // then
-            Assert.AreEqual(2, parent.CountVariables());
-            Assert.AreEqual(2, child.CountVariables());
+            Assert.That(parent.CountVariables(), Is.EqualTo(2));
+            Assert.That(child.CountVariables(), Is.EqualTo(2));
             Assert.IsNotNull(parent.GetVariable("a"));
             Assert.IsNotNull(child.GetVariable("a"));
             Assert.IsNotNull(parent.GetVariable("b"));
@@ -99,8 +99,8 @@ namespace MetaphysicsIndustries.Solus.Test.EnvironmentT
             parent.SetVariable("a", new Literal(1));
             var child = parent.CreateChildEnvironment();
             // precondition
-            Assert.AreEqual(1, parent.CountVariables());
-            Assert.AreEqual(1, child.CountVariables());
+            Assert.That(parent.CountVariables(), Is.EqualTo(1));
+            Assert.That(child.CountVariables(), Is.EqualTo(1));
             Assert.IsNotNull(parent.GetVariable("a"));
             Assert.IsNotNull(child.GetVariable("a"));
             Assert.IsNull(parent.GetVariable("b"));
@@ -108,8 +108,8 @@ namespace MetaphysicsIndustries.Solus.Test.EnvironmentT
             // when
             child.SetVariable("b", new Literal(2));
             // then
-            Assert.AreEqual(1, parent.CountVariables());
-            Assert.AreEqual(2, child.CountVariables());
+            Assert.That(parent.CountVariables(), Is.EqualTo(1));
+            Assert.That(child.CountVariables(), Is.EqualTo(2));
             Assert.IsNotNull(parent.GetVariable("a"));
             Assert.IsNotNull(child.GetVariable("a"));
             Assert.IsNull(parent.GetVariable("b"));
@@ -141,22 +141,22 @@ namespace MetaphysicsIndustries.Solus.Test.EnvironmentT
             parent.SetVariable("a", new Literal(1));
             var child = parent.CreateChildEnvironment();
             // precondition
-            Assert.AreEqual(1,
-                ((Literal)parent.GetVariable("a")).Value.ToFloat());
-            Assert.AreEqual(1,
-                ((Literal)child.GetVariable("a")).Value.ToFloat());
-            Assert.AreSame(parent.GetVariable("a"),
-                child.GetVariable("a"));
+            Assert.That(((Literal)parent.GetVariable("a")).Value.ToFloat(),
+                Is.EqualTo(1));
+            Assert.That(((Literal)child.GetVariable("a")).Value.ToFloat(),
+                Is.EqualTo(1));
+            Assert.That(child.GetVariable("a"),
+                Is.SameAs(parent.GetVariable("a")));
             // when
             child.RemoveVariable("a");
             child.SetVariable("a", new Literal(2));
             // then
-            Assert.AreEqual(1,
-                ((Literal)parent.GetVariable("a")).Value.ToFloat());
-            Assert.AreEqual(2,
-                ((Literal)child.GetVariable("a")).Value.ToFloat());
-            Assert.AreNotSame(parent.GetVariable("a"),
-                child.GetVariable("a"));
+            Assert.That(((Literal)parent.GetVariable("a")).Value.ToFloat(),
+                Is.EqualTo(1));
+            Assert.That(((Literal)child.GetVariable("a")).Value.ToFloat(),
+                Is.EqualTo(2));
+            Assert.That(parent.GetVariable("a"),
+                Is.Not.SameAs(child.GetVariable("a")));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EnvironmentT/CloneTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EnvironmentT/CloneTest.cs
@@ -37,15 +37,15 @@ namespace MetaphysicsIndustries.Solus.Test.EnvironmentT
             var original = new SolusEnvironment(useDefaults: false);
             original.SetVariable("a", new Literal(1));
             // precondition
-            Assert.AreEqual(1, original.CountVariables());
+            Assert.That(original.CountVariables(), Is.EqualTo(1));
             Assert.Contains("a", original.GetVariableNames().ToList());
             // when
             var clone = original.Clone();
             // then
-            Assert.AreEqual(1, original.CountVariables());
+            Assert.That(original.CountVariables(), Is.EqualTo(1));
             Assert.Contains("a", original.GetVariableNames().ToList());
 
-            Assert.AreEqual(1, clone.CountVariables());
+            Assert.That(clone.CountVariables(), Is.EqualTo(1));
             Assert.Contains("a", clone.GetVariableNames().ToList());
         }
 
@@ -57,17 +57,17 @@ namespace MetaphysicsIndustries.Solus.Test.EnvironmentT
             original.SetVariable("a", new Literal(1));
             var clone = original.Clone();
             // precondition
-            Assert.AreEqual(1,
-                ((Literal)original.GetVariable("a")).Value.ToFloat());
-            Assert.AreEqual(1,
-                ((Literal)clone.GetVariable("a")).Value.ToFloat());
+            Assert.That(((Literal)original.GetVariable("a")).Value.ToFloat(),
+                Is.EqualTo(1));
+            Assert.That(((Literal)clone.GetVariable("a")).Value.ToFloat(),
+                Is.EqualTo(1));
             // when
             ((Literal) original.GetVariable("a")).Value = 2.ToNumber();
             // then
-            Assert.AreEqual(2,
-                ((Literal)original.GetVariable("a")).Value.ToFloat());
-            Assert.AreEqual(2,
-                ((Literal)clone.GetVariable("a")).Value.ToFloat());
+            Assert.That(((Literal)original.GetVariable("a")).Value.ToFloat(),
+                Is.EqualTo(2));
+            Assert.That(((Literal)clone.GetVariable("a")).Value.ToFloat(),
+                Is.EqualTo(2));
         }
 
         [Test]
@@ -78,8 +78,8 @@ namespace MetaphysicsIndustries.Solus.Test.EnvironmentT
             original.SetVariable("a", new Literal(1));
             var clone = original.Clone();
             // precondition
-            Assert.AreEqual(1, original.CountVariables());
-            Assert.AreEqual(1, clone.CountVariables());
+            Assert.That(original.CountVariables(), Is.EqualTo(1));
+            Assert.That(clone.CountVariables(), Is.EqualTo(1));
             Assert.IsNotNull(original.GetVariable("a"));
             Assert.IsNotNull(clone.GetVariable("a"));
             Assert.IsNull(original.GetVariable("b"));
@@ -87,8 +87,8 @@ namespace MetaphysicsIndustries.Solus.Test.EnvironmentT
             // when
             clone.SetVariable("b", new Literal(2));
             // then
-            Assert.AreEqual(1, original.CountVariables());
-            Assert.AreEqual(2, clone.CountVariables());
+            Assert.That(original.CountVariables(), Is.EqualTo(1));
+            Assert.That(clone.CountVariables(), Is.EqualTo(2));
             Assert.IsNotNull(original.GetVariable("a"));
             Assert.IsNotNull(clone.GetVariable("a"));
             Assert.IsNull(original.GetVariable("b"));

--- a/MetaphysicsIndustries.Solus.Test/EnvironmentT/DerivedTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EnvironmentT/DerivedTest.cs
@@ -74,10 +74,10 @@ namespace MetaphysicsIndustries.Solus.Test.EnvironmentT
             var clone = original.Clone();
             // then
             var derived = (DerivedEnvironment) clone;
-            Assert.AreEqual(3, derived.Items.Count);
-            Assert.AreEqual("one", derived.Items[0]);
-            Assert.AreEqual("two", derived.Items[1]);
-            Assert.AreEqual("three", derived.Items[2]);
+            Assert.That(derived.Items.Count, Is.EqualTo(3));
+            Assert.That(derived.Items[0], Is.EqualTo("one"));
+            Assert.That(derived.Items[1], Is.EqualTo("two"));
+            Assert.That(derived.Items[2], Is.EqualTo("three"));
         }
 
         [Test]

--- a/MetaphysicsIndustries.Solus.Test/EnvironmentT/EnvironmentTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EnvironmentT/EnvironmentTest.cs
@@ -45,7 +45,7 @@ namespace MetaphysicsIndustries.Solus.Test.EnvironmentT
             // when
             var result = new SolusEnvironment(useDefaults: false);
             // then
-            Assert.AreEqual(0, result.CountVariables());
+            Assert.That(result.CountVariables(), Is.EqualTo(0));
         }
 
         [Test]
@@ -54,11 +54,11 @@ namespace MetaphysicsIndustries.Solus.Test.EnvironmentT
             // given
             var env = new SolusEnvironment(useDefaults: false);
             // precondition
-            Assert.AreEqual(0, env.CountVariables());
+            Assert.That(env.CountVariables(), Is.EqualTo(0));
             // when
             env.SetVariable("a", new Literal(1));
             // then
-            Assert.AreEqual(1, env.CountVariables());
+            Assert.That(env.CountVariables(), Is.EqualTo(1));
             Assert.Contains("a", env.GetVariableNames().ToList());
         }
 
@@ -68,7 +68,7 @@ namespace MetaphysicsIndustries.Solus.Test.EnvironmentT
             // when
             var result = new SolusEnvironment(useDefaults: true);
             // then
-            Assert.AreEqual(30, result.CountVariables());
+            Assert.That(result.CountVariables(), Is.EqualTo(30));
             var vars = result.GetVariableNames().ToList();
             Assert.Contains("sin", vars);
             Assert.Contains("cos", vars);

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/EvalIntervalTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/EvalIntervalTest.cs
@@ -50,12 +50,12 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT
             eval.EvalInterval(expr, env, interval, numSteps, store);
             // then
             Assert.IsNotNull(store.Values);
-            Assert.AreEqual(5, store.Values.Length);
-            Assert.AreEqual(4, store.Values[0].Value);
-            Assert.AreEqual(9, store.Values[1].Value);
-            Assert.AreEqual(16, store.Values[2].Value);
-            Assert.AreEqual(25, store.Values[3].Value);
-            Assert.AreEqual(36, store.Values[4].Value);
+            Assert.That(store.Values.Length, Is.EqualTo(5));
+            Assert.That(store.Values[0].Value, Is.EqualTo(4));
+            Assert.That(store.Values[1].Value, Is.EqualTo(9));
+            Assert.That(store.Values[2].Value, Is.EqualTo(16));
+            Assert.That(store.Values[3].Value, Is.EqualTo(25));
+            Assert.That(store.Values[4].Value, Is.EqualTo(36));
         }
 
         [Test]
@@ -75,12 +75,12 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT
             eval.EvalInterval(expr, env, interval, numSteps, store);
             // then
             var result = store.GetResult();
-            Assert.AreEqual(5, result.Length);
-            Assert.AreEqual(4, result[0].ToNumber().Value);
-            Assert.AreEqual(9, result[1].ToNumber().Value);
-            Assert.AreEqual(16, result[2].ToNumber().Value);
-            Assert.AreEqual(25, result[3].ToNumber().Value);
-            Assert.AreEqual(36, result[4].ToNumber().Value);
+            Assert.That(result.Length, Is.EqualTo(5));
+            Assert.That(result[0].ToNumber().Value, Is.EqualTo(4));
+            Assert.That(result[1].ToNumber().Value, Is.EqualTo(9));
+            Assert.That(result[2].ToNumber().Value, Is.EqualTo(16));
+            Assert.That(result[3].ToNumber().Value, Is.EqualTo(25));
+            Assert.That(result[4].ToNumber().Value, Is.EqualTo(36));
         }
 
         [Test]
@@ -106,43 +106,43 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT
                 store);
             // then
             Assert.IsNotNull(store.Values);
-            Assert.AreEqual(5, store.Values.GetLength(0));
-            Assert.AreEqual(6, store.Values.GetLength(1));
+            Assert.That(store.Values.GetLength(0), Is.EqualTo(5));
+            Assert.That(store.Values.GetLength(1), Is.EqualTo(6));
 
-            Assert.AreEqual(14, store.Values[0, 0].Value);
-            Assert.AreEqual(16, store.Values[0, 1].Value);
-            Assert.AreEqual(18, store.Values[0, 2].Value);
-            Assert.AreEqual(20, store.Values[0, 3].Value);
-            Assert.AreEqual(22, store.Values[0, 4].Value);
-            Assert.AreEqual(24, store.Values[0, 5].Value);
+            Assert.That(store.Values[0, 0].Value, Is.EqualTo(14));
+            Assert.That(store.Values[0, 1].Value, Is.EqualTo(16));
+            Assert.That(store.Values[0, 2].Value, Is.EqualTo(18));
+            Assert.That(store.Values[0, 3].Value, Is.EqualTo(20));
+            Assert.That(store.Values[0, 4].Value, Is.EqualTo(22));
+            Assert.That(store.Values[0, 5].Value, Is.EqualTo(24));
 
-            Assert.AreEqual(21, store.Values[1, 0].Value);
-            Assert.AreEqual(24, store.Values[1, 1].Value);
-            Assert.AreEqual(27, store.Values[1, 2].Value);
-            Assert.AreEqual(30, store.Values[1, 3].Value);
-            Assert.AreEqual(33, store.Values[1, 4].Value);
-            Assert.AreEqual(36, store.Values[1, 5].Value);
+            Assert.That(store.Values[1, 0].Value, Is.EqualTo(21));
+            Assert.That(store.Values[1, 1].Value, Is.EqualTo(24));
+            Assert.That(store.Values[1, 2].Value, Is.EqualTo(27));
+            Assert.That(store.Values[1, 3].Value, Is.EqualTo(30));
+            Assert.That(store.Values[1, 4].Value, Is.EqualTo(33));
+            Assert.That(store.Values[1, 5].Value, Is.EqualTo(36));
 
-            Assert.AreEqual(28, store.Values[2, 0].Value);
-            Assert.AreEqual(32, store.Values[2, 1].Value);
-            Assert.AreEqual(36, store.Values[2, 2].Value);
-            Assert.AreEqual(40, store.Values[2, 3].Value);
-            Assert.AreEqual(44, store.Values[2, 4].Value);
-            Assert.AreEqual(48, store.Values[2, 5].Value);
+            Assert.That(store.Values[2, 0].Value, Is.EqualTo(28));
+            Assert.That(store.Values[2, 1].Value, Is.EqualTo(32));
+            Assert.That(store.Values[2, 2].Value, Is.EqualTo(36));
+            Assert.That(store.Values[2, 3].Value, Is.EqualTo(40));
+            Assert.That(store.Values[2, 4].Value, Is.EqualTo(44));
+            Assert.That(store.Values[2, 5].Value, Is.EqualTo(48));
 
-            Assert.AreEqual(35, store.Values[3, 0].Value);
-            Assert.AreEqual(40, store.Values[3, 1].Value);
-            Assert.AreEqual(45, store.Values[3, 2].Value);
-            Assert.AreEqual(50, store.Values[3, 3].Value);
-            Assert.AreEqual(55, store.Values[3, 4].Value);
-            Assert.AreEqual(60, store.Values[3, 5].Value);
+            Assert.That(store.Values[3, 0].Value, Is.EqualTo(35));
+            Assert.That(store.Values[3, 1].Value, Is.EqualTo(40));
+            Assert.That(store.Values[3, 2].Value, Is.EqualTo(45));
+            Assert.That(store.Values[3, 3].Value, Is.EqualTo(50));
+            Assert.That(store.Values[3, 4].Value, Is.EqualTo(55));
+            Assert.That(store.Values[3, 5].Value, Is.EqualTo(60));
 
-            Assert.AreEqual(42, store.Values[4, 0].Value);
-            Assert.AreEqual(48, store.Values[4, 1].Value);
-            Assert.AreEqual(54, store.Values[4, 2].Value);
-            Assert.AreEqual(60, store.Values[4, 3].Value);
-            Assert.AreEqual(66, store.Values[4, 4].Value);
-            Assert.AreEqual(72, store.Values[4, 5].Value);
+            Assert.That(store.Values[4, 0].Value, Is.EqualTo(42));
+            Assert.That(store.Values[4, 1].Value, Is.EqualTo(48));
+            Assert.That(store.Values[4, 2].Value, Is.EqualTo(54));
+            Assert.That(store.Values[4, 3].Value, Is.EqualTo(60));
+            Assert.That(store.Values[4, 4].Value, Is.EqualTo(66));
+            Assert.That(store.Values[4, 5].Value, Is.EqualTo(72));
         }
 
         [Test]
@@ -168,43 +168,43 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT
                 store);
             // then
             var result = store.GetResult();
-            Assert.AreEqual(5, result.RowCount);
-            Assert.AreEqual(6, result.ColumnCount);
+            Assert.That(result.RowCount, Is.EqualTo(5));
+            Assert.That(result.ColumnCount, Is.EqualTo(6));
 
-            Assert.AreEqual(14, result[0, 0].ToNumber().Value);
-            Assert.AreEqual(16, result[0, 1].ToNumber().Value);
-            Assert.AreEqual(18, result[0, 2].ToNumber().Value);
-            Assert.AreEqual(20, result[0, 3].ToNumber().Value);
-            Assert.AreEqual(22, result[0, 4].ToNumber().Value);
-            Assert.AreEqual(24, result[0, 5].ToNumber().Value);
+            Assert.That(result[0, 0].ToNumber().Value, Is.EqualTo(14));
+            Assert.That(result[0, 1].ToNumber().Value, Is.EqualTo(16));
+            Assert.That(result[0, 2].ToNumber().Value, Is.EqualTo(18));
+            Assert.That(result[0, 3].ToNumber().Value, Is.EqualTo(20));
+            Assert.That(result[0, 4].ToNumber().Value, Is.EqualTo(22));
+            Assert.That(result[0, 5].ToNumber().Value, Is.EqualTo(24));
 
-            Assert.AreEqual(21, result[1, 0].ToNumber().Value);
-            Assert.AreEqual(24, result[1, 1].ToNumber().Value);
-            Assert.AreEqual(27, result[1, 2].ToNumber().Value);
-            Assert.AreEqual(30, result[1, 3].ToNumber().Value);
-            Assert.AreEqual(33, result[1, 4].ToNumber().Value);
-            Assert.AreEqual(36, result[1, 5].ToNumber().Value);
+            Assert.That(result[1, 0].ToNumber().Value, Is.EqualTo(21));
+            Assert.That(result[1, 1].ToNumber().Value, Is.EqualTo(24));
+            Assert.That(result[1, 2].ToNumber().Value, Is.EqualTo(27));
+            Assert.That(result[1, 3].ToNumber().Value, Is.EqualTo(30));
+            Assert.That(result[1, 4].ToNumber().Value, Is.EqualTo(33));
+            Assert.That(result[1, 5].ToNumber().Value, Is.EqualTo(36));
 
-            Assert.AreEqual(28, result[2, 0].ToNumber().Value);
-            Assert.AreEqual(32, result[2, 1].ToNumber().Value);
-            Assert.AreEqual(36, result[2, 2].ToNumber().Value);
-            Assert.AreEqual(40, result[2, 3].ToNumber().Value);
-            Assert.AreEqual(44, result[2, 4].ToNumber().Value);
-            Assert.AreEqual(48, result[2, 5].ToNumber().Value);
+            Assert.That(result[2, 0].ToNumber().Value, Is.EqualTo(28));
+            Assert.That(result[2, 1].ToNumber().Value, Is.EqualTo(32));
+            Assert.That(result[2, 2].ToNumber().Value, Is.EqualTo(36));
+            Assert.That(result[2, 3].ToNumber().Value, Is.EqualTo(40));
+            Assert.That(result[2, 4].ToNumber().Value, Is.EqualTo(44));
+            Assert.That(result[2, 5].ToNumber().Value, Is.EqualTo(48));
 
-            Assert.AreEqual(35, result[3, 0].ToNumber().Value);
-            Assert.AreEqual(40, result[3, 1].ToNumber().Value);
-            Assert.AreEqual(45, result[3, 2].ToNumber().Value);
-            Assert.AreEqual(50, result[3, 3].ToNumber().Value);
-            Assert.AreEqual(55, result[3, 4].ToNumber().Value);
-            Assert.AreEqual(60, result[3, 5].ToNumber().Value);
+            Assert.That(result[3, 0].ToNumber().Value, Is.EqualTo(35));
+            Assert.That(result[3, 1].ToNumber().Value, Is.EqualTo(40));
+            Assert.That(result[3, 2].ToNumber().Value, Is.EqualTo(45));
+            Assert.That(result[3, 3].ToNumber().Value, Is.EqualTo(50));
+            Assert.That(result[3, 4].ToNumber().Value, Is.EqualTo(55));
+            Assert.That(result[3, 5].ToNumber().Value, Is.EqualTo(60));
 
-            Assert.AreEqual(42, result[4, 0].ToNumber().Value);
-            Assert.AreEqual(48, result[4, 1].ToNumber().Value);
-            Assert.AreEqual(54, result[4, 2].ToNumber().Value);
-            Assert.AreEqual(60, result[4, 3].ToNumber().Value);
-            Assert.AreEqual(66, result[4, 4].ToNumber().Value);
-            Assert.AreEqual(72, result[4, 5].ToNumber().Value);
+            Assert.That(result[4, 0].ToNumber().Value, Is.EqualTo(42));
+            Assert.That(result[4, 1].ToNumber().Value, Is.EqualTo(48));
+            Assert.That(result[4, 2].ToNumber().Value, Is.EqualTo(54));
+            Assert.That(result[4, 3].ToNumber().Value, Is.EqualTo(60));
+            Assert.That(result[4, 4].ToNumber().Value, Is.EqualTo(66));
+            Assert.That(result[4, 5].ToNumber().Value, Is.EqualTo(72));
         }
 
         [Test]
@@ -235,45 +235,45 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT
                 store);
             // then
             Assert.IsNotNull(store.Values);
-            Assert.AreEqual(2, store.Values.GetLength(0));
-            Assert.AreEqual(3, store.Values.GetLength(1));
-            Assert.AreEqual(5, store.Values.GetLength(2));
+            Assert.That(store.Values.GetLength(0), Is.EqualTo(2));
+            Assert.That(store.Values.GetLength(1), Is.EqualTo(3));
+            Assert.That(store.Values.GetLength(2), Is.EqualTo(5));
 
-            Assert.AreEqual(56, store.Values[0, 0, 0].Value);
-            Assert.AreEqual(64, store.Values[0, 0, 1].Value);
-            Assert.AreEqual(72, store.Values[0, 0, 2].Value);
-            Assert.AreEqual(80, store.Values[0, 0, 3].Value);
-            Assert.AreEqual(88, store.Values[0, 0, 4].Value);
+            Assert.That(store.Values[0, 0, 0].Value, Is.EqualTo(56));
+            Assert.That(store.Values[0, 0, 1].Value, Is.EqualTo(64));
+            Assert.That(store.Values[0, 0, 2].Value, Is.EqualTo(72));
+            Assert.That(store.Values[0, 0, 3].Value, Is.EqualTo(80));
+            Assert.That(store.Values[0, 0, 4].Value, Is.EqualTo(88));
 
-            Assert.AreEqual(70, store.Values[0, 1, 0].Value);
-            Assert.AreEqual(80, store.Values[0, 1, 1].Value);
-            Assert.AreEqual(90, store.Values[0, 1, 2].Value);
-            Assert.AreEqual(100, store.Values[0, 1, 3].Value);
-            Assert.AreEqual(110, store.Values[0, 1, 4].Value);
+            Assert.That(store.Values[0, 1, 0].Value, Is.EqualTo(70));
+            Assert.That(store.Values[0, 1, 1].Value, Is.EqualTo(80));
+            Assert.That(store.Values[0, 1, 2].Value, Is.EqualTo(90));
+            Assert.That(store.Values[0, 1, 3].Value, Is.EqualTo(100));
+            Assert.That(store.Values[0, 1, 4].Value, Is.EqualTo(110));
 
-            Assert.AreEqual(84, store.Values[0, 2, 0].Value);
-            Assert.AreEqual(96, store.Values[0, 2, 1].Value);
-            Assert.AreEqual(108, store.Values[0, 2, 2].Value);
-            Assert.AreEqual(120, store.Values[0, 2, 3].Value);
-            Assert.AreEqual(132, store.Values[0, 2, 4].Value);
+            Assert.That(store.Values[0, 2, 0].Value, Is.EqualTo(84));
+            Assert.That(store.Values[0, 2, 1].Value, Is.EqualTo(96));
+            Assert.That(store.Values[0, 2, 2].Value, Is.EqualTo(108));
+            Assert.That(store.Values[0, 2, 3].Value, Is.EqualTo(120));
+            Assert.That(store.Values[0, 2, 4].Value, Is.EqualTo(132));
 
-            Assert.AreEqual(84, store.Values[1, 0, 0].Value);
-            Assert.AreEqual(96, store.Values[1, 0, 1].Value);
-            Assert.AreEqual(108, store.Values[1, 0, 2].Value);
-            Assert.AreEqual(120, store.Values[1, 0, 3].Value);
-            Assert.AreEqual(132, store.Values[1, 0, 4].Value);
+            Assert.That(store.Values[1, 0, 0].Value, Is.EqualTo(84));
+            Assert.That(store.Values[1, 0, 1].Value, Is.EqualTo(96));
+            Assert.That(store.Values[1, 0, 2].Value, Is.EqualTo(108));
+            Assert.That(store.Values[1, 0, 3].Value, Is.EqualTo(120));
+            Assert.That(store.Values[1, 0, 4].Value, Is.EqualTo(132));
 
-            Assert.AreEqual(105, store.Values[1, 1, 0].Value);
-            Assert.AreEqual(120, store.Values[1, 1, 1].Value);
-            Assert.AreEqual(135, store.Values[1, 1, 2].Value);
-            Assert.AreEqual(150, store.Values[1, 1, 3].Value);
-            Assert.AreEqual(165, store.Values[1, 1, 4].Value);
+            Assert.That(store.Values[1, 1, 0].Value, Is.EqualTo(105));
+            Assert.That(store.Values[1, 1, 1].Value, Is.EqualTo(120));
+            Assert.That(store.Values[1, 1, 2].Value, Is.EqualTo(135));
+            Assert.That(store.Values[1, 1, 3].Value, Is.EqualTo(150));
+            Assert.That(store.Values[1, 1, 4].Value, Is.EqualTo(165));
 
-            Assert.AreEqual(126, store.Values[1, 2, 0].Value);
-            Assert.AreEqual(144, store.Values[1, 2, 1].Value);
-            Assert.AreEqual(162, store.Values[1, 2, 2].Value);
-            Assert.AreEqual(180, store.Values[1, 2, 3].Value);
-            Assert.AreEqual(198, store.Values[1, 2, 4].Value);
+            Assert.That(store.Values[1, 2, 0].Value, Is.EqualTo(126));
+            Assert.That(store.Values[1, 2, 1].Value, Is.EqualTo(144));
+            Assert.That(store.Values[1, 2, 2].Value, Is.EqualTo(162));
+            Assert.That(store.Values[1, 2, 3].Value, Is.EqualTo(180));
+            Assert.That(store.Values[1, 2, 4].Value, Is.EqualTo(198));
         }
 
         [Test]
@@ -329,7 +329,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT
             eval.EvalInterval(expr, env, interval, 5, null,
                 new AggregateOp[] { aggr });
             // then
-            Assert.AreEqual(25, aggr.State.Value);
+            Assert.That(aggr.State.Value, Is.EqualTo(25));
         }
 
         [Test]
@@ -365,7 +365,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT
                 null,
                 new AggregateOp[] { aggr });
             // then
-            Assert.AreEqual(18, aggr.State.Value);
+            Assert.That(aggr.State.Value, Is.EqualTo(18));
         }
 
         [Test]
@@ -404,7 +404,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT
                 null,
                 new AggregateOp[] { aggr });
             // then
-            Assert.AreEqual(162, aggr.State.Value);
+            Assert.That(aggr.State.Value, Is.EqualTo(162));
         }
 
         [Test]
@@ -436,8 +436,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT
             // when
             eval.EvalInterval(expr, env, interval, 5, null, aggrs);
             // then
-            Assert.AreEqual(7, aggrMax.State.Value);
-            Assert.AreEqual(3, aggrMin.State.Value);
+            Assert.That(aggrMax.State.Value, Is.EqualTo(7));
+            Assert.That(aggrMin.State.Value, Is.EqualTo(3));
         }
 
         [Test]
@@ -457,7 +457,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT
             eval.EvalInterval(expr, env, interval, 5, null,
                 new AggregateOp[] { aggr });
             // then
-            Assert.AreEqual(25, aggr.State.ToNumber().Value);
+            Assert.That(aggr.State.ToNumber().Value, Is.EqualTo(25));
         }
 
     }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/ExpressionsT/ComponentAccessT/EvalComponentAccessTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/ExpressionsT/ComponentAccessT/EvalComponentAccessTest.cs
@@ -48,7 +48,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             // then
             Assert.IsFalse(result.IsVector(null));
             Assert.IsTrue(result.IsScalar(null));
-            Assert.AreEqual(2, result.ToFloat());
+            Assert.That(result.ToFloat(), Is.EqualTo(2));
         }
 
         [Test]
@@ -66,7 +66,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             // then
             Assert.IsFalse(result.IsMatrix(null));
             Assert.IsTrue(result.IsScalar(null));
-            Assert.AreEqual(4, result.ToFloat());
+            Assert.That(result.ToFloat(), Is.EqualTo(4));
         }
 
         [Test]
@@ -81,10 +81,11 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<OperandException>(
                 () => eval.Eval(expr, null));
             // and
-            Assert.AreEqual(
-                "Unable to get components from expression, " +
-                "or the expression does not have components",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo(
+                    "Unable to get components from expression, " +
+                    "or the expression does not have components"));
         }
 
         [Test]
@@ -99,9 +100,9 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<OperandException>(
                 () => eval.Eval(expr, null));
             // and
-            Assert.AreEqual(
-                "Wrong number of indexes for the expression",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Wrong number of indexes for the expression"));
         }
 
         [Test]
@@ -117,9 +118,9 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<OperandException>(
                 () => eval.Eval(expr, null));
             // and
-            Assert.AreEqual(
-                "Wrong number of indexes for the expression",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Wrong number of indexes for the expression"));
         }
 
         [Test]
@@ -138,7 +139,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<IndexException>(
                 () => eval.Eval(expr, null));
             // and
-            Assert.AreEqual("Indexes must be scalar", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Indexes must be scalar"));
         }
 
         [Test]
@@ -157,7 +158,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<IndexException>(
                 () => eval.Eval(expr, null));
             // and
-            Assert.AreEqual("Indexes must be scalar", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Indexes must be scalar"));
         }
 
         [Test]
@@ -172,7 +173,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<IndexException>(
                 () => eval.Eval(expr, null));
             // and
-            Assert.AreEqual("Indexes must be scalar", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Indexes must be scalar"));
         }
 
         [Test]
@@ -187,9 +188,9 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<IndexException>(
                 () => eval.Eval(expr, null));
             // and
-            Assert.AreEqual(
-                "Indexes must not be negative",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Indexes must not be negative"));
         }
 
         // TODO: check for index greater than vector dimension
@@ -216,10 +217,10 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<OperandException>(
                 () => eval.Eval(expr, null));
             // and
-            Assert.AreEqual(
-                "Unable to get components from expression, " +
-                "or the expression does not have components",
-                ex.Message);
+            Assert.That(ex.Message,
+                Is.EqualTo(
+                    "Unable to get components from expression, " +
+                    "or the expression does not have components"));
         }
 
         [Test]
@@ -236,7 +237,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsScalar(null));
             Assert.IsTrue(result.IsString(null));
-            Assert.AreEqual("b", result.ToStringValue().Value);
+            Assert.That(result.ToStringValue().Value, Is.EqualTo("b"));
         }
 
         [Test]
@@ -251,9 +252,9 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<OperandException>(
                 () => eval.Eval(expr, null));
             // and
-            Assert.AreEqual(
-                "Wrong number of indexes for the expression",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Wrong number of indexes for the expression"));
         }
 
         [Test]
@@ -268,9 +269,9 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<IndexException>(
                 () => eval.Eval(expr, null));
             // and
-            Assert.AreEqual(
-                "Index exceeds the size of the vector",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Index exceeds the size of the vector"));
         }
 
         [Test]
@@ -286,9 +287,9 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<IndexException>(
                 () => eval.Eval(expr, null));
             // and
-            Assert.AreEqual(
-                "Index exceeds the size of the string",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Index exceeds the size of the string"));
         }
 
         [Test]
@@ -303,9 +304,9 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<IndexException>(
                 () => eval.Eval(expr, null));
             // and
-            Assert.AreEqual(
-                "Index exceeds number of rows of the matrix",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Index exceeds number of rows of the matrix"));
         }
 
         [Test]
@@ -320,9 +321,9 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<IndexException>(
                 () => eval.Eval(expr, null));
             // and
-            Assert.AreEqual(
-                "Index exceeds number of columns of the matrix",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Index exceeds number of columns of the matrix"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/ExpressionsT/FunctionCallT/EvalFunctionCallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/ExpressionsT/FunctionCallT/EvalFunctionCallTest.cs
@@ -52,7 +52,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             Assert.IsTrue(result0.IsIsScalar(null));
             Assert.IsInstanceOf<Number>(result0);
             var result = result0.ToNumber();
-            Assert.AreEqual(5, result.Value);
+            Assert.That(result.Value, Is.EqualTo(5));
         }
 
         [Test]
@@ -74,7 +74,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             Assert.IsTrue(result0.IsIsScalar(null));
             Assert.IsInstanceOf<Number>(result0);
             var result = result0.ToNumber();
-            Assert.AreEqual(5, result.Value);
+            Assert.That(result.Value, Is.EqualTo(5));
         }
 
         [Test]
@@ -113,7 +113,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             // then
             Assert.IsInstanceOf<Number>(result);
             var n = (Number)result;
-            Assert.AreEqual(2, n.Value);
+            Assert.That(n.Value, Is.EqualTo(2));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/ExpressionsT/IntervalExpressionT/EvalIntervalExpressionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/ExpressionsT/IntervalExpressionT/EvalIntervalExpressionTest.cs
@@ -48,9 +48,9 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             Assert.IsTrue(result.IsInterval(null));
             Assert.IsInstanceOf<Interval>(result);
             var interval = (Interval)result;
-            Assert.AreEqual(1, interval.LowerBound);
+            Assert.That(interval.LowerBound, Is.EqualTo(1));
             Assert.IsTrue(interval.OpenLowerBound);
-            Assert.AreEqual(2, interval.UpperBound);
+            Assert.That(interval.UpperBound, Is.EqualTo(2));
             Assert.IsTrue(interval.OpenUpperBound);
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/ExpressionsT/MatrixExpressionT/EvalMatrixExpressionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/ExpressionsT/MatrixExpressionT/EvalMatrixExpressionTest.cs
@@ -49,12 +49,12 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             // then
             Assert.IsInstanceOf<Matrix>(result);
             var matrix = (Matrix)result;
-            Assert.AreEqual(2, matrix.RowCount);
-            Assert.AreEqual(2, matrix.ColumnCount);
-            Assert.AreEqual(1.ToNumber(), matrix[0, 0]);
-            Assert.AreEqual(2.ToNumber(), matrix[0, 1]);
-            Assert.AreEqual(3.ToNumber(), matrix[1, 0]);
-            Assert.AreEqual(4.ToNumber(), matrix[1, 1]);
+            Assert.That(matrix.RowCount, Is.EqualTo(2));
+            Assert.That(matrix.ColumnCount, Is.EqualTo(2));
+            Assert.That(matrix[0, 0], Is.EqualTo(1.ToNumber()));
+            Assert.That(matrix[0, 1], Is.EqualTo(2.ToNumber()));
+            Assert.That(matrix[1, 0], Is.EqualTo(3.ToNumber()));
+            Assert.That(matrix[1, 1], Is.EqualTo(4.ToNumber()));
         }
 
         [Test]
@@ -74,14 +74,14 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             // then
             Assert.IsInstanceOf<Matrix>(result);
             var matrix = (Matrix)result;
-            Assert.AreEqual(2, matrix.RowCount);
-            Assert.AreEqual(3, matrix.ColumnCount);
-            Assert.AreEqual(1.ToNumber(), matrix[0, 0]);
-            Assert.AreEqual(2.ToNumber(), matrix[0, 1]);
-            Assert.AreEqual(3.ToNumber(), matrix[0, 2]);
-            Assert.AreEqual(4.ToNumber(), matrix[1, 0]);
-            Assert.AreEqual(5.ToNumber(), matrix[1, 1]);
-            Assert.AreEqual(6.ToNumber(), matrix[1, 2]);
+            Assert.That(matrix.RowCount, Is.EqualTo(2));
+            Assert.That(matrix.ColumnCount, Is.EqualTo(3));
+            Assert.That(matrix[0, 0], Is.EqualTo(1.ToNumber()));
+            Assert.That(matrix[0, 1], Is.EqualTo(2.ToNumber()));
+            Assert.That(matrix[0, 2], Is.EqualTo(3.ToNumber()));
+            Assert.That(matrix[1, 0], Is.EqualTo(4.ToNumber()));
+            Assert.That(matrix[1, 1], Is.EqualTo(5.ToNumber()));
+            Assert.That(matrix[1, 2], Is.EqualTo(6.ToNumber()));
         }
 
         [Test]
@@ -99,8 +99,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var exc = Assert.Throws<NameException>(
                 () => eval.Eval(expr, env));
             // and
-            Assert.AreEqual("Variable not found: a",
-                exc.Message);
+            Assert.That(exc.Message,
+                Is.EqualTo("Variable not found: a"));
         }
 
         [Test]
@@ -120,12 +120,12 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             // then
             Assert.IsInstanceOf<Matrix>(result);
             var matrix = (Matrix)result;
-            Assert.AreEqual(2, matrix.RowCount);
-            Assert.AreEqual(2, matrix.ColumnCount);
-            Assert.AreEqual(1.ToNumber(), matrix[0, 0]);
-            Assert.AreEqual(2.ToNumber(), matrix[0, 1]);
-            Assert.AreEqual(3.ToNumber(), matrix[1, 0]);
-            Assert.AreEqual(5.ToNumber(), matrix[1, 1]);
+            Assert.That(matrix.RowCount, Is.EqualTo(2));
+            Assert.That(matrix.ColumnCount, Is.EqualTo(2));
+            Assert.That(matrix[0, 0], Is.EqualTo(1.ToNumber()));
+            Assert.That(matrix[0, 1], Is.EqualTo(2.ToNumber()));
+            Assert.That(matrix[1, 0], Is.EqualTo(3.ToNumber()));
+            Assert.That(matrix[1, 1], Is.EqualTo(5.ToNumber()));
         }
 
         [Test]
@@ -147,19 +147,19 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             // then
             Assert.IsInstanceOf<Matrix>(result);
             var matrix = (Matrix)result;
-            Assert.AreEqual(2, matrix.RowCount);
-            Assert.AreEqual(2, matrix.ColumnCount);
-            Assert.AreEqual(1.ToNumber(), matrix[0, 0]);
-            Assert.AreEqual(2.ToNumber(), matrix[0, 1]);
-            Assert.AreEqual(3.ToNumber(), matrix[1, 0]);
+            Assert.That(matrix.RowCount, Is.EqualTo(2));
+            Assert.That(matrix.ColumnCount, Is.EqualTo(2));
+            Assert.That(matrix[0, 0], Is.EqualTo(1.ToNumber()));
+            Assert.That(matrix[0, 1], Is.EqualTo(2.ToNumber()));
+            Assert.That(matrix[1, 0], Is.EqualTo(3.ToNumber()));
             Assert.IsInstanceOf<Matrix>(matrix[1, 1]);
             var matrix2 = (Matrix)matrix[1, 1];
-            Assert.AreEqual(2, matrix2.RowCount);
-            Assert.AreEqual(2, matrix2.ColumnCount);
-            Assert.AreEqual(4.ToNumber(), matrix2[0, 0]);
-            Assert.AreEqual(5.ToNumber(), matrix2[0, 1]);
-            Assert.AreEqual(6.ToNumber(), matrix2[1, 0]);
-            Assert.AreEqual(7.ToNumber(), matrix2[1, 1]);
+            Assert.That(matrix2.RowCount, Is.EqualTo(2));
+            Assert.That(matrix2.ColumnCount, Is.EqualTo(2));
+            Assert.That(matrix2[0, 0], Is.EqualTo(4.ToNumber()));
+            Assert.That(matrix2[0, 1], Is.EqualTo(5.ToNumber()));
+            Assert.That(matrix2[1, 0], Is.EqualTo(6.ToNumber()));
+            Assert.That(matrix2[1, 1], Is.EqualTo(7.ToNumber()));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/ExpressionsT/VariableAccessT/EvalVariableAccessTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/ExpressionsT/VariableAccessT/EvalVariableAccessTest.cs
@@ -51,7 +51,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             Assert.IsTrue(result0.IsIsScalar(null));
             Assert.IsInstanceOf<Number>(result0);
             var result = result0.ToNumber();
-            Assert.AreEqual(3, result.Value);
+            Assert.That(result.Value, Is.EqualTo(3));
         }
 
         [Test]
@@ -71,7 +71,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             Assert.IsTrue(result0.IsIsScalar(null));
             Assert.IsInstanceOf<Number>(result0);
             var result = result0.ToNumber();
-            Assert.AreEqual(1, result.Value);
+            Assert.That(result.Value, Is.EqualTo(1));
         }
 
         [Test]
@@ -90,7 +90,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             Assert.IsTrue(result0.IsIsScalar(null));
             Assert.IsInstanceOf<Number>(result0);
             var result = result0.ToNumber();
-            Assert.AreEqual(3, result.Value);
+            Assert.That(result.Value, Is.EqualTo(3));
         }
 
         [Test]
@@ -109,10 +109,10 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             Assert.IsTrue(result0.IsIsVector(null));
             Assert.IsInstanceOf<Vector>(result0);
             var result = (Vector)result0;
-            Assert.AreEqual(3, result.Length);
-            Assert.AreEqual(1, result[0].ToNumber().Value);
-            Assert.AreEqual(2, result[1].ToNumber().Value);
-            Assert.AreEqual(3, result[2].ToNumber().Value);
+            Assert.That(result.Length, Is.EqualTo(3));
+            Assert.That(result[0].ToNumber().Value, Is.EqualTo(1));
+            Assert.That(result[1].ToNumber().Value, Is.EqualTo(2));
+            Assert.That(result[2].ToNumber().Value, Is.EqualTo(3));
         }
 
         [Test]
@@ -135,12 +135,12 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             Assert.IsTrue(result0.IsIsMatrix(null));
             Assert.IsInstanceOf<Matrix>(result0);
             var result = (Matrix)result0;
-            Assert.AreEqual(2, result.RowCount);
-            Assert.AreEqual(2, result.ColumnCount);
-            Assert.AreEqual(1, result[0, 0].ToNumber().Value);
-            Assert.AreEqual(2, result[0, 1].ToNumber().Value);
-            Assert.AreEqual(3, result[1, 0].ToNumber().Value);
-            Assert.AreEqual(4, result[1, 1].ToNumber().Value);
+            Assert.That(result.RowCount, Is.EqualTo(2));
+            Assert.That(result.ColumnCount, Is.EqualTo(2));
+            Assert.That(result[0, 0].ToNumber().Value, Is.EqualTo(1));
+            Assert.That(result[0, 1].ToNumber().Value, Is.EqualTo(2));
+            Assert.That(result[1, 0].ToNumber().Value, Is.EqualTo(3));
+            Assert.That(result[1, 1].ToNumber().Value, Is.EqualTo(4));
         }
 
         [Test]
@@ -159,7 +159,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             Assert.IsTrue(result0.IsIsString(null));
             Assert.IsInstanceOf<StringValue>(result0);
             var result = (StringValue)result0;
-            Assert.AreEqual("abc", result.Value);
+            Assert.That(result.Value, Is.EqualTo("abc"));
         }
 
         [Test]
@@ -178,8 +178,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             Assert.IsTrue(result0.IsIsInterval(null));
             Assert.IsInstanceOf<Interval>(result0);
             var result = (Interval)result0;
-            Assert.AreEqual(1.1f, result.LowerBound);
-            Assert.AreEqual(3.5f, result.UpperBound);
+            Assert.That(result.LowerBound, Is.EqualTo(1.1f));
+            Assert.That(result.UpperBound, Is.EqualTo(3.5f));
         }
 
         [Test]
@@ -197,7 +197,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             Assert.IsTrue(result0.IsConcrete);
             Assert.IsTrue(result0.IsIsFunction(null));
             Assert.IsInstanceOf<CosineFunction>(result0);
-            Assert.AreSame(CosineFunction.Value, result0);
+            Assert.That(result0, Is.SameAs(CosineFunction.Value));
         }
 
         [Test]
@@ -215,7 +215,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             Assert.IsTrue(result.IsConcrete);
             Assert.IsTrue(result.IsIsExpression(null));
             Assert.IsInstanceOf<ColorExpression>(result);
-            Assert.AreSame(expr2, result);
+            Assert.That(result, Is.SameAs(expr2));
         }
 
         [Test]
@@ -229,7 +229,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<NameException>(
                 () => eval.Eval(expr, env));
             // and
-            Assert.AreEqual("Variable not found: a", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Variable not found: a"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/ExpressionsT/VectorExpressionT/EvalVectorExpressionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/ExpressionsT/VectorExpressionT/EvalVectorExpressionTest.cs
@@ -48,10 +48,10 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             // then
             Assert.IsInstanceOf<IVector>(result);
             var vector = (IVector)result;
-            Assert.AreEqual(3, vector.Length);
-            Assert.AreEqual(1.ToNumber(), vector.GetComponent(0));
-            Assert.AreEqual(2.ToNumber(), vector.GetComponent(1));
-            Assert.AreEqual(3.ToNumber(), vector.GetComponent(2));
+            Assert.That(vector.Length, Is.EqualTo(3));
+            Assert.That(vector.GetComponent(0), Is.EqualTo(1.ToNumber()));
+            Assert.That(vector.GetComponent(1), Is.EqualTo(2.ToNumber()));
+            Assert.That(vector.GetComponent(2), Is.EqualTo(3.ToNumber()));
         }
 
         [Test]
@@ -67,8 +67,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             // expect
             var exc = Assert.Throws<NameException>(() => eval.Eval(expr, env));
             // and
-            Assert.AreEqual("Variable not found: a",
-                exc.Message);
+            Assert.That(exc.Message,
+                Is.EqualTo("Variable not found: a"));
         }
 
         [Test]
@@ -87,10 +87,10 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             // then
             Assert.IsInstanceOf<IVector>(result);
             var vector = (IVector)result;
-            Assert.AreEqual(3, vector.Length);
-            Assert.AreEqual(1.ToNumber(), vector.GetComponent(0));
-            Assert.AreEqual(2.ToNumber(), vector.GetComponent(1));
-            Assert.AreEqual(5.ToNumber(), vector.GetComponent(2));
+            Assert.That(vector.Length, Is.EqualTo(3));
+            Assert.That(vector.GetComponent(0), Is.EqualTo(1.ToNumber()));
+            Assert.That(vector.GetComponent(1), Is.EqualTo(2.ToNumber()));
+            Assert.That(vector.GetComponent(2), Is.EqualTo(5.ToNumber()));
         }
 
         [Test]
@@ -110,15 +110,15 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             // then
             Assert.IsInstanceOf<IVector>(result);
             var vector = (IVector)result;
-            Assert.AreEqual(3, vector.Length);
-            Assert.AreEqual(1.ToNumber(), vector.GetComponent(0));
-            Assert.AreEqual(2.ToNumber(), vector.GetComponent(1));
+            Assert.That(vector.Length, Is.EqualTo(3));
+            Assert.That(vector.GetComponent(0), Is.EqualTo(1.ToNumber()));
+            Assert.That(vector.GetComponent(1), Is.EqualTo(2.ToNumber()));
             Assert.IsInstanceOf<IVector>(vector.GetComponent(2));
             var vector2 = (IVector)vector.GetComponent(2);
-            Assert.AreEqual(3, vector2.Length);
-            Assert.AreEqual(3.ToNumber(), vector2.GetComponent(0));
-            Assert.AreEqual(4.ToNumber(), vector2.GetComponent(1));
-            Assert.AreEqual(5.ToNumber(), vector2.GetComponent(2));
+            Assert.That(vector2.Length, Is.EqualTo(3));
+            Assert.That(vector2.GetComponent(0), Is.EqualTo(3.ToNumber()));
+            Assert.That(vector2.GetComponent(1), Is.EqualTo(4.ToNumber()));
+            Assert.That(vector2.GetComponent(2), Is.EqualTo(5.ToNumber()));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/AbsoluteValueFunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/AbsoluteValueFunctionT/CallTest.cs
@@ -43,7 +43,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             // when
             var result = eval.Call(f, args, null);
             // then
-            Assert.AreEqual(1, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(1));
         }
 
         [Test]
@@ -56,7 +56,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             // when
             var result = eval.Call(f, args, null);
             // then
-            Assert.AreEqual(1, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(1));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/AdditionOperationT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/AdditionOperationT/CallTest.cs
@@ -68,7 +68,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             // when
             var result = eval.Call(f, args, null);
             // then
-            Assert.AreEqual(3, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(3));
         }
 
         [Test]
@@ -86,7 +86,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             // when
             var result = eval.Call(f, args, null);
             // then
-            Assert.AreEqual(7, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(7));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/ArccosecantFunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/ArccosecantFunctionT/CallTest.cs
@@ -55,7 +55,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsTrue(result.IsScalar(null));
-            Assert.AreEqual(expected, result.ToFloat(), 0.000001f);
+            Assert.That(result.ToFloat(),
+                Is.EqualTo(expected).Within(0.000001f));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/ArccosineFunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/ArccosineFunctionT/CallTest.cs
@@ -54,7 +54,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsTrue(result.IsScalar(null));
-            Assert.AreEqual(expected, result.ToFloat(), 0.000001f);
+            Assert.That(result.ToFloat(),
+                Is.EqualTo(expected).Within(0.000001f));
         }
 
         [Test]
@@ -68,7 +69,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<OperandException>(
                 () => eval.Call(f, args, null));
             // and
-            Assert.AreEqual("Argument less than -1", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Argument less than -1"));
         }
 
         [Test]
@@ -82,7 +83,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<OperandException>(
                 () => eval.Call(f, args, null));
             // and
-            Assert.AreEqual("Argument greater than 1", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Argument greater than 1"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/ArccotangentFunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/ArccotangentFunctionT/CallTest.cs
@@ -53,7 +53,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsTrue(result.IsScalar(null));
-            Assert.AreEqual(expected, result.ToFloat(), 0.000001f);
+            Assert.That(result.ToFloat(),
+                Is.EqualTo(expected).Within(0.000001f));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/ArcsecantFunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/ArcsecantFunctionT/CallTest.cs
@@ -53,7 +53,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsTrue(result.IsScalar(null));
-            Assert.AreEqual(expected, result.ToFloat(), 0.000001f);
+            Assert.That(result.ToFloat(),
+                Is.EqualTo(expected).Within(0.000001f));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/ArcsineFunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/ArcsineFunctionT/CallTest.cs
@@ -56,7 +56,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsTrue(result.IsScalar(null));
-            Assert.AreEqual(expected, result.ToFloat(), 0.000001f);
+            Assert.That(result.ToFloat(),
+                Is.EqualTo(expected).Within(0.000001f));
         }
 
         [Test]
@@ -70,7 +71,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<OperandException>(
                 () => eval.Call(f, args, null));
             // and
-            Assert.AreEqual("Argument less than -1", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Argument less than -1"));
         }
 
         [Test]
@@ -84,7 +85,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<OperandException>(
                 () => eval.Call(f, args, null));
             // and
-            Assert.AreEqual("Argument greater than 1", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Argument greater than 1"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/ArctangentFunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/ArctangentFunctionT/CallTest.cs
@@ -55,7 +55,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsTrue(result.IsScalar(null));
-            Assert.AreEqual(expected, result.ToFloat(), 0.000001f);
+            Assert.That(result.ToFloat(),
+                Is.EqualTo(expected).Within(0.000001f));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/BitwiseAndOperationT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/BitwiseAndOperationT/CallTest.cs
@@ -60,7 +60,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsTrue(result.IsScalar(null));
-            Assert.AreEqual(expected, result.ToFloat());
+            Assert.That(result.ToFloat(), Is.EqualTo(expected));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/BitwiseOrOperationT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/BitwiseOrOperationT/CallTest.cs
@@ -66,7 +66,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsTrue(result.IsScalar(null));
-            Assert.AreEqual(expected, result.ToFloat());
+            Assert.That(result.ToFloat(), Is.EqualTo(expected));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/CeilingFunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/CeilingFunctionT/CallTest.cs
@@ -49,7 +49,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsTrue(result.IsScalar(null));
-            Assert.AreEqual(expected, result.ToFloat());
+            Assert.That(result.ToFloat(), Is.EqualTo(expected));
         }
 
         [Test]
@@ -66,7 +66,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsTrue(result.IsScalar(null));
-            Assert.AreEqual(expected, result.ToFloat());
+            Assert.That(result.ToFloat(), Is.EqualTo(expected));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/CosecantFunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/CosecantFunctionT/CallTest.cs
@@ -70,7 +70,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsTrue(result.IsScalar(null));
-            Assert.AreEqual(expected, result.ToFloat(), 0.000001f);
+            Assert.That(result.ToFloat(),
+                Is.EqualTo(expected).Within(0.000001f));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/CosineFunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/CosineFunctionT/CallTest.cs
@@ -69,7 +69,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsTrue(result.IsScalar(null));
-            Assert.AreEqual(expected, result.ToFloat(), 0.000001f);
+            Assert.That(result.ToFloat(),
+                Is.EqualTo(expected).Within(0.000001f));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/CotangentFunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/CotangentFunctionT/CallTest.cs
@@ -71,7 +71,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsTrue(result.IsScalar(null));
-            Assert.AreEqual(expected, result.ToFloat(), 0.000001f);
+            Assert.That(result.ToFloat(),
+                Is.EqualTo(expected).Within(0.000001f));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/DistFunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/DistFunctionT/CallTest.cs
@@ -68,7 +68,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsTrue(result.IsScalar(null));
-            Assert.AreEqual(expected, result.ToFloat(), 0.000001f);
+            Assert.That(result.ToFloat(),
+                Is.EqualTo(expected).Within(0.000001f));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/DistSqFunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/DistSqFunctionT/CallTest.cs
@@ -68,7 +68,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsTrue(result.IsScalar(null));
-            Assert.AreEqual(expected, result.ToFloat(), 0.000001f);
+            Assert.That(result.ToFloat(),
+                Is.EqualTo(expected).Within(0.000001f));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/DivisionOperationT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/DivisionOperationT/CallTest.cs
@@ -65,7 +65,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsTrue(result.IsScalar(null));
-            Assert.AreEqual(expected, result.ToFloat(), 0.000001f);
+            Assert.That(result.ToFloat(),
+                Is.EqualTo(expected).Within(0.000001f));
         }
 
         [Test]
@@ -79,7 +80,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<OperandException>(
                 () => eval.Call(f, args, null));
             // and
-            Assert.AreEqual("Division by zero", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Division by zero"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/EqualComparisonOperationT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/EqualComparisonOperationT/CallTest.cs
@@ -67,7 +67,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsTrue(result.IsScalar(null));
-            Assert.AreEqual(expected, result.ToFloat(), 0.000001f);
+            Assert.That(result.ToFloat(),
+                Is.EqualTo(expected).Within(0.000001f));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/ExponentOperationT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/ExponentOperationT/CallTest.cs
@@ -81,7 +81,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsTrue(result.IsScalar(null));
-            Assert.AreEqual(expected, result.ToFloat(), 0.000001f);
+            Assert.That(result.ToFloat(),
+                Is.EqualTo(expected).Within(0.000001f));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/FactorialFunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/FactorialFunctionT/CallTest.cs
@@ -97,7 +97,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             // when
             var result = eval.Call(f, args, null);
             // then
-            Assert.AreEqual(expected, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(expected));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/FloorFunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/FloorFunctionT/CallTest.cs
@@ -48,7 +48,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsTrue(result.IsScalar(null));
-            Assert.AreEqual(expected, result.ToFloat());
+            Assert.That(result.ToFloat(), Is.EqualTo(expected));
         }
 
         [Test]
@@ -65,7 +65,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsTrue(result.IsScalar(null));
-            Assert.AreEqual(expected, result.ToFloat());
+            Assert.That(result.ToFloat(), Is.EqualTo(expected));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/GreaterThanComparisonOperationT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/GreaterThanComparisonOperationT/CallTest.cs
@@ -68,7 +68,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsTrue(result.IsScalar(null));
-            Assert.AreEqual(expected, result.ToFloat(), 0.000001f);
+            Assert.That(result.ToFloat(),
+                Is.EqualTo(expected).Within(0.000001f));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/GreaterThanOrEqualComparisonOperationT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/GreaterThanOrEqualComparisonOperationT/CallTest.cs
@@ -68,7 +68,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsTrue(result.IsScalar(null));
-            Assert.AreEqual(expected, result.ToFloat(), 0.000001f);
+            Assert.That(result.ToFloat(),
+                Is.EqualTo(expected).Within(0.000001f));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/LessThanComparisonOperationT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/LessThanComparisonOperationT/CallTest.cs
@@ -68,7 +68,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsTrue(result.IsScalar(null));
-            Assert.AreEqual(expected, result.ToFloat(), 0.000001f);
+            Assert.That(result.ToFloat(),
+                Is.EqualTo(expected).Within(0.000001f));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/LessThanOrEqualComparisonOperationT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/LessThanOrEqualComparisonOperationT/CallTest.cs
@@ -72,7 +72,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsTrue(result.IsScalar(null));
-            Assert.AreEqual(expected, result.ToFloat(), 0.000001f);
+            Assert.That(result.ToFloat(),
+                Is.EqualTo(expected).Within(0.000001f));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/Log10FunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/Log10FunctionT/CallTest.cs
@@ -62,7 +62,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             // when
             var result = eval.Call(f, args, null);
             // then
-            Assert.AreEqual(expected, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(expected));
         }
 
         [Test]
@@ -76,7 +76,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<OperandException>(
                 () => eval.Call(f, args, null));
             // and
-            Assert.AreEqual("Argument must be positive", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Argument must be positive"));
         }
 
         [Test]
@@ -90,7 +90,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<OperandException>(
                 () => eval.Call(f, args, null));
             // and
-            Assert.AreEqual("Argument must be positive", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Argument must be positive"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/Log2FunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/Log2FunctionT/CallTest.cs
@@ -63,7 +63,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             // when
             var result = eval.Call(f, args, null);
             // then
-            Assert.AreEqual(expected, result.ToNumber().Value, 0.00001f);
+            Assert.That(result.ToNumber().Value,
+                Is.EqualTo(expected).Within(0.00001f));
         }
 
         [Test]
@@ -77,7 +78,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<OperandException>(
                 () => eval.Call(f, args, null));
             // and
-            Assert.AreEqual("Argument must be positive", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Argument must be positive"));
         }
 
         [Test]
@@ -91,7 +92,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<OperandException>(
                 () => eval.Call(f, args, null));
             // and
-            Assert.AreEqual("Argument must be positive", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Argument must be positive"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/LogarithmFunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/LogarithmFunctionT/CallTest.cs
@@ -69,7 +69,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             // when
             var result = eval.Call(f, args, null);
             // then
-            Assert.AreEqual(expected, result.ToNumber().Value, 0.00001f);
+            Assert.That(result.ToNumber().Value,
+                Is.EqualTo(expected).Within(0.00001f));
         }
 
         [Test]
@@ -83,7 +84,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<OperandException>(
                 () => eval.Call(f, args, null));
             // and
-            Assert.AreEqual("Argument must be positive", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Argument must be positive"));
         }
 
         [Test]
@@ -97,7 +98,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<OperandException>(
                 () => eval.Call(f, args, null));
             // and
-            Assert.AreEqual("Base must be positive", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Base must be positive"));
         }
 
         [Test]
@@ -111,7 +112,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<OperandException>(
                 () => eval.Call(f, args, null));
             // and
-            Assert.AreEqual("Base must not be one", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Base must not be one"));
         }
 
         [Test]
@@ -125,7 +126,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<OperandException>(
                 () => eval.Call(f, args, null));
             // and
-            Assert.AreEqual("Argument must be positive", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Argument must be positive"));
         }
 
         [Test]
@@ -139,7 +140,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<OperandException>(
                 () => eval.Call(f, args, null));
             // and
-            Assert.AreEqual("Base must be positive", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Base must be positive"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/LogicalAndOperationT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/LogicalAndOperationT/CallTest.cs
@@ -75,7 +75,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsTrue(result.IsScalar(null));
-            Assert.AreEqual(expected, result.ToFloat(), 0.000001f);
+            Assert.That(result.ToFloat(),
+                Is.EqualTo(expected).Within(0.000001f));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/LogicalOrOperationT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/LogicalOrOperationT/CallTest.cs
@@ -75,7 +75,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsTrue(result.IsScalar(null));
-            Assert.AreEqual(expected, result.ToFloat(), 0.000001f);
+            Assert.That(result.ToFloat(),
+                Is.EqualTo(expected).Within(0.000001f));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/MaximumFiniteFunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/MaximumFiniteFunctionT/CallTest.cs
@@ -54,7 +54,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(5, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(5));
         }
 
         [Test]
@@ -75,7 +75,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(9, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(9));
         }
 
         [Test]
@@ -97,7 +97,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(-1, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(-1));
         }
 
         [Test]
@@ -118,7 +118,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(-6, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(-6));
         }
 
         [Test]
@@ -138,7 +138,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(1, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(1));
         }
 
         [Test]
@@ -160,7 +160,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(9, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(9));
         }
 
         [Test]
@@ -178,7 +178,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(5, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(5));
         }
 
         [Test]
@@ -192,7 +192,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<ArgumentException>(
                 () => eval.Call(f, args, null));
             // and
-            Assert.AreEqual("No arguments passed", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("No arguments passed"));
         }
 
         [Test]
@@ -214,7 +214,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(5, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(5));
         }
 
         [Test]
@@ -236,7 +236,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(5, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(5));
         }
 
         [Test]
@@ -258,7 +258,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(5, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(5));
         }
 
         [Test]
@@ -279,7 +279,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(1, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(1));
         }
 
         [Test]
@@ -298,7 +298,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(float.NaN, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(float.NaN));
         }
 
         [Test]
@@ -316,7 +316,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(float.NaN, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(float.NaN));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/MaximumFunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/MaximumFunctionT/CallTest.cs
@@ -53,7 +53,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(5, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(5));
         }
 
         [Test]
@@ -73,7 +73,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(9, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(9));
         }
 
         [Test]
@@ -94,7 +94,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(-1, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(-1));
         }
 
         [Test]
@@ -114,7 +114,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(-6, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(-6));
         }
 
         [Test]
@@ -133,7 +133,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(1, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(1));
         }
 
         [Test]
@@ -154,7 +154,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(9, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(9));
         }
 
         [Test]
@@ -171,7 +171,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(5, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(5));
         }
 
         [Test]
@@ -185,7 +185,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<ArgumentException>(
                 () => eval.Call(f, args, null));
             // and
-            Assert.AreEqual("No arguments passed", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("No arguments passed"));
         }
 
         [Test]
@@ -206,7 +206,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(float.NaN, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(float.NaN));
         }
 
         [Test]
@@ -227,7 +227,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(float.PositiveInfinity, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value,
+                Is.EqualTo(float.PositiveInfinity));
         }
 
         [Test]
@@ -248,7 +249,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(5, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(5));
         }
 
         [Test]
@@ -267,7 +268,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(float.NaN, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(float.NaN));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/MinimumFiniteFunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/MinimumFiniteFunctionT/CallTest.cs
@@ -53,7 +53,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(1, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(1));
         }
 
         [Test]
@@ -73,7 +73,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(6, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(6));
         }
 
         [Test]
@@ -94,7 +94,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(-5, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(-5));
         }
 
         [Test]
@@ -114,7 +114,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(-9, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(-9));
         }
 
         [Test]
@@ -133,7 +133,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(-1, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(-1));
         }
 
         [Test]
@@ -154,7 +154,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(1, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(1));
         }
 
         [Test]
@@ -171,7 +171,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(5, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(5));
         }
 
         [Test]
@@ -185,7 +185,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<ArgumentException>(
                 () => eval.Call(f, args, null));
             // and
-            Assert.AreEqual("No arguments passed", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("No arguments passed"));
         }
 
         [Test]
@@ -206,7 +206,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(1, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(1));
         }
 
         [Test]
@@ -227,7 +227,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(1, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(1));
         }
 
         [Test]
@@ -248,7 +248,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(1, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(1));
         }
 
         [Test]
@@ -268,7 +268,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(1, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(1));
         }
 
         [Test]
@@ -287,7 +287,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(float.NaN, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(float.NaN));
         }
 
         [Test]
@@ -305,7 +305,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(float.NaN, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(float.NaN));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/MinimumFunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/MinimumFunctionT/CallTest.cs
@@ -53,7 +53,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(1, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(1));
         }
 
         [Test]
@@ -73,7 +73,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(6, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(6));
         }
 
         [Test]
@@ -94,7 +94,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(-5, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(-5));
         }
 
         [Test]
@@ -114,7 +114,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(-9, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(-9));
         }
 
         [Test]
@@ -133,7 +133,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(-1, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(-1));
         }
 
         [Test]
@@ -154,7 +154,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(1, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(1));
         }
 
         [Test]
@@ -171,7 +171,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(5, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(5));
         }
 
         [Test]
@@ -185,7 +185,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<ArgumentException>(
                 () => eval.Call(f, args, null));
             // and
-            Assert.AreEqual("No arguments passed", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("No arguments passed"));
         }
 
         [Test]
@@ -206,7 +206,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(float.NaN, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(float.NaN));
         }
 
         [Test]
@@ -227,7 +227,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(1, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(1));
         }
 
         [Test]
@@ -248,7 +248,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(float.NegativeInfinity, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value,
+                Is.EqualTo(float.NegativeInfinity));
         }
 
         [Test]
@@ -267,7 +268,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsInstanceOf<Number>(result);
-            Assert.AreEqual(float.NaN, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(float.NaN));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/ModularDivisionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/ModularDivisionT/CallTest.cs
@@ -89,7 +89,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsTrue(result.IsScalar(null));
-            Assert.AreEqual(expected, result.ToFloat(), 0.000001f);
+            Assert.That(result.ToFloat(),
+                Is.EqualTo(expected).Within(0.000001f));
         }
 
         [Test]
@@ -103,7 +104,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<OperandException>(
                 () => eval.Call(f, args, null));
             // and
-            Assert.AreEqual("Division by zero", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Division by zero"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/MultiplicationOperationT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/MultiplicationOperationT/CallTest.cs
@@ -63,7 +63,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsTrue(result.IsScalar(null));
-            Assert.AreEqual(expected, result.ToFloat(), 0.000001f);
+            Assert.That(result.ToFloat(),
+                Is.EqualTo(expected).Within(0.000001f));
         }
 
         [Test]
@@ -104,7 +105,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             // when
             var result = eval.Call(f, args, null);
             // then
-            Assert.AreEqual(6, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(6));
         }
 
         [Test]
@@ -122,7 +123,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             // when
             var result = eval.Call(f, args, null);
             // then
-            Assert.AreEqual(30, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(30));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/NaturalLogarithmFunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/NaturalLogarithmFunctionT/CallTest.cs
@@ -63,7 +63,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             // when
             var result = eval.Call(f, args, null);
             // then
-            Assert.AreEqual(expected, result.ToNumber().Value, 0.00001f);
+            Assert.That(result.ToNumber().Value,
+                Is.EqualTo(expected).Within(0.00001f));
         }
 
         [Test]
@@ -77,7 +78,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<OperandException>(
                 () => eval.Call(f, args, null));
             // and
-            Assert.AreEqual("Argument must be positive", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Argument must be positive"));
         }
 
         [Test]
@@ -91,7 +92,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<OperandException>(
                 () => eval.Call(f, args, null));
             // and
-            Assert.AreEqual("Argument must be positive", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Argument must be positive"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/NegationOperationT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/NegationOperationT/CallTest.cs
@@ -53,7 +53,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsTrue(result.IsScalar(null));
-            Assert.AreEqual(expected, result.ToFloat(), 0.000001f);
+            Assert.That(result.ToFloat(),
+                Is.EqualTo(expected).Within(0.000001f));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/NotEqualComparisonOperationT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/NotEqualComparisonOperationT/CallTest.cs
@@ -67,7 +67,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsTrue(result.IsScalar(null));
-            Assert.AreEqual(expected, result.ToFloat(), 0.000001f);
+            Assert.That(result.ToFloat(),
+                Is.EqualTo(expected).Within(0.000001f));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/SecantFunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/SecantFunctionT/CallTest.cs
@@ -69,7 +69,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsTrue(result.IsScalar(null));
-            Assert.AreEqual(expected, result.ToFloat(), 0.000001f);
+            Assert.That(result.ToFloat(),
+                Is.EqualTo(expected).Within(0.000001f));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/SineFunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/SineFunctionT/CallTest.cs
@@ -70,7 +70,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsTrue(result.IsScalar(null));
-            Assert.AreEqual(expected, result.ToFloat(), 0.000001f);
+            Assert.That(result.ToFloat(),
+                Is.EqualTo(expected).Within(0.000001f));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/SizeFunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/SizeFunctionT/CallTest.cs
@@ -46,9 +46,9 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<ArgumentException>(
                 () => eval.Call(f, args, null));
             // and
-            Assert.AreEqual("Wrong number of arguments given to " +
-                            "size (expected 1 but got 0)",
-                ex.Message);
+            Assert.That(ex.Message,
+                Is.EqualTo("Wrong number of arguments given to " +
+                           "size (expected 1 but got 0)"));
         }
 
         [Test]
@@ -66,9 +66,9 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<ArgumentException>(
                 () => eval.Call(f, args, null));
             // and
-            Assert.AreEqual("Wrong number of arguments given to " +
-                            "size (expected 1 but got 2)",
-                ex.Message);
+            Assert.That(ex.Message,
+                Is.EqualTo("Wrong number of arguments given to " +
+                           "size (expected 1 but got 2)"));
         }
 
         [Test]
@@ -82,9 +82,9 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<ArgumentException>(
                 () => eval.Call(f, args, null));
             // and
-            Assert.AreEqual("Argument wrong type: expected " +
-                            "Vector or Matrix or String but got Scalar",
-                ex.Message);
+            Assert.That(ex.Message,
+                Is.EqualTo("Argument wrong type: expected " +
+                           "Vector or Matrix or String but got Scalar"));
         }
 
         [Test]
@@ -103,8 +103,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             Assert.IsFalse(result.IsScalar(null));
             Assert.IsTrue(result.IsVector(null));
             var v = result.ToVector();
-            Assert.AreEqual(1, v.Length);
-            Assert.AreEqual(2, v[0].ToFloat());
+            Assert.That(v.Length, Is.EqualTo(1));
+            Assert.That(v[0].ToFloat(), Is.EqualTo(2));
         }
 
         [Test]
@@ -127,9 +127,9 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             Assert.IsFalse(result.IsScalar(null));
             Assert.IsTrue(result.IsVector(null));
             var v = result.ToVector();
-            Assert.AreEqual(2, v.Length);
-            Assert.AreEqual(2, v[0].ToFloat());
-            Assert.AreEqual(3, v[1].ToFloat());
+            Assert.That(v.Length, Is.EqualTo(2));
+            Assert.That(v[0].ToFloat(), Is.EqualTo(2));
+            Assert.That(v[1].ToFloat(), Is.EqualTo(3));
         }
 
         [Test]
@@ -145,8 +145,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             Assert.IsFalse(result.IsScalar(null));
             Assert.IsTrue(result.IsVector(null));
             var v = result.ToVector();
-            Assert.AreEqual(1, v.Length);
-            Assert.AreEqual(3, v[0].ToFloat());
+            Assert.That(v.Length, Is.EqualTo(1));
+            Assert.That(v[0].ToFloat(), Is.EqualTo(3));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/TangentFunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/TangentFunctionT/CallTest.cs
@@ -70,7 +70,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Call(f, args, null);
             // then
             Assert.IsTrue(result.IsScalar(null));
-            Assert.AreEqual(expected, result.ToFloat(), 0.000001f);
+            Assert.That(result.ToFloat(),
+                Is.EqualTo(expected).Within(0.000001f));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/UnitStepFunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/UnitStepFunctionT/CallTest.cs
@@ -44,7 +44,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             // when
             var result = eval.Call(f, args, null);
             // then
-            Assert.AreEqual(1, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(1));
         }
 
         [Test]
@@ -57,7 +57,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             // when
             var result = eval.Call(f, args, null);
             // then
-            Assert.AreEqual(1, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(1));
         }
 
         [Test]
@@ -70,7 +70,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             // when
             var result = eval.Call(f, args, null);
             // then
-            Assert.AreEqual(0, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(0));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/UserDefinedFunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/UserDefinedFunctionT/CallTest.cs
@@ -59,7 +59,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             // when
             var result = eval.Call(f, args, env);
             // then
-            Assert.AreEqual(7, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(7));
         }
 
         [Test]
@@ -85,18 +85,18 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var eval = Util.CreateEvaluator<T>();
             // precondition
             Assert.IsInstanceOf<Literal>(env.GetVariable("a"));
-            Assert.AreEqual(8,
-                ((Literal)env.GetVariable("a")).Value.ToNumber().Value);
+            Assert.That(((Literal)env.GetVariable("a")).Value.ToNumber().Value,
+                Is.EqualTo(8));
             Assert.IsFalse(env.ContainsVariable("b"));
             Assert.IsFalse(env.ContainsVariable("c"));
             // when
             var result = eval.Call(f, args, env);
             // then
-            Assert.AreEqual(7, result.ToNumber().Value);
+            Assert.That(result.ToNumber().Value, Is.EqualTo(7));
             // and
             Assert.IsInstanceOf<Literal>(env.GetVariable("a"));
-            Assert.AreEqual(8,
-                ((Literal)env.GetVariable("a")).Value.ToNumber().Value);
+            Assert.That(((Literal)env.GetVariable("a")).Value.ToNumber().Value,
+                Is.EqualTo(8));
             Assert.IsFalse(env.ContainsVariable("b"));
             Assert.IsFalse(env.ContainsVariable("c"));
         }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/MacrosT/DeriveMacroT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/MacrosT/DeriveMacroT/CallTest.cs
@@ -52,8 +52,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var fc = (FunctionCall)result;
             Assert.IsInstanceOf<Literal>(fc.Function);
             var f = (Literal)fc.Function;
-            Assert.AreSame(AdditionOperation.Value, f.Value);
-            Assert.AreEqual(2, fc.Arguments.Count);
+            Assert.That(f.Value, Is.SameAs(AdditionOperation.Value));
+            Assert.That(fc.Arguments.Count, Is.EqualTo(2));
             Assert.IsTrue(fc.Arguments[0] is Literal ||
                           fc.Arguments[0] is FunctionCall);
             Assert.IsTrue(fc.Arguments[1] is Literal ||
@@ -71,30 +71,32 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
                 lit = (Literal)fc.Arguments[1];
             }
 
-            Assert.AreEqual(5,lit.Value.ToNumber().Value);
+            Assert.That(lit.Value.ToNumber().Value,
+                Is.EqualTo(5));
 
             Assert.IsInstanceOf<Literal>(fc2.Function);
-            Assert.AreSame(MultiplicationOperation.Value,
-                ((Literal)fc2.Function).Value);
-            Assert.AreEqual(2, fc2.Arguments.Count);
+            Assert.That(((Literal)fc2.Function).Value,
+                Is.SameAs(MultiplicationOperation.Value));
+            Assert.That(fc2.Arguments.Count, Is.EqualTo(2));
             Assert.IsInstanceOf<Literal>(fc2.Arguments[0]);
 
             var arg11 = (Literal)fc2.Arguments[0];
-            Assert.AreEqual(3,arg11.Value.ToNumber().Value);
+            Assert.That(arg11.Value.ToNumber().Value,
+                Is.EqualTo(3));
 
             Assert.IsInstanceOf<FunctionCall>(fc2.Arguments[1]);
             var arg12 = (FunctionCall)fc2.Arguments[1];
             Assert.IsInstanceOf<Literal>(arg12.Function);
-            Assert.AreSame(MultiplicationOperation.Value,
-                ((Literal)arg12.Function).Value);
-            Assert.AreEqual(2, arg12.Arguments.Count);
+            Assert.That(((Literal)arg12.Function).Value,
+                Is.SameAs(MultiplicationOperation.Value));
+            Assert.That(arg12.Arguments.Count, Is.EqualTo(2));
             Assert.IsInstanceOf<Literal>(arg12.Arguments[0]);
-            Assert.AreEqual(2,
-                ((Literal)arg12.Arguments[0]).Value.ToNumber().Value);
+            Assert.That(((Literal)arg12.Arguments[0]).Value.ToNumber().Value,
+                Is.EqualTo(2));
 
             Assert.IsInstanceOf<VariableAccess>(arg12.Arguments[1]);
-            Assert.AreEqual("x",
-                ((VariableAccess)arg12.Arguments[1]).VariableName);
+            Assert.That(((VariableAccess)arg12.Arguments[1]).VariableName,
+                Is.EqualTo("x"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/MacrosT/IfMacroT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/MacrosT/IfMacroT/CallTest.cs
@@ -59,7 +59,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             // then
             Assert.IsInstanceOf<Literal>(result);
             var literal = (Literal) result;
-            Assert.AreEqual(0, literal.Value.ToFloat());
+            Assert.That(literal.Value.ToFloat(), Is.EqualTo(0));
             // and
             Assert.True(thenEvaled);
             Assert.False(elseEvaled);
@@ -90,7 +90,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             // then
             Assert.IsInstanceOf<Literal>(result);
             var literal = (Literal) result;
-            Assert.AreEqual(0, literal.Value.ToFloat());
+            Assert.That(literal.Value.ToFloat(), Is.EqualTo(0));
             // and
             Assert.False(thenEvaled);
             Assert.True(elseEvaled);
@@ -121,7 +121,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             // then
             Assert.IsInstanceOf<Literal>(result);
             var literal = (Literal) result;
-            Assert.AreEqual(0, literal.Value.ToFloat());
+            Assert.That(literal.Value.ToFloat(), Is.EqualTo(0));
             // and
             Assert.False(thenEvaled);
             Assert.True(elseEvaled);
@@ -152,7 +152,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             // then
             Assert.IsInstanceOf<Literal>(result);
             var literal = (Literal) result;
-            Assert.AreEqual(0, literal.Value.ToFloat());
+            Assert.That(literal.Value.ToFloat(), Is.EqualTo(0));
             // and
             Assert.False(thenEvaled);
             Assert.True(elseEvaled);
@@ -183,7 +183,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             // then
             Assert.IsInstanceOf<Literal>(result);
             var literal = (Literal) result;
-            Assert.AreEqual(0, literal.Value.ToFloat());
+            Assert.That(literal.Value.ToFloat(), Is.EqualTo(0));
             // and
             Assert.False(thenEvaled);
             Assert.True(elseEvaled);

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/MacrosT/SqrtMacroT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/MacrosT/SqrtMacroT/CallTest.cs
@@ -48,14 +48,15 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var fc = (FunctionCall)result;
             Assert.IsInstanceOf<Literal>(fc.Function);
             var target = (Literal)fc.Function;
-            Assert.AreSame(ExponentOperation.Value, target.Value);
-            Assert.AreEqual(2,fc.Arguments.Count);
+            Assert.That(target.Value, Is.SameAs(ExponentOperation.Value));
+            Assert.That(fc.Arguments.Count,
+                Is.EqualTo(2));
             Assert.IsInstanceOf<Literal>(fc.Arguments[0]);
-            Assert.AreEqual(2f,
-                ((Literal)fc.Arguments[0]).Value.ToNumber().Value);
+            Assert.That(((Literal)fc.Arguments[0]).Value.ToNumber().Value,
+                Is.EqualTo(2f));
             Assert.IsInstanceOf<Literal>(fc.Arguments[1]);
-            Assert.AreEqual(0.5f,
-                ((Literal)fc.Arguments[1]).Value.ToNumber().Value);
+            Assert.That(((Literal)fc.Arguments[1]).Value.ToNumber().Value,
+                Is.EqualTo(0.5f));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/MacrosT/SubstMacroT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/MacrosT/SubstMacroT/CallTest.cs
@@ -47,10 +47,10 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             // when
             var result = eval.Eval(expr, null);
             // then
-            Assert.AreSame(original, result);
+            Assert.That(result, Is.SameAs(original));
             Assert.IsInstanceOf<VariableAccess>(result);
-            Assert.AreEqual("x",
-                ((VariableAccess)result).VariableName);
+            Assert.That(((VariableAccess)result).VariableName,
+                Is.EqualTo("x"));
         }
 
         [Test]
@@ -67,8 +67,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Eval(expr, null);
             // then
             Assert.IsInstanceOf<Literal>(result);
-            Assert.AreEqual(1,
-                ((Literal)result).Value.ToNumber().Value);
+            Assert.That(((Literal)result).Value.ToNumber().Value,
+                Is.EqualTo(1));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/ColorExpressionT/ResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/ColorExpressionT/ResultTest.cs
@@ -41,7 +41,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ColorExpressionT
             Assert.IsTrue(result.IsScalar(env));
             Assert.IsFalse(result.IsVector(env));
             Assert.IsFalse(result.IsMatrix(env));
-            Assert.AreEqual(0, result.GetTensorRank(env));
+            Assert.That(result.GetTensorRank(env), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(env));
             Assert.IsNull(result.GetDimension(env, 0));
             Assert.IsNull(result.GetDimensions(env));

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/ComponentAccessT/ComponentAccessTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/ComponentAccessT/ComponentAccessTest.cs
@@ -40,11 +40,11 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = new ComponentAccess(expr, indexes);
             // then
-            Assert.AreSame(expr, result.Expr);
-            Assert.AreEqual(1, result.Indexes.Count);
+            Assert.That(result.Expr, Is.SameAs(expr));
+            Assert.That(result.Indexes.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<Literal>(result.Indexes[0]);
-            Assert.AreEqual(1,
-                ((Literal) result.Indexes[0]).Value.ToFloat());
+            Assert.That(((Literal) result.Indexes[0]).Value.ToFloat(),
+                Is.EqualTo(1));
         }
 
         [Test]
@@ -59,10 +59,10 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // then
             Assert.IsInstanceOf<ComponentAccess>(result);
             var ca2 = (ComponentAccess) result;
-            Assert.AreNotSame(ca, ca2);
-            Assert.AreSame(ca.Expr, ca2.Expr);
-            Assert.AreEqual(1, ca2.Indexes.Count);
-            Assert.AreSame(ca.Indexes[0], ca2.Indexes[0]);
+            Assert.That(ca2, Is.Not.SameAs(ca));
+            Assert.That(ca2.Expr, Is.SameAs(ca.Expr));
+            Assert.That(ca2.Indexes.Count, Is.EqualTo(1));
+            Assert.That(ca2.Indexes[0], Is.SameAs(ca.Indexes[0]));
         }
 
         [Test]
@@ -83,11 +83,11 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             ca.AcceptVisitor(visitor);
             // then
-            Assert.AreEqual(4, exprs.Count);
-            Assert.AreSame(ca, exprs[0]);
-            Assert.AreSame(expr, exprs[1]);
-            Assert.AreSame(indexes[0], exprs[2]);
-            Assert.AreSame(indexes[1], exprs[3]);
+            Assert.That(exprs.Count, Is.EqualTo(4));
+            Assert.That(exprs[0], Is.SameAs(ca));
+            Assert.That(exprs[1], Is.SameAs(expr));
+            Assert.That(exprs[2], Is.SameAs(indexes[0]));
+            Assert.That(exprs[3], Is.SameAs(indexes[1]));
         }
 
         [Test]
@@ -104,7 +104,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = ca.ToString();
             // then
-            Assert.AreEqual("a[b, c]", result);
+            Assert.That(result, Is.EqualTo("a[b, c]"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/ComponentAccessT/ResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/ComponentAccessT/ResultTest.cs
@@ -230,7 +230,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = expr.GetResultType(env).GetTensorRank(env);
             // then
-            Assert.AreEqual(result, 0);
+            Assert.That(result, Is.EqualTo(0));
         }
 
         [Test]
@@ -253,7 +253,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = expr.GetResultType(env).GetTensorRank(env);
             // then
-            Assert.AreEqual(result, 0);
+            Assert.That(result, Is.EqualTo(0));
         }
 
         [Test]

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/ComponentAccessT/SimplifyTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/ComponentAccessT/SimplifyTest.cs
@@ -76,7 +76,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = ca.Simplify(empty);
             // then
-            Assert.AreSame(ca, result);
+            Assert.That(result, Is.SameAs(ca));
         }
 
         [Test]
@@ -92,7 +92,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             Assert.IsInstanceOf<Literal>(result);
             var lit = (Literal) result;
             Assert.IsTrue(lit.Value.IsScalar(null));
-            Assert.AreEqual(5, lit.Value.ToFloat());
+            Assert.That(lit.Value.ToFloat(), Is.EqualTo(5));
         }
 
         [Test]
@@ -108,8 +108,8 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             Assert.IsInstanceOf<ComponentAccess>(result);
             var ca2 = (ComponentAccess) result;
             Assert.IsInstanceOf<VectorExpression>(ca2.Expr);
-            Assert.AreEqual(3, ((VectorExpression) ca2.Expr).Length);
-            Assert.AreEqual(1, ca2.Indexes.Count);
+            Assert.That(((VectorExpression) ca2.Expr).Length, Is.EqualTo(3));
+            Assert.That(ca2.Indexes.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<VariableAccess>(ca2.Indexes[0]);
         }
 
@@ -125,7 +125,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // then
             Assert.IsInstanceOf<VariableAccess>(result);
             var va = (VariableAccess) result;
-            Assert.AreEqual("b", va.VariableName);
+            Assert.That(va.VariableName, Is.EqualTo("b"));
         }
 
         [Test]
@@ -138,7 +138,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = ca.Simplify(empty);
             // then
-            Assert.AreSame(ca, result);
+            Assert.That(result, Is.SameAs(ca));
         }
 
         [Test]
@@ -153,7 +153,8 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             var result = expr.Simplify(env);
             // then
             Assert.IsInstanceOf<VariableAccess>(result);
-            Assert.AreEqual("b", ((VariableAccess)result).VariableName);
+            Assert.That(((VariableAccess)result).VariableName,
+                Is.EqualTo("b"));
         }
 
         [Test]
@@ -170,7 +171,8 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             var result = expr.Simplify(env);
             // then
             Assert.IsInstanceOf<VariableAccess>(result);
-            Assert.AreEqual("d", ((VariableAccess)result).VariableName);
+            Assert.That(((VariableAccess)result).VariableName,
+                Is.EqualTo("d"));
         }
 
         class MockTensorExpression : TensorExpression
@@ -219,7 +221,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = expr.Simplify(env);
             // then
-            Assert.AreSame(expr, result);
+            Assert.That(result, Is.SameAs(expr));
         }
 
         [Test]
@@ -233,7 +235,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = expr.Simplify(env);
             // then
-            Assert.AreSame(expr, result);
+            Assert.That(result, Is.SameAs(expr));
         }
 
         [Test]
@@ -249,7 +251,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = expr.Simplify(env);
             // then
-            Assert.AreSame(expr, result);
+            Assert.That(result, Is.SameAs(expr));
         }
 
         [Test]
@@ -266,7 +268,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = expr.Simplify(env);
             // then
-            Assert.AreSame(expr, result);
+            Assert.That(result, Is.SameAs(expr));
         }
 
         [Test]
@@ -285,7 +287,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = expr.Simplify(env);
             // then
-            Assert.AreSame(expr, result);
+            Assert.That(result, Is.SameAs(expr));
         }
 
         [Test]
@@ -302,7 +304,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = expr.Simplify(env);
             // then
-            Assert.AreSame(expr, result);
+            Assert.That(result, Is.SameAs(expr));
         }
 
         [Test]
@@ -316,7 +318,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = expr.Simplify(env);
             // then
-            Assert.AreSame(expr, result);
+            Assert.That(result, Is.SameAs(expr));
         }
 
         // TODO: check for index greater than vector dimension
@@ -333,7 +335,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = expr.Simplify(env);
             // then
-            Assert.AreSame(expr, result);
+            Assert.That(result, Is.SameAs(expr));
         }
 
         [Test]
@@ -347,7 +349,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = expr.Simplify(env);
             // then
-            Assert.AreSame(expr, result);
+            Assert.That(result, Is.SameAs(expr));
         }
 
         [Test]
@@ -363,7 +365,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = expr.Simplify(env);
             // then
-            Assert.AreSame(expr, result);
+            Assert.That(result, Is.SameAs(expr));
         }
 
         [Test]
@@ -379,7 +381,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = expr.Simplify(env);
             // then
-            Assert.AreSame(expr, result);
+            Assert.That(result, Is.SameAs(expr));
         }
 
         [Test]
@@ -395,7 +397,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ComponentAccessT
             // when
             var result = expr.Simplify(env);
             // then
-            Assert.AreSame(expr, result);
+            Assert.That(result, Is.SameAs(expr));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/ExpressionsT/ComponentAccessT/CheckTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/ExpressionsT/ComponentAccessT/CheckTest.cs
@@ -70,10 +70,10 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var ex = Assert.Throws<OperandException>(
                 () => ec.Check(expr, null));
             // and
-            Assert.AreEqual(
-                "Unable to get components from expression, " +
-                "or the expression does not have components",
-                ex.Message);
+            Assert.That(ex.Message,
+                Is.EqualTo(
+                    "Unable to get components from expression, " +
+                    "or the expression does not have components"));
         }
 
         [Test]
@@ -88,9 +88,9 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var ex = Assert.Throws<OperandException>(
                 () => ec.Check(expr, null));
             // and
-            Assert.AreEqual(
-                "Wrong number of indexes for the expression",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Wrong number of indexes for the expression"));
         }
 
         [Test]
@@ -106,9 +106,9 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var ex = Assert.Throws<OperandException>(
                 () => ec.Check(expr, null));
             // and
-            Assert.AreEqual(
-                "Wrong number of indexes for the expression",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Wrong number of indexes for the expression"));
         }
 
         [Test]
@@ -127,7 +127,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var ex = Assert.Throws<IndexException>(
                 () => ec.Check(expr, null));
             // and
-            Assert.AreEqual("Indexes must be scalar", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Indexes must be scalar"));
         }
 
         [Test]
@@ -146,7 +146,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var ex = Assert.Throws<IndexException>(
                 () => ec.Check(expr, null));
             // and
-            Assert.AreEqual("Indexes must be scalar", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Indexes must be scalar"));
         }
 
         [Test]
@@ -161,7 +161,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var ex = Assert.Throws<IndexException>(
                 () => ec.Check(expr, null));
             // and
-            Assert.AreEqual("Indexes must be scalar", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Indexes must be scalar"));
         }
 
         [Test]
@@ -176,9 +176,9 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var ex = Assert.Throws<IndexException>(
                 () => ec.Check(expr, null));
             // and
-            Assert.AreEqual(
-                "Indexes must not be negative",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Indexes must not be negative"));
         }
 
         // TODO: check for index greater than vector dimension
@@ -205,10 +205,10 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var ex = Assert.Throws<OperandException>(
                 () => ec.Check(expr, null));
             // and
-            Assert.AreEqual(
-                "Unable to get components from expression, " +
-                "or the expression does not have components",
-                ex.Message);
+            Assert.That(ex.Message,
+                Is.EqualTo(
+                    "Unable to get components from expression, " +
+                    "or the expression does not have components"));
         }
 
         [Test]
@@ -235,9 +235,9 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var ex = Assert.Throws<OperandException>(
                 () => ec.Check(expr, null));
             // and
-            Assert.AreEqual(
-                "Wrong number of indexes for the expression",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Wrong number of indexes for the expression"));
         }
 
         [Test]
@@ -252,9 +252,9 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var ex = Assert.Throws<IndexException>(
                 () => ec.Check(expr, null));
             // and
-            Assert.AreEqual(
-                "Index exceeds the size of the vector",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Index exceeds the size of the vector"));
         }
 
         [Test]
@@ -270,9 +270,9 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var ex = Assert.Throws<IndexException>(
                 () => ec.Check(expr, null));
             // and
-            Assert.AreEqual(
-                "Index exceeds the size of the string",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Index exceeds the size of the string"));
         }
 
         [Test]
@@ -287,9 +287,9 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var ex = Assert.Throws<IndexException>(
                 () => ec.Check(expr, null));
             // and
-            Assert.AreEqual(
-                "Index exceeds number of rows of the matrix",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Index exceeds number of rows of the matrix"));
         }
 
         [Test]
@@ -304,9 +304,9 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var ex = Assert.Throws<IndexException>(
                 () => ec.Check(expr, null));
             // and
-            Assert.AreEqual(
-                "Index exceeds number of columns of the matrix",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Index exceeds number of columns of the matrix"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/ExpressionsT/MatrixExpressionT/CheckTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/ExpressionsT/MatrixExpressionT/CheckTest.cs
@@ -77,8 +77,8 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var exc = Assert.Throws<NameException>(
                 () => ec.Check(expr, env));
             // and
-            Assert.AreEqual("Variable not found: a",
-                exc.Message);
+            Assert.That(exc.Message,
+                Is.EqualTo("Variable not found: a"));
         }
 
         [Test]

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/ExpressionsT/VariableAccessT/CheckTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/ExpressionsT/VariableAccessT/CheckTest.cs
@@ -166,7 +166,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var ex = Assert.Throws<NameException>(
                 () => ec.Check(expr, env));
             // and
-            Assert.AreEqual("Variable not found: a", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Variable not found: a"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/ExpressionsT/VectorExpressionT/CheckTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/ExpressionsT/VectorExpressionT/CheckTest.cs
@@ -60,8 +60,8 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var exc = Assert.Throws<NameException>(
                 () => ec.Check(expr, env));
             // and
-            Assert.AreEqual("Variable not found: a",
-                exc.Message);
+            Assert.That(exc.Message,
+                Is.EqualTo("Variable not found: a"));
         }
 
         [Test]

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/ArccosineFunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/ArccosineFunctionT/CallTest.cs
@@ -66,7 +66,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var ex = Assert.Throws<OperandException>(
                 () => ec.Check(expr, null));
             // and
-            Assert.AreEqual("Argument less than -1", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Argument less than -1"));
         }
 
         [Test]
@@ -82,7 +82,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var ex = Assert.Throws<OperandException>(
                 () => ec.Check(expr, null));
             // and
-            Assert.AreEqual("Argument greater than 1", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Argument greater than 1"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/ArcsineFunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/ArcsineFunctionT/CallTest.cs
@@ -68,7 +68,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var ex = Assert.Throws<OperandException>(
                 () => ec.Check(expr, null));
             // and
-            Assert.AreEqual("Argument less than -1", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Argument less than -1"));
         }
 
         [Test]
@@ -84,7 +84,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var ex = Assert.Throws<OperandException>(
                 () => ec.Check(expr, null));
             // and
-            Assert.AreEqual("Argument greater than 1", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Argument greater than 1"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/DivisionOperationT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/DivisionOperationT/CallTest.cs
@@ -81,7 +81,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var ex = Assert.Throws<OperandException>(
                 () => ec.Check(expr, null));
             // and
-            Assert.AreEqual("Division by zero", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Division by zero"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/Log10FunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/Log10FunctionT/CallTest.cs
@@ -75,7 +75,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var ex = Assert.Throws<OperandException>(
                 () => ec.Check(expr, null));
             // and
-            Assert.AreEqual("Argument must be positive", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Argument must be positive"));
         }
 
         [Test]
@@ -91,7 +91,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var ex = Assert.Throws<OperandException>(
                 () => ec.Check(expr, null));
             // and
-            Assert.AreEqual("Argument must be positive", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Argument must be positive"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/Log2FunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/Log2FunctionT/CallTest.cs
@@ -76,7 +76,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var ex = Assert.Throws<OperandException>(
                 () => ec.Check(expr, null));
             // and
-            Assert.AreEqual("Argument must be positive", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Argument must be positive"));
         }
 
         [Test]
@@ -92,7 +92,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var ex = Assert.Throws<OperandException>(
                 () => ec.Check(expr, null));
             // and
-            Assert.AreEqual("Argument must be positive", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Argument must be positive"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/LogarithmFunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/LogarithmFunctionT/CallTest.cs
@@ -82,7 +82,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var ex = Assert.Throws<OperandException>(
                 () => ec.Check(expr, null));
             // and
-            Assert.AreEqual("Argument must be positive", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Argument must be positive"));
         }
 
         [Test]
@@ -98,7 +98,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var ex = Assert.Throws<OperandException>(
                 () => ec.Check(expr, null));
             // and
-            Assert.AreEqual("Base must be positive", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Base must be positive"));
         }
 
         [Test]
@@ -114,7 +114,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var ex = Assert.Throws<OperandException>(
                 () => ec.Check(expr, null));
             // and
-            Assert.AreEqual("Base must not be one", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Base must not be one"));
         }
 
         [Test]
@@ -130,7 +130,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var ex = Assert.Throws<OperandException>(
                 () => ec.Check(expr, null));
             // and
-            Assert.AreEqual("Argument must be positive", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Argument must be positive"));
         }
 
         [Test]
@@ -146,7 +146,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var ex = Assert.Throws<OperandException>(
                 () => ec.Check(expr, null));
             // and
-            Assert.AreEqual("Base must be positive", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Base must be positive"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/MaximumFiniteFunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/MaximumFiniteFunctionT/CallTest.cs
@@ -171,7 +171,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var ex = Assert.Throws<ArgumentException>(
                 () => ec.Check(expr, null));
             // and
-            Assert.AreEqual("No arguments passed", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("No arguments passed"));
         }
 
         [Test]

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/MaximumFunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/MaximumFunctionT/CallTest.cs
@@ -170,7 +170,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var ex = Assert.Throws<ArgumentException>(
                 () => ec.Check(expr, null));
             // and
-            Assert.AreEqual("No arguments passed", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("No arguments passed"));
         }
 
         [Test]

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/MinimumFiniteFunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/MinimumFiniteFunctionT/CallTest.cs
@@ -170,7 +170,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var ex = Assert.Throws<ArgumentException>(
                 () => ec.Check(expr, null));
             // and
-            Assert.AreEqual("No arguments passed", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("No arguments passed"));
         }
 
         [Test]

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/MinimumFunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/MinimumFunctionT/CallTest.cs
@@ -170,7 +170,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var ex = Assert.Throws<ArgumentException>(
                 () => ec.Check(expr, null));
             // and
-            Assert.AreEqual("No arguments passed", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("No arguments passed"));
         }
 
         [Test]

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/ModularDivisionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/ModularDivisionT/CallTest.cs
@@ -101,7 +101,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var ex = Assert.Throws<OperandException>(
                 () => ec.Check(expr, null));
             // and
-            Assert.AreEqual("Division by zero", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Division by zero"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/NaturalLogarithmFunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/NaturalLogarithmFunctionT/CallTest.cs
@@ -76,7 +76,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var ex = Assert.Throws<OperandException>(
                 () => ec.Check(expr, null));
             // and
-            Assert.AreEqual("Argument must be positive", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Argument must be positive"));
         }
 
         [Test]
@@ -92,7 +92,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var ex = Assert.Throws<OperandException>(
                 () => ec.Check(expr, null));
             // and
-            Assert.AreEqual("Argument must be positive", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Argument must be positive"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/SizeFunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/SizeFunctionT/CallTest.cs
@@ -45,9 +45,10 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var ex = Assert.Throws<ArgumentException>(
                 () => ec.Check(expr, null));
             // and
-            Assert.AreEqual("Wrong number of arguments given to " +
-                            "size (expected 1 but got 0)",
-                ex.Message);
+            Assert.That(ex.Message,
+                Is.EqualTo(
+                    "Wrong number of arguments given to " +
+                    "size (expected 1 but got 0)"));
         }
 
         [Test]
@@ -66,9 +67,10 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var ex = Assert.Throws<ArgumentException>(
                 () => ec.Check(expr, null));
             // and
-            Assert.AreEqual("Wrong number of arguments given to " +
-                            "size (expected 1 but got 2)",
-                ex.Message);
+            Assert.That(ex.Message,
+                Is.EqualTo(
+                    "Wrong number of arguments given to " +
+                    "size (expected 1 but got 2)"));
         }
 
         [Test]
@@ -83,9 +85,10 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var ex = Assert.Throws<ArgumentException>(
                 () => ec.Check(expr, null));
             // and
-            Assert.AreEqual("Argument wrong type: expected " +
-                            "Vector or Matrix or String but got Scalar",
-                ex.Message);
+            Assert.That(ex.Message,
+                Is.EqualTo(
+                    "Argument wrong type: expected " +
+                    "Vector or Matrix or String but got Scalar"));
         }
 
         [Test]

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/FunctionCallT/ResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/FunctionCallT/ResultTest.cs
@@ -43,7 +43,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.FunctionCallT
             Assert.IsTrue(mmo.IsScalar(env));
             Assert.IsFalse(mmo.IsVector(env));
             Assert.IsFalse(mmo.IsMatrix(env));
-            Assert.AreEqual(0, mmo.GetTensorRank(env));
+            Assert.That(mmo.GetTensorRank(env), Is.EqualTo(0));
             Assert.IsFalse(mmo.IsString(env));
             Assert.IsFalse(mmo.IsInterval(env));
             Assert.IsFalse(mmo.IsFunction(env));
@@ -54,7 +54,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.FunctionCallT
             Assert.IsTrue(result.IsScalar(env));
             Assert.IsFalse(result.IsVector(env));
             Assert.IsFalse(result.IsMatrix(env));
-            Assert.AreEqual(0, result.GetTensorRank(env));
+            Assert.That(result.GetTensorRank(env), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(env));
             Assert.IsFalse(result.IsInterval(env));
             Assert.IsFalse(result.IsFunction(env));
@@ -76,9 +76,9 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.FunctionCallT
             Assert.IsFalse(mmo.IsScalar(env));
             Assert.IsFalse(mmo.IsVector(env));
             Assert.IsTrue(mmo.IsMatrix(env));
-            Assert.AreEqual(2, mmo.GetTensorRank(env));
-            Assert.AreEqual(3, mmo.GetDimension(env, 0));
-            Assert.AreEqual(4, mmo.GetDimension(env, 1));
+            Assert.That(mmo.GetTensorRank(env), Is.EqualTo(2));
+            Assert.That(mmo.GetDimension(env, 0), Is.EqualTo(3));
+            Assert.That(mmo.GetDimension(env, 1), Is.EqualTo(4));
             Assert.IsFalse(mmo.IsString(env));
             Assert.IsFalse(mmo.IsInterval(env));
             Assert.IsFalse(mmo.IsFunction(env));
@@ -89,9 +89,9 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.FunctionCallT
             Assert.IsFalse(result.IsScalar(env));
             Assert.IsFalse(result.IsVector(env));
             Assert.IsTrue(result.IsMatrix(env));
-            Assert.AreEqual(2, result.GetTensorRank(env));
-            Assert.AreEqual(3, result.GetDimension(env, 0));
-            Assert.AreEqual(4, result.GetDimension(env, 1));
+            Assert.That(result.GetTensorRank(env), Is.EqualTo(2));
+            Assert.That(result.GetDimension(env, 0), Is.EqualTo(3));
+            Assert.That(result.GetDimension(env, 1), Is.EqualTo(4));
             Assert.IsFalse(result.IsString(env));
             Assert.IsFalse(result.IsInterval(env));
             Assert.IsFalse(result.IsFunction(env));

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/IntervalExpressionT/CloneTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/IntervalExpressionT/CloneTest.cs
@@ -40,15 +40,15 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.IntervalExpressionT
             // then
             Assert.IsInstanceOf<IntervalExpression>(result0);
             var result = (IntervalExpression)result0;
-            Assert.AreNotSame(i, result);
+            Assert.That(result, Is.Not.SameAs(i));
 
             // shallow, for now
-            Assert.AreSame(i.LowerBound, result.LowerBound);
-            Assert.AreEqual(i.OpenLowerBound, result.OpenLowerBound);
+            Assert.That(result.LowerBound, Is.SameAs(i.LowerBound));
+            Assert.That(result.OpenLowerBound, Is.EqualTo(i.OpenLowerBound));
 
             // shallow, for now
-            Assert.AreSame(i.UpperBound, result.UpperBound);
-            Assert.AreEqual(i.OpenUpperBound, result.OpenUpperBound);
+            Assert.That(result.UpperBound, Is.SameAs(i.UpperBound));
+            Assert.That(result.OpenUpperBound, Is.EqualTo(i.OpenUpperBound));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/LiteralT/ResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/LiteralT/ResultTest.cs
@@ -40,7 +40,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.LiteralT
             Assert.IsTrue(value.IsScalar(env));
             Assert.IsFalse(value.IsVector(env));
             Assert.IsFalse(value.IsMatrix(env));
-            Assert.AreEqual(0, value.GetTensorRank(env));
+            Assert.That(value.GetTensorRank(env), Is.EqualTo(0));
             Assert.IsFalse(value.IsString(env));
             // when
             var result = expr.GetResultType(env);
@@ -48,7 +48,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.LiteralT
             Assert.IsTrue(result.IsScalar(env));
             Assert.IsFalse(result.IsVector(env));
             Assert.IsFalse(result.IsMatrix(env));
-            Assert.AreEqual(0, result.GetTensorRank(env));
+            Assert.That(result.GetTensorRank(env), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(env));
         }
 
@@ -70,9 +70,9 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.LiteralT
             Assert.IsFalse(value.IsScalar(env));
             Assert.IsFalse(value.IsVector(env));
             Assert.IsTrue(value.IsMatrix(env));
-            Assert.AreEqual(2, value.GetTensorRank(env));
-            Assert.AreEqual(3, value.GetDimension(env, 0));
-            Assert.AreEqual(4, value.GetDimension(env, 1));
+            Assert.That(value.GetTensorRank(env), Is.EqualTo(2));
+            Assert.That(value.GetDimension(env, 0), Is.EqualTo(3));
+            Assert.That(value.GetDimension(env, 1), Is.EqualTo(4));
             Assert.IsFalse(value.IsString(env));
             // when
             var result = expr.GetResultType(env);
@@ -80,9 +80,9 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.LiteralT
             Assert.IsFalse(result.IsScalar(env));
             Assert.IsFalse(result.IsVector(env));
             Assert.IsTrue(result.IsMatrix(env));
-            Assert.AreEqual(2, result.GetTensorRank(env));
-            Assert.AreEqual(3, result.GetDimension(env, 0));
-            Assert.AreEqual(4, result.GetDimension(env, 1));
+            Assert.That(result.GetTensorRank(env), Is.EqualTo(2));
+            Assert.That(result.GetDimension(env, 0), Is.EqualTo(3));
+            Assert.That(result.GetDimension(env, 1), Is.EqualTo(4));
             Assert.IsFalse(result.IsString(env));
         }
 
@@ -97,7 +97,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.LiteralT
             Assert.IsFalse(value.IsScalar(env));
             Assert.IsFalse(value.IsVector(env));
             Assert.IsFalse(value.IsMatrix(env));
-            Assert.AreEqual(0, value.GetTensorRank(env));
+            Assert.That(value.GetTensorRank(env), Is.EqualTo(0));
             Assert.IsTrue(value.IsString(env));
             // when
             var result = expr.GetResultType(env);
@@ -105,7 +105,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.LiteralT
             Assert.IsFalse(result.IsScalar(env));
             Assert.IsFalse(result.IsVector(env));
             Assert.IsFalse(result.IsMatrix(env));
-            Assert.AreEqual(0, result.GetTensorRank(env));
+            Assert.That(result.GetTensorRank(env), Is.EqualTo(0));
             Assert.IsTrue(result.IsString(env));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/MatrixExpressionT/ResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/MatrixExpressionT/ResultTest.cs
@@ -46,12 +46,13 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.MatrixExpressionT
             Assert.IsFalse(result.IsScalar(env));
             Assert.IsFalse(result.IsVector(env));
             Assert.IsTrue(result.IsMatrix(env));
-            Assert.AreEqual(2, result.GetTensorRank(env));
+            Assert.That(result.GetTensorRank(env), Is.EqualTo(2));
             Assert.IsFalse(result.IsString(env));
-            Assert.AreEqual(2, result.GetDimension(env, 0));
-            Assert.AreEqual(3, result.GetDimension(env, 1));
-            Assert.AreEqual(new int[] { 2, 3 },
-                result.GetDimensions(env));
+            Assert.That(result.GetDimension(env, 0), Is.EqualTo(2));
+            Assert.That(result.GetDimension(env, 1), Is.EqualTo(3));
+            Assert.That(
+                result.GetDimensions(env),
+                Is.EqualTo(new[] { 2, 3 }));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/RandomExpressionT/ResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/RandomExpressionT/ResultTest.cs
@@ -40,7 +40,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.RandomExpressionT
             Assert.IsTrue(result.IsScalar(env));
             Assert.IsFalse(result.IsVector(env));
             Assert.IsFalse(result.IsMatrix(env));
-            Assert.AreEqual(0, result.GetTensorRank(env));
+            Assert.That(result.GetTensorRank(env), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(env));
             Assert.IsNull(result.GetDimension(env, 0));
             Assert.IsNull(result.GetDimensions(env));

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/VariableAccessT/ResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/VariableAccessT/ResultTest.cs
@@ -41,7 +41,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.VariableAccessT
             Assert.IsTrue(mmo.IsScalar(env));
             Assert.IsFalse(mmo.IsVector(env));
             Assert.IsFalse(mmo.IsMatrix(env));
-            Assert.AreEqual(0, mmo.GetTensorRank(env));
+            Assert.That(mmo.GetTensorRank(env), Is.EqualTo(0));
             Assert.IsFalse(mmo.IsString(env));
             // when
             var result = expr.GetResultType(env);
@@ -49,7 +49,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.VariableAccessT
             Assert.IsTrue(result.IsScalar(env));
             Assert.IsFalse(result.IsVector(env));
             Assert.IsFalse(result.IsMatrix(env));
-            Assert.AreEqual(0, result.GetTensorRank(env));
+            Assert.That(result.GetTensorRank(env), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(env));
         }
 
@@ -67,9 +67,9 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.VariableAccessT
             Assert.IsFalse(mmo.IsScalar(env));
             Assert.IsFalse(mmo.IsVector(env));
             Assert.IsTrue(mmo.IsMatrix(env));
-            Assert.AreEqual(2, mmo.GetTensorRank(env));
-            Assert.AreEqual(3, mmo.GetDimension(env, 0));
-            Assert.AreEqual(4, mmo.GetDimension(env, 1));
+            Assert.That(mmo.GetTensorRank(env), Is.EqualTo(2));
+            Assert.That(mmo.GetDimension(env, 0), Is.EqualTo(3));
+            Assert.That(mmo.GetDimension(env, 1), Is.EqualTo(4));
             Assert.IsFalse(mmo.IsString(env));
             // when
             var result = expr.GetResultType(env);
@@ -77,9 +77,9 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.VariableAccessT
             Assert.IsFalse(result.IsScalar(env));
             Assert.IsFalse(result.IsVector(env));
             Assert.IsTrue(result.IsMatrix(env));
-            Assert.AreEqual(2, result.GetTensorRank(env));
-            Assert.AreEqual(3, result.GetDimension(env, 0));
-            Assert.AreEqual(4, result.GetDimension(env, 1));
+            Assert.That(result.GetTensorRank(env), Is.EqualTo(2));
+            Assert.That(result.GetDimension(env, 0), Is.EqualTo(3));
+            Assert.That(result.GetDimension(env, 1), Is.EqualTo(4));
             Assert.IsFalse(result.IsString(env));
         }
 
@@ -97,7 +97,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.VariableAccessT
             Assert.IsFalse(mmo.IsScalar(env));
             Assert.IsFalse(mmo.IsVector(env));
             Assert.IsFalse(mmo.IsMatrix(env));
-            Assert.AreEqual(0, mmo.GetTensorRank(env));
+            Assert.That(mmo.GetTensorRank(env), Is.EqualTo(0));
             Assert.IsTrue(mmo.IsString(env));
             // when
             var result = expr.GetResultType(env);
@@ -105,7 +105,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.VariableAccessT
             Assert.IsFalse(result.IsScalar(env));
             Assert.IsFalse(result.IsVector(env));
             Assert.IsFalse(result.IsMatrix(env));
-            Assert.AreEqual(0, result.GetTensorRank(env));
+            Assert.That(result.GetTensorRank(env), Is.EqualTo(0));
             Assert.IsTrue(result.IsString(env));
         }
 

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/VectorExpressionT/ResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/VectorExpressionT/ResultTest.cs
@@ -44,14 +44,14 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.VectorExpressionT
             Assert.IsFalse(result.IsScalar(env));
             Assert.IsTrue(result.IsVector(env));
             Assert.IsFalse(result.IsMatrix(env));
-            Assert.AreEqual(1, result.GetTensorRank(env));
+            Assert.That(result.GetTensorRank(env), Is.EqualTo(1));
             Assert.IsFalse(result.IsString(env));
             Assert.IsNull(result.GetDimension(env, -1));
-            Assert.AreEqual(4, result.GetDimension(env, 0));
+            Assert.That(result.GetDimension(env, 0), Is.EqualTo(4));
             Assert.IsNull(result.GetDimension(env, 1));
-            Assert.AreEqual(new int[] { 4 },
-                result.GetDimensions(env));
-            Assert.AreEqual(4, result.GetVectorLength(env));
+            Assert.That(result.GetDimensions(env),
+                Is.EqualTo(new int[] { 4 }));
+            Assert.That(result.GetVectorLength(env), Is.EqualTo(4));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/AbsoluteValueFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/AbsoluteValueFunctionT/GetResultTest.cs
@@ -39,7 +39,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.AbsoluteValueFunctionT
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = AbsoluteValueFunction.Value;
@@ -48,7 +48,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.AbsoluteValueFunctionT
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/AdditionOperationT/AdditionOperationTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/AdditionOperationT/AdditionOperationTest.cs
@@ -41,22 +41,22 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.AdditionOperationT
         public void NameIsSet()
         {
             // expect
-            Assert.AreEqual("+", AdditionOperation.Value.Name);
+            Assert.That(AdditionOperation.Value.Name, Is.EqualTo("+"));
         }
 
         [Test]
         public void PrecedenceIsSet()
         {
             // expect
-            Assert.AreEqual(OperationPrecedence.Addition,
-                AdditionOperation.Value.Precedence);
+            Assert.That(AdditionOperation.Value.Precedence,
+                Is.EqualTo(OperationPrecedence.Addition));
         }
 
         [Test]
         public void IdentityValueIsSet()
         {
             // expect
-            Assert.AreEqual(0, AdditionOperation.Value.IdentityValue);
+            Assert.That(AdditionOperation.Value.IdentityValue, Is.EqualTo(0));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/AdditionOperationT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/AdditionOperationT/GetResultTest.cs
@@ -40,7 +40,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.AdditionOperationT
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = AdditionOperation.Value;
@@ -49,7 +49,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.AdditionOperationT
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
 
@@ -64,7 +64,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.AdditionOperationT
             Assert.IsFalse(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsTrue(arg1.IsString(null));
             // when
             var value = AdditionOperation.Value;
@@ -73,7 +73,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.AdditionOperationT
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/ArccosecantFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/ArccosecantFunctionT/GetResultTest.cs
@@ -39,7 +39,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.ArccosecantFunctionT
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = ArccosecantFunction.Value;
@@ -48,7 +48,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.ArccosecantFunctionT
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/ArccosineFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/ArccosineFunctionT/GetResultTest.cs
@@ -39,7 +39,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.ArccosineFunctionT
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = ArccosineFunction.Value;
@@ -48,7 +48,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.ArccosineFunctionT
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/ArccotangentFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/ArccotangentFunctionT/GetResultTest.cs
@@ -39,7 +39,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.ArccotangentFunctionT
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = ArccotangentFunction.Value;
@@ -48,7 +48,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.ArccotangentFunctionT
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/ArcsecantFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/ArcsecantFunctionT/GetResultTest.cs
@@ -39,7 +39,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.ArcsecantFunctionT
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = ArcsecantFunction.Value;
@@ -48,7 +48,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.ArcsecantFunctionT
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/ArcsineFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/ArcsineFunctionT/GetResultTest.cs
@@ -39,7 +39,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.ArcsineFunctionT
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = ArcsineFunction.Value;
@@ -48,7 +48,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.ArcsineFunctionT
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/Arctangent2FunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/Arctangent2FunctionT/GetResultTest.cs
@@ -39,7 +39,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.Arctangent2FunctionT
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = Arctangent2Function.Value;
@@ -48,7 +48,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.Arctangent2FunctionT
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/ArctangentFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/ArctangentFunctionT/GetResultTest.cs
@@ -39,7 +39,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.ArctangentFunctionT
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = ArctangentFunction.Value;
@@ -48,7 +48,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.ArctangentFunctionT
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/AssociativeCommutativeOperationT/CheckArgumentsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/AssociativeCommutativeOperationT/CheckArgumentsTest.cs
@@ -39,10 +39,10 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.
             // expect
             var ex = Assert.Throws<ArgumentException>(
                 () => AdditionOperation.Value.CheckArguments(args));
-            Assert.AreEqual(
-                "Wrong number of arguments given to + " +
-                "(given 1, require at least 2)",
-                ex.Message);
+            Assert.That(ex.Message,
+                Is.EqualTo(
+                    "Wrong number of arguments given to + " +
+                    "(given 1, require at least 2)"));
         }
 
         [Test]
@@ -87,9 +87,10 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.
             // expect
             var ex = Assert.Throws<ArgumentException>(
                 () => AdditionOperation.Value.CheckArguments(args));
-            Assert.AreEqual(
-                "Argument 0 wrong type: expected Scalar but got Vector",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo(
+                    "Argument 0 wrong type: expected Scalar but got Vector"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/BitwiseAndOperationT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/BitwiseAndOperationT/GetResultTest.cs
@@ -39,7 +39,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.BitwiseAndOperationT
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = BitwiseAndOperation.Value;
@@ -48,7 +48,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.BitwiseAndOperationT
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/BitwiseOrOperationT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/BitwiseOrOperationT/GetResultTest.cs
@@ -39,7 +39,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.BitwiseOrOperationT
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = BitwiseOrOperation.Value;
@@ -48,7 +48,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.BitwiseOrOperationT
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/CatmullRomSplineT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/CatmullRomSplineT/GetResultTest.cs
@@ -41,7 +41,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.CatmullRomSplineT
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var result = f.GetResultType(null, args);
@@ -49,7 +49,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.CatmullRomSplineT
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/CeilingFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/CeilingFunctionT/GetResultTest.cs
@@ -39,7 +39,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.CeilingFunctionT
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = CeilingFunction.Value;
@@ -48,7 +48,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.CeilingFunctionT
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/CosecantFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/CosecantFunctionT/GetResultTest.cs
@@ -39,7 +39,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.CosecantFunctionT
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = CosecantFunction.Value;
@@ -48,7 +48,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.CosecantFunctionT
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/CosineFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/CosineFunctionT/GetResultTest.cs
@@ -39,7 +39,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.CosineFunctionT
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = CosineFunction.Value;
@@ -48,7 +48,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.CosineFunctionT
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/CotangentFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/CotangentFunctionT/GetResultTest.cs
@@ -39,7 +39,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.CotangentFunctionT
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = CotangentFunction.Value;
@@ -48,7 +48,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.CotangentFunctionT
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/DistFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/DistFunctionT/GetResultTest.cs
@@ -39,7 +39,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.DistFunctionT
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = DistFunction.Value;
@@ -48,7 +48,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.DistFunctionT
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/DistSqFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/DistSqFunctionT/GetResultTest.cs
@@ -39,7 +39,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.DistSqFunctionT
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = DistSqFunction.Value;
@@ -48,7 +48,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.DistSqFunctionT
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/DivisionOperationT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/DivisionOperationT/GetResultTest.cs
@@ -39,7 +39,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.DivisionOperationT
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = DivisionOperation.Value;
@@ -48,7 +48,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.DivisionOperationT
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/EqualComparisonOperationT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/EqualComparisonOperationT/GetResultTest.cs
@@ -40,7 +40,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = EqualComparisonOperation.Value;
@@ -49,7 +49,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/ExponentOperationT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/ExponentOperationT/GetResultTest.cs
@@ -39,7 +39,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.ExponentOperationT
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = ExponentOperation.Value;
@@ -48,7 +48,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.ExponentOperationT
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/FactorialFunctionT/FactorialFunctionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/FactorialFunctionT/FactorialFunctionTest.cs
@@ -41,7 +41,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.FactorialFunctionT
         public void NameIsSet()
         {
             // expect
-            Assert.AreEqual("Factorial", FactorialFunction.Value.Name);
+            Assert.That(FactorialFunction.Value.Name, Is.EqualTo("Factorial"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/FactorialFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/FactorialFunctionT/GetResultTest.cs
@@ -39,7 +39,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.FactorialFunctionT
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = FactorialFunction.Value;
@@ -48,7 +48,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.FactorialFunctionT
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/FloorFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/FloorFunctionT/GetResultTest.cs
@@ -39,7 +39,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.FloorFunctionT
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = FloorFunction.Value;
@@ -48,7 +48,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.FloorFunctionT
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/FunctionT/CheckArgumentsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/FunctionT/CheckArgumentsTest.cs
@@ -50,10 +50,10 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.FunctionT
             // expect
             var ex = Assert.Throws<ArgumentException>(() =>
                 Function.CheckArguments(args, paramTypes, "displayName"));
-            Assert.AreEqual(
-                "Wrong number of arguments given to displayName " +
-                "(expected 0 but got 1)",
-                ex.Message);
+            Assert.That(ex.Message,
+                Is.EqualTo(
+                    "Wrong number of arguments given to displayName " +
+                    "(expected 0 but got 1)"));
         }
 
         [Test]
@@ -65,10 +65,10 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.FunctionT
             // expect
             var ex = Assert.Throws<ArgumentException>(() =>
                 Function.CheckArguments(args, paramTypes, "displayName"));
-            Assert.AreEqual(
-                "Wrong number of arguments given to displayName " +
-                "(expected 1 but got 0)",
-                ex.Message);
+            Assert.That(ex.Message,
+                Is.EqualTo(
+                    "Wrong number of arguments given to displayName " +
+                    "(expected 1 but got 0)"));
         }
 
         [Test]
@@ -80,9 +80,9 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.FunctionT
             // expect
             var ex = Assert.Throws<ArgumentException>(() =>
                 Function.CheckArguments(args, paramTypes, "displayName"));
-            Assert.AreEqual(
-                $"Argument 0 wrong type: expected Scalar but got Vector",
-                ex.Message);
+            Assert.That(ex.Message,
+                Is.EqualTo(
+                    "Argument 0 wrong type: expected Scalar but got Vector"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/FunctionT/FunctionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/FunctionT/FunctionTest.cs
@@ -38,11 +38,11 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.FunctionT
             // when
             var f = new MockFunction(paramTypes, "func1");
             // then
-            Assert.AreEqual("func1", f.Name);
-            Assert.AreEqual("func1", f.DisplayName);
+            Assert.That(f.Name, Is.EqualTo("func1"));
+            Assert.That(f.DisplayName, Is.EqualTo("func1"));
             Assert.IsNotNull(f.ParamTypes);
-            Assert.AreEqual(1, f.ParamTypes.Count);
-            Assert.AreEqual(Types.Scalar, f.ParamTypes[0]);
+            Assert.That(f.ParamTypes.Count, Is.EqualTo(1));
+            Assert.That(f.ParamTypes[0], Is.EqualTo(Types.Scalar));
         }
 
         [Test]
@@ -52,7 +52,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.FunctionT
             var ex = Assert.Throws<ValueException>(
                 () => new MockFunction(null, "func2"));
             // and
-            Assert.AreEqual("paramTypes", ex.ParamName);
+            Assert.That(ex.ParamName, Is.EqualTo("paramTypes"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/GreaterThanComparisonOperationT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/GreaterThanComparisonOperationT/GetResultTest.cs
@@ -40,7 +40,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = GreaterThanComparisonOperation.Value;
@@ -49,7 +49,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/GreaterThanOrEqualComparisonOperationT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/GreaterThanOrEqualComparisonOperationT/GetResultTest.cs
@@ -40,7 +40,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var result =
@@ -50,7 +50,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/LessThanComparisonOperationT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/LessThanComparisonOperationT/GetResultTest.cs
@@ -40,7 +40,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = LessThanComparisonOperation.Value;
@@ -49,7 +49,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/LessThanOrEqualComparisonOperationT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/LessThanOrEqualComparisonOperationT/GetResultTest.cs
@@ -40,7 +40,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var result =
@@ -50,7 +50,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/LoadImageFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/LoadImageFunctionT/GetResultTest.cs
@@ -40,7 +40,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.LoadImageFunctionT
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = LoadImageFunction.Value;
@@ -49,7 +49,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.LoadImageFunctionT
             Assert.IsFalse(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsTrue(result.IsMatrix(null));
-            Assert.AreEqual(2, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(2));
             Assert.IsFalse(result.IsString(null));
             Assert.IsNull(result.GetDimension(null, -1));
             Assert.IsNull(result.GetDimension(null, 0));

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/LoadImageFunctionT/LoadImageTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/LoadImageFunctionT/LoadImageTest.cs
@@ -39,24 +39,24 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.LoadImageFunctionT
             // when
             var result = LoadImageFunction.LoadImage("filename", reader);
             // then
-            Assert.AreEqual(4, result.RowCount);
-            Assert.AreEqual(4, result.ColumnCount);
-            Assert.AreEqual(0x0000ff, result[0, 0].ToNumber().Value);
-            Assert.AreEqual(0x00007f, result[0, 1].ToNumber().Value);
-            Assert.AreEqual(0x000000, result[0, 2].ToNumber().Value);
-            Assert.AreEqual(0x7f7f7f, result[0, 3].ToNumber().Value);
-            Assert.AreEqual(0x00ff00, result[1, 0].ToNumber().Value);
-            Assert.AreEqual(0x007f00, result[1, 1].ToNumber().Value);
-            Assert.AreEqual(0xffff00, result[1, 2].ToNumber().Value);
-            Assert.AreEqual(0x7f7f00, result[1, 3].ToNumber().Value);
-            Assert.AreEqual(0xff0000, result[2, 0].ToNumber().Value);
-            Assert.AreEqual(0x7f0000, result[2, 1].ToNumber().Value);
-            Assert.AreEqual(0xff00ff, result[2, 2].ToNumber().Value);
-            Assert.AreEqual(0x7f007f, result[2, 3].ToNumber().Value);
-            Assert.AreEqual(0xffffff, result[3, 0].ToNumber().Value);
-            Assert.AreEqual(0x7f7f7f, result[3, 1].ToNumber().Value);
-            Assert.AreEqual(0x00ffff, result[3, 2].ToNumber().Value);
-            Assert.AreEqual(0x007f7f, result[3, 3].ToNumber().Value);
+            Assert.That(result.RowCount, Is.EqualTo(4));
+            Assert.That(result.ColumnCount, Is.EqualTo(4));
+            Assert.That(result[0, 0].ToNumber().Value, Is.EqualTo(0x0000ff));
+            Assert.That(result[0, 1].ToNumber().Value, Is.EqualTo(0x00007f));
+            Assert.That(result[0, 2].ToNumber().Value, Is.EqualTo(0x000000));
+            Assert.That(result[0, 3].ToNumber().Value, Is.EqualTo(0x7f7f7f));
+            Assert.That(result[1, 0].ToNumber().Value, Is.EqualTo(0x00ff00));
+            Assert.That(result[1, 1].ToNumber().Value, Is.EqualTo(0x007f00));
+            Assert.That(result[1, 2].ToNumber().Value, Is.EqualTo(0xffff00));
+            Assert.That(result[1, 3].ToNumber().Value, Is.EqualTo(0x7f7f00));
+            Assert.That(result[2, 0].ToNumber().Value, Is.EqualTo(0xff0000));
+            Assert.That(result[2, 1].ToNumber().Value, Is.EqualTo(0x7f0000));
+            Assert.That(result[2, 2].ToNumber().Value, Is.EqualTo(0xff00ff));
+            Assert.That(result[2, 3].ToNumber().Value, Is.EqualTo(0x7f007f));
+            Assert.That(result[3, 0].ToNumber().Value, Is.EqualTo(0xffffff));
+            Assert.That(result[3, 1].ToNumber().Value, Is.EqualTo(0x7f7f7f));
+            Assert.That(result[3, 2].ToNumber().Value, Is.EqualTo(0x00ffff));
+            Assert.That(result[3, 3].ToNumber().Value, Is.EqualTo(0x007f7f));
         }
 
         [Test]
@@ -72,24 +72,24 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.LoadImageFunctionT
             // then
             Assert.IsTrue(result0.IsIsMatrix(null));
             var result = result0.ToMatrix();
-            Assert.AreEqual(4, result.RowCount);
-            Assert.AreEqual(4, result.ColumnCount);
-            Assert.AreEqual(0x0000ff, result[0, 0].ToNumber().Value);
-            Assert.AreEqual(0x00007f, result[0, 1].ToNumber().Value);
-            Assert.AreEqual(0x000000, result[0, 2].ToNumber().Value);
-            Assert.AreEqual(0x7f7f7f, result[0, 3].ToNumber().Value);
-            Assert.AreEqual(0x00ff00, result[1, 0].ToNumber().Value);
-            Assert.AreEqual(0x007f00, result[1, 1].ToNumber().Value);
-            Assert.AreEqual(0xffff00, result[1, 2].ToNumber().Value);
-            Assert.AreEqual(0x7f7f00, result[1, 3].ToNumber().Value);
-            Assert.AreEqual(0xff0000, result[2, 0].ToNumber().Value);
-            Assert.AreEqual(0x7f0000, result[2, 1].ToNumber().Value);
-            Assert.AreEqual(0xff00ff, result[2, 2].ToNumber().Value);
-            Assert.AreEqual(0x7f007f, result[2, 3].ToNumber().Value);
-            Assert.AreEqual(0xffffff, result[3, 0].ToNumber().Value);
-            Assert.AreEqual(0x7f7f7f, result[3, 1].ToNumber().Value);
-            Assert.AreEqual(0x00ffff, result[3, 2].ToNumber().Value);
-            Assert.AreEqual(0x007f7f, result[3, 3].ToNumber().Value);
+            Assert.That(result.RowCount, Is.EqualTo(4));
+            Assert.That(result.ColumnCount, Is.EqualTo(4));
+            Assert.That(result[0, 0].ToNumber().Value, Is.EqualTo(0x0000ff));
+            Assert.That(result[0, 1].ToNumber().Value, Is.EqualTo(0x00007f));
+            Assert.That(result[0, 2].ToNumber().Value, Is.EqualTo(0x000000));
+            Assert.That(result[0, 3].ToNumber().Value, Is.EqualTo(0x7f7f7f));
+            Assert.That(result[1, 0].ToNumber().Value, Is.EqualTo(0x00ff00));
+            Assert.That(result[1, 1].ToNumber().Value, Is.EqualTo(0x007f00));
+            Assert.That(result[1, 2].ToNumber().Value, Is.EqualTo(0xffff00));
+            Assert.That(result[1, 3].ToNumber().Value, Is.EqualTo(0x7f7f00));
+            Assert.That(result[2, 0].ToNumber().Value, Is.EqualTo(0xff0000));
+            Assert.That(result[2, 1].ToNumber().Value, Is.EqualTo(0x7f0000));
+            Assert.That(result[2, 2].ToNumber().Value, Is.EqualTo(0xff00ff));
+            Assert.That(result[2, 3].ToNumber().Value, Is.EqualTo(0x7f007f));
+            Assert.That(result[3, 0].ToNumber().Value, Is.EqualTo(0xffffff));
+            Assert.That(result[3, 1].ToNumber().Value, Is.EqualTo(0x7f7f7f));
+            Assert.That(result[3, 2].ToNumber().Value, Is.EqualTo(0x00ffff));
+            Assert.That(result[3, 3].ToNumber().Value, Is.EqualTo(0x007f7f));
         }
 
         public byte[] TinyTestPatternPng =

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/Log10FunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/Log10FunctionT/GetResultTest.cs
@@ -38,7 +38,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.Log10FunctionT
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = Log10Function.Value;
@@ -47,7 +47,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.Log10FunctionT
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/Log2FunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/Log2FunctionT/GetResultTest.cs
@@ -39,7 +39,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.Log2FunctionT
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = Log2Function.Value;
@@ -48,7 +48,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.Log2FunctionT
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/LogarithmFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/LogarithmFunctionT/GetResultTest.cs
@@ -40,7 +40,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.LogarithmFunctionT
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = LogarithmFunction.Value;
@@ -49,7 +49,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.LogarithmFunctionT
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/LogicalAndOperationT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/LogicalAndOperationT/GetResultTest.cs
@@ -39,7 +39,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.LogicalAndOperationT
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = LogicalAndOperation.Value;
@@ -48,7 +48,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.LogicalAndOperationT
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/LogicalOrOperationT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/LogicalOrOperationT/GetResultTest.cs
@@ -39,7 +39,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.LogicalOrOperationT
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = LogicalOrOperation.Value;
@@ -48,7 +48,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.LogicalOrOperationT
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/MaximumFiniteFunctionT/MaximumFiniteFunctionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/MaximumFiniteFunctionT/MaximumFiniteFunctionTest.cs
@@ -41,7 +41,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.MaximumFiniteFunctionT
         public void NameIsSet()
         {
             // expect
-            Assert.AreEqual("maxf", MaximumFiniteFunction.Value.Name);
+            Assert.That(MaximumFiniteFunction.Value.Name, Is.EqualTo("maxf"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/MaximumFunctionT/MaximumFunctionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/MaximumFunctionT/MaximumFunctionTest.cs
@@ -41,7 +41,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.MaximumFunctionT
         public void NameIsSet()
         {
             // expect
-            Assert.AreEqual("max", MaximumFunction.Value.Name);
+            Assert.That(MaximumFunction.Value.Name, Is.EqualTo("max"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/MinimumFiniteFunctionT/MinimumFiniteFunctionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/MinimumFiniteFunctionT/MinimumFiniteFunctionTest.cs
@@ -41,7 +41,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.MinimumFiniteFunctionT
         public void NameIsSet()
         {
             // expect
-            Assert.AreEqual("minf", MinimumFiniteFunction.Value.Name);
+            Assert.That(MinimumFiniteFunction.Value.Name, Is.EqualTo("minf"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/MinimumFunctionT/MinimumFunctionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/MinimumFunctionT/MinimumFunctionTest.cs
@@ -41,7 +41,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.MinimumFunctionT
         public void NameIsSet()
         {
             // expect
-            Assert.AreEqual("min", MinimumFunction.Value.Name);
+            Assert.That(MinimumFunction.Value.Name, Is.EqualTo("min"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/ModularDivisionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/ModularDivisionT/GetResultTest.cs
@@ -39,7 +39,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.ModularDivisionT
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = ModularDivision.Value;
@@ -48,7 +48,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.ModularDivisionT
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/MultiplicationOperationT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/MultiplicationOperationT/GetResultTest.cs
@@ -39,7 +39,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.MultiplicationOperationT
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = MultiplicationOperation.Value;
@@ -48,7 +48,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.MultiplicationOperationT
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
 
@@ -62,7 +62,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.MultiplicationOperationT
             Assert.IsFalse(arg1.IsScalar(null));
             Assert.IsTrue(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(1, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(1));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = MultiplicationOperation.Value;
@@ -71,7 +71,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.MultiplicationOperationT
             Assert.IsFalse(result.IsScalar(null));
             Assert.IsTrue(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(1, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(1));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/NaturalLogarithmFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/NaturalLogarithmFunctionT/GetResultTest.cs
@@ -39,7 +39,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.NaturalLogarithmFunctionT
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = NaturalLogarithmFunction.Value;
@@ -48,7 +48,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.NaturalLogarithmFunctionT
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/NegationOperationT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/NegationOperationT/GetResultTest.cs
@@ -39,7 +39,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.NegationOperationT
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = NegationOperation.Value;
@@ -48,7 +48,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.NegationOperationT
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
 
@@ -62,7 +62,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.NegationOperationT
             Assert.IsFalse(arg1.IsScalar(null));
             Assert.IsTrue(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(1, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(1));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = NegationOperation.Value;
@@ -71,7 +71,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.NegationOperationT
             Assert.IsFalse(result.IsScalar(null));
             Assert.IsTrue(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(1, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(1));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/NotEqualComparisonOperationT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/NotEqualComparisonOperationT/GetResultTest.cs
@@ -40,7 +40,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = NotEqualComparisonOperation.Value;
@@ -49,7 +49,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/SecantFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/SecantFunctionT/GetResultTest.cs
@@ -39,7 +39,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.SecantFunctionT
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = SecantFunction.Value;
@@ -48,7 +48,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.SecantFunctionT
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/SineFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/SineFunctionT/GetResultTest.cs
@@ -39,7 +39,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.SineFunctionT
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = SineFunction.Value;
@@ -48,7 +48,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.SineFunctionT
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/SizeFunctionT/CheckArgumentsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/SizeFunctionT/CheckArgumentsTest.cs
@@ -39,9 +39,10 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.SizeFunctionT
             var ex = Assert.Throws<ArgumentException>(
                 () => SizeFunction.Value.CheckArguments(args));
             // and
-            Assert.AreEqual("Wrong number of arguments given to " +
-                            "size (expected 1 but got 0)",
-                ex.Message);
+            Assert.That(ex.Message,
+                Is.EqualTo(
+                    "Wrong number of arguments given to " +
+                    "size (expected 1 but got 0)"));
         }
 
         [Test]
@@ -57,9 +58,11 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.SizeFunctionT
             var ex = Assert.Throws<ArgumentException>(
                 () => SizeFunction.Value.CheckArguments(args));
             // and
-            Assert.AreEqual("Wrong number of arguments given to " +
-                            "size (expected 1 but got 2)",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo(
+                    "Wrong number of arguments given to " +
+                    "size (expected 1 but got 2)"));
         }
 
         [Test]
@@ -71,9 +74,11 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.SizeFunctionT
             var ex = Assert.Throws<ArgumentException>(
                 () => SizeFunction.Value.CheckArguments(args));
             // and
-            Assert.AreEqual("Argument wrong type: expected " +
-                            "Vector or Matrix or String but got Scalar",
-                ex.Message);
+            Assert.That(
+                ex.Message,
+                Is.EqualTo(
+                    "Argument wrong type: expected " +
+                    "Vector or Matrix or String but got Scalar"));
         }
 
         [Test]

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/SizeFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/SizeFunctionT/GetResultTest.cs
@@ -39,7 +39,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.SizeFunctionT
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = SizeFunction.Value;
@@ -48,10 +48,10 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.SizeFunctionT
             Assert.IsFalse(result.IsScalar(null));
             Assert.IsTrue(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(1, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(1));
             Assert.IsFalse(result.IsString(null));
             // and
-            Assert.AreEqual(0, result.GetVectorLength(null));
+            Assert.That(result.GetVectorLength(null), Is.EqualTo(0));
         }
 
         [Test]
@@ -64,7 +64,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.SizeFunctionT
             Assert.IsFalse(arg1.IsScalar(null));
             Assert.IsTrue(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(1, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(1));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = SizeFunction.Value;
@@ -73,10 +73,10 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.SizeFunctionT
             Assert.IsFalse(result.IsScalar(null));
             Assert.IsTrue(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(1, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(1));
             Assert.IsFalse(result.IsString(null));
             // and
-            Assert.AreEqual(1, result.GetVectorLength(null));
+            Assert.That(result.GetVectorLength(null), Is.EqualTo(1));
         }
 
         [Test]
@@ -89,7 +89,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.SizeFunctionT
             Assert.IsFalse(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsTrue(arg1.IsMatrix(null));
-            Assert.AreEqual(2, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(2));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = SizeFunction.Value;
@@ -98,10 +98,10 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.SizeFunctionT
             Assert.IsFalse(result.IsScalar(null));
             Assert.IsTrue(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(1, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(1));
             Assert.IsFalse(result.IsString(null));
             // and
-            Assert.AreEqual(2, result.GetVectorLength(null));
+            Assert.That(result.GetVectorLength(null), Is.EqualTo(2));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/TangentFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/TangentFunctionT/GetResultTest.cs
@@ -39,7 +39,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.TangentFunctionT
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = TangentFunction.Value;
@@ -48,7 +48,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.TangentFunctionT
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/UnitStepFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/UnitStepFunctionT/GetResultTest.cs
@@ -39,7 +39,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.UnitStepFunctionT
             Assert.IsTrue(arg1.IsScalar(null));
             Assert.IsFalse(arg1.IsVector(null));
             Assert.IsFalse(arg1.IsMatrix(null));
-            Assert.AreEqual(0, arg1.GetTensorRank(null));
+            Assert.That(arg1.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(arg1.IsString(null));
             // when
             var value = UnitStepFunction.Value;
@@ -48,7 +48,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.UnitStepFunctionT
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/UserDefinedFunctionT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/UserDefinedFunctionT/GetResultTest.cs
@@ -40,7 +40,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.UserDefinedFunctionT
             Assert.IsTrue(expr.GetResultType(null).IsScalar(null));
             Assert.IsFalse(expr.GetResultType(null).IsVector(null));
             Assert.IsFalse(expr.GetResultType(null).IsMatrix(null));
-            Assert.AreEqual(0, expr.GetResultType(null).GetTensorRank(null));
+            Assert.That(expr.GetResultType(null).GetTensorRank(null),
+                Is.EqualTo(0));
             Assert.IsFalse(expr.GetResultType(null).IsString(null));
             // when
             var result = f.GetResultType(null, new IMathObject[0]);
@@ -48,7 +49,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.UserDefinedFunctionT
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
         }
 
@@ -62,7 +63,8 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.UserDefinedFunctionT
             Assert.IsFalse(expr.GetResultType(null).IsScalar(null));
             Assert.IsTrue(expr.GetResultType(null).IsVector(null));
             Assert.IsFalse(expr.GetResultType(null).IsMatrix(null));
-            Assert.AreEqual(1, expr.GetResultType(null).GetTensorRank(null));
+            Assert.That(expr.GetResultType(null).GetTensorRank(null),
+                Is.EqualTo(1));
             Assert.IsFalse(expr.GetResultType(null).IsString(null));
             // when
             var result = f.GetResultType(null, new IMathObject[0]);
@@ -70,7 +72,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.UserDefinedFunctionT
             Assert.IsFalse(result.IsScalar(null));
             Assert.IsTrue(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(1, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(1));
             Assert.IsFalse(result.IsString(null));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/MacrosT/DeriveMacroT/DeriveMacroTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/MacrosT/DeriveMacroT/DeriveMacroTest.cs
@@ -34,14 +34,16 @@ namespace MetaphysicsIndustries.Solus.Test.MacrosT.DeriveMacroT
             // expect
             Assert.IsNotNull(DeriveMacro.Value);
             // and
-            Assert.AreEqual("derive", DeriveMacro.Value.Name);
-            Assert.AreEqual(2, DeriveMacro.Value.NumArguments);
-            Assert.AreEqual(
-                @"The derive operator
+            Assert.That(DeriveMacro.Value.Name, Is.EqualTo("derive"));
+            Assert.That(DeriveMacro.Value.NumArguments, Is.EqualTo(2));
+            Assert.That(
+                DeriveMacro.Value.DocString,
+                Is.EqualTo(
+                    @"The derive operator
   derive(f(x), x)
 
-Returns the derivative of f(x) with respect to x.",
-                DeriveMacro.Value.DocString);
+Returns the derivative of f(x) with respect to x."
+                ));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/MacrosT/IfMacroT/IfMacroTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/MacrosT/IfMacroT/IfMacroTest.cs
@@ -33,8 +33,8 @@ namespace MetaphysicsIndustries.Solus.Test.MacrosT.IfMacroT
             // given
             var result = IfMacro.Value;
             // expect
-            Assert.AreEqual("if", result.Name);
-            Assert.AreEqual(3, result.NumArguments);
+            Assert.That(result.Name, Is.EqualTo("if"));
+            Assert.That(result.NumArguments, Is.EqualTo(3));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/MacrosT/SubstMacroT/SubstMacroTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/MacrosT/SubstMacroT/SubstMacroTest.cs
@@ -33,8 +33,8 @@ namespace MetaphysicsIndustries.Solus.Test.MacrosT.SubstMacroT
         {
             // expect
             Assert.IsNotNull(SubstMacro.Value);
-            Assert.AreEqual("subst", SubstMacro.Value.Name);
-            Assert.AreEqual(3, SubstMacro.Value.NumArguments);
+            Assert.That(SubstMacro.Value.Name, Is.EqualTo("subst"));
+            Assert.That(SubstMacro.Value.NumArguments, Is.EqualTo(3));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/MetaphysicsIndustries.Solus.Test.csproj
+++ b/MetaphysicsIndustries.Solus.Test/MetaphysicsIndustries.Solus.Test.csproj
@@ -11,8 +11,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.5.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="coverlet.collector" Version="3.1.2" />
   </ItemGroup>
 

--- a/MetaphysicsIndustries.Solus.Test/SolusParserT/SolusParserTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/SolusParserT/SolusParserTest.cs
@@ -43,13 +43,13 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             // then
             Assert.IsInstanceOf<FunctionCall>(expr);
             var fc = (FunctionCall)expr;
-            Assert.AreEqual(2, fc.Arguments.Count);
+            Assert.That(fc.Arguments.Count, Is.EqualTo(2));
             Assert.IsInstanceOf<Literal>(fc.Arguments[0]);
-            Assert.AreEqual(2,
-                ((Literal)fc.Arguments[0]).Value.ToNumber().Value);
+            Assert.That(((Literal)fc.Arguments[0]).Value.ToNumber().Value,
+                Is.EqualTo(2));
             Assert.IsInstanceOf<Literal>(fc.Arguments[1]);
-            Assert.AreEqual(2,
-                ((Literal)fc.Arguments[1]).Value.ToNumber().Value);
+            Assert.That(((Literal)fc.Arguments[1]).Value.ToNumber().Value,
+                Is.EqualTo(2));
         }
 
         [Test]
@@ -64,21 +64,24 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             var fcall = (FunctionCall)expr;
             Assert.IsInstanceOf<Literal>(fcall.Function);
             var literal = (Literal)fcall.Function;
-            Assert.AreSame(MultiplicationOperation.Value, literal.Value);
-            Assert.AreEqual(2, fcall.Arguments.Count);
+            Assert.That(literal.Value,
+                Is.SameAs(MultiplicationOperation.Value));
+            Assert.That(fcall.Arguments.Count, Is.EqualTo(2));
             Assert.IsInstanceOf(typeof(VariableAccess), fcall.Arguments[0]);
-            Assert.AreEqual("a", (fcall.Arguments[0] as VariableAccess).VariableName);
+            Assert.That((fcall.Arguments[0] as VariableAccess).VariableName,
+                Is.EqualTo("a"));
             Assert.IsInstanceOf(typeof(FunctionCall), fcall.Arguments[1]);
             var fcall2 = (FunctionCall)fcall.Arguments[1];
             Assert.IsInstanceOf<Literal>(fcall2.Function);
             literal = (Literal)fcall2.Function;
-            Assert.AreSame(AdditionOperation.Value, literal.Value);
-            Assert.AreEqual(2, fcall2.Arguments.Count);
+            Assert.That(literal.Value, Is.SameAs(AdditionOperation.Value));
+            Assert.That(fcall2.Arguments.Count, Is.EqualTo(2));
             Assert.IsInstanceOf(typeof(Literal), fcall2.Arguments[0]);
-            Assert.AreEqual(2.0f,
-                ((Literal) fcall2.Arguments[0]).Value.ToFloat());
+            Assert.That(((Literal) fcall2.Arguments[0]).Value.ToFloat(),
+                Is.EqualTo(2.0f));
             Assert.IsInstanceOf(typeof(VariableAccess), fcall2.Arguments[1]);
-            Assert.AreEqual("c", (fcall2.Arguments[1] as VariableAccess).VariableName);
+            Assert.That((fcall2.Arguments[1] as VariableAccess).VariableName,
+                Is.EqualTo("c"));
         }
 
         [Test]
@@ -112,7 +115,7 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
                 }
             }
 
-            Assert.AreEqual(6.0f, sum);
+            Assert.That(sum, Is.EqualTo(6.0f));
             Assert.That(varnames.Contains("a"));
             Assert.That(varnames.Contains("b"));
             Assert.That(varnames.Contains("c"));
@@ -129,36 +132,40 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             var fcall = (FunctionCall)expr;
             Assert.IsInstanceOf<Literal>(fcall.Function);
             var literal = (Literal)fcall.Function;
-            Assert.AreSame(AdditionOperation.Value, literal.Value);
-            Assert.AreEqual(3, fcall.Arguments.Count);
+            Assert.That(literal.Value, Is.SameAs(AdditionOperation.Value));
+            Assert.That(fcall.Arguments.Count, Is.EqualTo(3));
 
             Assert.IsInstanceOf(typeof(Literal), fcall.Arguments[0]);
-            Assert.AreEqual(1.0f,
-                ((Literal) fcall.Arguments[0]).Value.ToFloat());
+            Assert.That(((Literal) fcall.Arguments[0]).Value.ToFloat(),
+                Is.EqualTo(1.0f));
 
             Assert.IsInstanceOf(typeof(VariableAccess), fcall.Arguments[1]);
-            Assert.AreEqual("a", (fcall.Arguments[1] as VariableAccess).VariableName);
+            Assert.That((fcall.Arguments[1] as VariableAccess).VariableName,
+                Is.EqualTo("a"));
 
             Assert.IsInstanceOf(typeof(FunctionCall), fcall.Arguments[2]);
             var fcall2 = (FunctionCall)fcall.Arguments[2];
             Assert.IsInstanceOf<Literal>(fcall2.Function);
             literal = (Literal)fcall2.Function;
-            Assert.AreSame(MultiplicationOperation.Value, literal.Value);
-            Assert.AreEqual(4, fcall2.Arguments.Count);
+            Assert.That(literal.Value,
+                Is.SameAs(MultiplicationOperation.Value));
+            Assert.That(fcall2.Arguments.Count, Is.EqualTo(4));
 
             Assert.IsInstanceOf(typeof(Literal), fcall2.Arguments[0]);
-            Assert.AreEqual(2.0f,
-                ((Literal) fcall2.Arguments[0]).Value.ToFloat());
+            Assert.That(((Literal) fcall2.Arguments[0]).Value.ToFloat(),
+                Is.EqualTo(2.0f));
 
             Assert.IsInstanceOf(typeof(VariableAccess), fcall2.Arguments[1]);
-            Assert.AreEqual("b", (fcall2.Arguments[1] as VariableAccess).VariableName);
+            Assert.That((fcall2.Arguments[1] as VariableAccess).VariableName,
+                Is.EqualTo("b"));
 
             Assert.IsInstanceOf(typeof(Literal), fcall2.Arguments[2]);
-            Assert.AreEqual(3.0f,
-                ((Literal) fcall2.Arguments[2]).Value.ToFloat());
+            Assert.That(((Literal) fcall2.Arguments[2]).Value.ToFloat(),
+                Is.EqualTo(3.0f));
 
             Assert.IsInstanceOf(typeof(VariableAccess), fcall2.Arguments[3]);
-            Assert.AreEqual("c", (fcall2.Arguments[3] as VariableAccess).VariableName);
+            Assert.That((fcall2.Arguments[3] as VariableAccess).VariableName,
+                Is.EqualTo("c"));
         }
 
         [Test]
@@ -172,38 +179,42 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             var fcall = (FunctionCall)expr;
             Assert.IsInstanceOf<Literal>(fcall.Function);
             var literal = (Literal)fcall.Function;
-            Assert.AreSame(AdditionOperation.Value, literal.Value);
-            Assert.AreEqual(3, fcall.Arguments.Count);
+            Assert.That(literal.Value, Is.SameAs(AdditionOperation.Value));
+            Assert.That(fcall.Arguments.Count, Is.EqualTo(3));
 
             Assert.IsInstanceOf(typeof(Literal), fcall.Arguments[0]);
-            Assert.AreEqual(1.0f,
-                ((Literal) fcall.Arguments[0]).Value.ToFloat());
+            Assert.That(((Literal) fcall.Arguments[0]).Value.ToFloat(),
+                Is.EqualTo(1.0f));
 
 
             Assert.IsInstanceOf(typeof(FunctionCall), fcall.Arguments[1]);
             var fcall2 = (FunctionCall)fcall.Arguments[1];
             Assert.IsInstanceOf<Literal>(fcall2.Function);
             literal = (Literal)fcall2.Function;
-            Assert.AreSame(MultiplicationOperation.Value, literal.Value);
-            Assert.AreEqual(4, fcall2.Arguments.Count);
+            Assert.That(literal.Value,
+                Is.SameAs(MultiplicationOperation.Value));
+            Assert.That(fcall2.Arguments.Count, Is.EqualTo(4));
 
             Assert.IsInstanceOf(typeof(VariableAccess), fcall2.Arguments[0]);
-            Assert.AreEqual("a", (fcall2.Arguments[0] as VariableAccess).VariableName);
+            Assert.That((fcall2.Arguments[0] as VariableAccess).VariableName,
+                Is.EqualTo("a"));
 
             Assert.IsInstanceOf(typeof(Literal), fcall2.Arguments[1]);
-            Assert.AreEqual(2.0f,
-                ((Literal) fcall2.Arguments[1]).Value.ToFloat());
+            Assert.That(((Literal) fcall2.Arguments[1]).Value.ToFloat(),
+                Is.EqualTo(2.0f));
 
             Assert.IsInstanceOf(typeof(VariableAccess), fcall2.Arguments[2]);
-            Assert.AreEqual("b", (fcall2.Arguments[2] as VariableAccess).VariableName);
+            Assert.That((fcall2.Arguments[2] as VariableAccess).VariableName,
+                Is.EqualTo("b"));
 
             Assert.IsInstanceOf(typeof(Literal), fcall2.Arguments[3]);
-            Assert.AreEqual(3.0f,
-                ((Literal) fcall2.Arguments[3]).Value.ToFloat());
+            Assert.That(((Literal) fcall2.Arguments[3]).Value.ToFloat(),
+                Is.EqualTo(3.0f));
 
 
             Assert.IsInstanceOf(typeof(VariableAccess), fcall.Arguments[2]);
-            Assert.AreEqual("c", (fcall.Arguments[2] as VariableAccess).VariableName);
+            Assert.That((fcall.Arguments[2] as VariableAccess).VariableName,
+                Is.EqualTo("c"));
         }
 
         [Test]
@@ -217,36 +228,40 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             var fcall = (FunctionCall)expr;
             Assert.IsInstanceOf<Literal>(fcall.Function);
             var literal = (Literal)fcall.Function;
-            Assert.AreSame(AdditionOperation.Value, literal.Value);
-            Assert.AreEqual(3, fcall.Arguments.Count);
+            Assert.That(literal.Value, Is.SameAs(AdditionOperation.Value));
+            Assert.That(fcall.Arguments.Count, Is.EqualTo(3));
 
             Assert.IsInstanceOf(typeof(FunctionCall), fcall.Arguments[0]);
             var fcall2 = (FunctionCall)fcall.Arguments[0];
             Assert.IsInstanceOf<Literal>(fcall2.Function);
             literal = (Literal)fcall2.Function;
-            Assert.AreSame(MultiplicationOperation.Value, literal.Value);
-            Assert.AreEqual(4, fcall2.Arguments.Count);
+            Assert.That(literal.Value,
+                Is.SameAs(MultiplicationOperation.Value));
+            Assert.That(fcall2.Arguments.Count, Is.EqualTo(4));
 
             Assert.IsInstanceOf(typeof(Literal), fcall2.Arguments[0]);
-            Assert.AreEqual(1.0f,
-                ((Literal) fcall2.Arguments[0]).Value.ToFloat());
+            Assert.That(((Literal) fcall2.Arguments[0]).Value.ToFloat(),
+                Is.EqualTo(1.0f));
 
             Assert.IsInstanceOf(typeof(VariableAccess), fcall2.Arguments[1]);
-            Assert.AreEqual("a", (fcall2.Arguments[1] as VariableAccess).VariableName);
+            Assert.That((fcall2.Arguments[1] as VariableAccess).VariableName,
+                Is.EqualTo("a"));
 
             Assert.IsInstanceOf(typeof(Literal), fcall2.Arguments[2]);
-            Assert.AreEqual(2.0f,
-                ((Literal) fcall2.Arguments[2]).Value.ToFloat());
+            Assert.That(((Literal) fcall2.Arguments[2]).Value.ToFloat(),
+                Is.EqualTo(2.0f));
 
             Assert.IsInstanceOf(typeof(VariableAccess), fcall2.Arguments[3]);
-            Assert.AreEqual("b", (fcall2.Arguments[3] as VariableAccess).VariableName);
+            Assert.That((fcall2.Arguments[3] as VariableAccess).VariableName,
+                Is.EqualTo("b"));
 
             Assert.IsInstanceOf(typeof(Literal), fcall.Arguments[1]);
-            Assert.AreEqual(3.0f,
-                ((Literal) fcall.Arguments[1]).Value.ToFloat());
+            Assert.That(((Literal) fcall.Arguments[1]).Value.ToFloat(),
+                Is.EqualTo(3.0f));
 
             Assert.IsInstanceOf(typeof(VariableAccess), fcall.Arguments[2]);
-            Assert.AreEqual("c", (fcall.Arguments[2] as VariableAccess).VariableName);
+            Assert.That((fcall.Arguments[2] as VariableAccess).VariableName,
+                Is.EqualTo("c"));
         }
 
         [Test]
@@ -260,46 +275,51 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             var fcall = (FunctionCall)expr;
             Assert.IsInstanceOf<Literal>(fcall.Function);
             var literal = (Literal)fcall.Function;
-            Assert.AreSame(AdditionOperation.Value, literal.Value);
-            Assert.AreEqual(3, fcall.Arguments.Count);
+            Assert.That(literal.Value, Is.SameAs(AdditionOperation.Value));
+            Assert.That(fcall.Arguments.Count, Is.EqualTo(3));
 
             Assert.IsInstanceOf(typeof(FunctionCall), fcall.Arguments[0]);
             var fcall2 = (FunctionCall)fcall.Arguments[0];
             Assert.IsInstanceOf<Literal>(fcall2.Function);
             literal = (Literal)fcall2.Function;
-            Assert.AreSame(MultiplicationOperation.Value, literal.Value);
-            Assert.AreEqual(3, fcall2.Arguments.Count);
+            Assert.That(literal.Value,
+                Is.SameAs(MultiplicationOperation.Value));
+            Assert.That(fcall2.Arguments.Count, Is.EqualTo(3));
 
             Assert.IsInstanceOf(typeof(Literal), fcall2.Arguments[0]);
-            Assert.AreEqual(1.0f,
-                ((Literal) fcall2.Arguments[0]).Value.ToFloat());
+            Assert.That(((Literal) fcall2.Arguments[0]).Value.ToFloat(),
+                Is.EqualTo(1.0f));
 
             Assert.IsInstanceOf(typeof(VariableAccess), fcall2.Arguments[1]);
-            Assert.AreEqual("a", (fcall2.Arguments[1] as VariableAccess).VariableName);
+            Assert.That((fcall2.Arguments[1] as VariableAccess).VariableName,
+                Is.EqualTo("a"));
 
             Assert.IsInstanceOf(typeof(Literal), fcall2.Arguments[2]);
-            Assert.AreEqual(2.0f,
-                ((Literal) fcall2.Arguments[2]).Value.ToFloat());
+            Assert.That(((Literal) fcall2.Arguments[2]).Value.ToFloat(),
+                Is.EqualTo(2.0f));
 
 
 
             Assert.IsInstanceOf(typeof(VariableAccess), fcall.Arguments[1]);
-            Assert.AreEqual("b", (fcall.Arguments[1] as VariableAccess).VariableName);
+            Assert.That((fcall.Arguments[1] as VariableAccess).VariableName,
+                Is.EqualTo("b"));
 
 
             Assert.IsInstanceOf(typeof(FunctionCall), fcall.Arguments[2]);
             fcall2 = (FunctionCall)fcall.Arguments[2];
             Assert.IsInstanceOf<Literal>(fcall2.Function);
             literal = (Literal)fcall2.Function;
-            Assert.AreSame(MultiplicationOperation.Value, literal.Value);
-            Assert.AreEqual(2, fcall2.Arguments.Count);
+            Assert.That(literal.Value,
+                Is.SameAs(MultiplicationOperation.Value));
+            Assert.That(fcall2.Arguments.Count, Is.EqualTo(2));
 
             Assert.IsInstanceOf(typeof(Literal), fcall2.Arguments[0]);
-            Assert.AreEqual(3.0f,
-                ((Literal) fcall2.Arguments[0]).Value.ToFloat());
+            Assert.That(((Literal) fcall2.Arguments[0]).Value.ToFloat(),
+                Is.EqualTo(3.0f));
 
             Assert.IsInstanceOf(typeof(VariableAccess), fcall2.Arguments[1]);
-            Assert.AreEqual("c", (fcall2.Arguments[1] as VariableAccess).VariableName);
+            Assert.That((fcall2.Arguments[1] as VariableAccess).VariableName,
+                Is.EqualTo("c"));
         }
 
         [Test]
@@ -313,45 +333,50 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             var fcall = (FunctionCall)expr;
             Assert.IsInstanceOf<Literal>(fcall.Function);
             var literal = (Literal)fcall.Function;
-            Assert.AreSame(AdditionOperation.Value, literal.Value);
-            Assert.AreEqual(3, fcall.Arguments.Count);
+            Assert.That(literal.Value, Is.SameAs(AdditionOperation.Value));
+            Assert.That(fcall.Arguments.Count, Is.EqualTo(3));
 
             Assert.IsInstanceOf(typeof(FunctionCall), fcall.Arguments[0]);
             var fcall2 = (FunctionCall)fcall.Arguments[0];
             Assert.IsInstanceOf<Literal>(fcall2.Function);
             literal = (Literal)fcall2.Function;
-            Assert.AreSame(MultiplicationOperation.Value, literal.Value);
-            Assert.AreEqual(2, fcall2.Arguments.Count);
+            Assert.That(literal.Value,
+                Is.SameAs(MultiplicationOperation.Value));
+            Assert.That(fcall2.Arguments.Count, Is.EqualTo(2));
 
             Assert.IsInstanceOf(typeof(Literal), fcall2.Arguments[0]);
-            Assert.AreEqual(1.0f,
-                ((Literal) fcall2.Arguments[0]).Value.ToFloat());
+            Assert.That(((Literal) fcall2.Arguments[0]).Value.ToFloat(),
+                Is.EqualTo(1.0f));
 
             Assert.IsInstanceOf(typeof(VariableAccess), fcall2.Arguments[1]);
-            Assert.AreEqual("a", (fcall2.Arguments[1] as VariableAccess).VariableName);
+            Assert.That((fcall2.Arguments[1] as VariableAccess).VariableName,
+                Is.EqualTo("a"));
 
 
             Assert.IsInstanceOf(typeof(Literal), fcall.Arguments[1]);
-            Assert.AreEqual(2.0f,
-                ((Literal) fcall.Arguments[1]).Value.ToFloat());
+            Assert.That(((Literal) fcall.Arguments[1]).Value.ToFloat(),
+                Is.EqualTo(2.0f));
 
 
             Assert.IsInstanceOf(typeof(FunctionCall), fcall.Arguments[2]);
             fcall2 = (FunctionCall)fcall.Arguments[2];
             Assert.IsInstanceOf<Literal>(fcall2.Function);
             literal = (Literal)fcall2.Function;
-            Assert.AreSame(MultiplicationOperation.Value, literal.Value);
-            Assert.AreEqual(3, fcall2.Arguments.Count);
+            Assert.That(literal.Value,
+                Is.SameAs(MultiplicationOperation.Value));
+            Assert.That(fcall2.Arguments.Count, Is.EqualTo(3));
 
             Assert.IsInstanceOf(typeof(VariableAccess), fcall2.Arguments[0]);
-            Assert.AreEqual("b", (fcall2.Arguments[0] as VariableAccess).VariableName);
+            Assert.That((fcall2.Arguments[0] as VariableAccess).VariableName,
+                Is.EqualTo("b"));
 
             Assert.IsInstanceOf(typeof(Literal), fcall2.Arguments[1]);
-            Assert.AreEqual(3.0f,
-                ((Literal) fcall2.Arguments[1]).Value.ToFloat());
+            Assert.That(((Literal) fcall2.Arguments[1]).Value.ToFloat(),
+                Is.EqualTo(3.0f));
 
             Assert.IsInstanceOf(typeof(VariableAccess), fcall2.Arguments[2]);
-            Assert.AreEqual("c", (fcall2.Arguments[2] as VariableAccess).VariableName);
+            Assert.That((fcall2.Arguments[2] as VariableAccess).VariableName,
+                Is.EqualTo("c"));
         }
 
         [Test]
@@ -365,47 +390,51 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             var fcall = (FunctionCall)expr;
             Assert.IsInstanceOf<Literal>(fcall.Function);
             var literal = (Literal)fcall.Function;
-            Assert.AreSame(BitwiseOrOperation.Value, literal.Value);
-            Assert.AreEqual(2, fcall.Arguments.Count);
+            Assert.That(literal.Value, Is.SameAs(BitwiseOrOperation.Value));
+            Assert.That(fcall.Arguments.Count, Is.EqualTo(2));
             Assert.IsInstanceOf(typeof(Literal), fcall.Arguments[0]);
-            Assert.AreEqual(1.0f,
-                ((Literal) fcall.Arguments[0]).Value.ToFloat());
+            Assert.That(((Literal) fcall.Arguments[0]).Value.ToFloat(),
+                Is.EqualTo(1.0f));
             Assert.IsInstanceOf(typeof(FunctionCall), fcall.Arguments[1]);
             fcall = (FunctionCall)(fcall.Arguments[1]);
             Assert.IsInstanceOf<Literal>(fcall.Function);
             literal = (Literal)fcall.Function;
-            Assert.AreSame(BitwiseAndOperation.Value, literal.Value);
-            Assert.AreEqual(2, fcall.Arguments.Count);
+            Assert.That(literal.Value, Is.SameAs(BitwiseAndOperation.Value));
+            Assert.That(fcall.Arguments.Count, Is.EqualTo(2));
             Assert.IsInstanceOf(typeof(VariableAccess), fcall.Arguments[0]);
-            Assert.AreEqual("a", (fcall.Arguments[0] as VariableAccess).VariableName);
+            Assert.That((fcall.Arguments[0] as VariableAccess).VariableName,
+                Is.EqualTo("a"));
             Assert.IsInstanceOf(typeof(FunctionCall), fcall.Arguments[1]);
             fcall = (FunctionCall)(fcall.Arguments[1]);
             Assert.IsInstanceOf<Literal>(fcall.Function);
             literal = (Literal)fcall.Function;
-            Assert.AreSame(AdditionOperation.Value, literal.Value);
-            Assert.AreEqual(2, fcall.Arguments.Count);
+            Assert.That(literal.Value, Is.SameAs(AdditionOperation.Value));
+            Assert.That(fcall.Arguments.Count, Is.EqualTo(2));
             Assert.IsInstanceOf(typeof(Literal), fcall.Arguments[0]);
-            Assert.AreEqual(2.0f,
-                ((Literal) fcall.Arguments[0]).Value.ToFloat());
+            Assert.That(((Literal) fcall.Arguments[0]).Value.ToFloat(),
+                Is.EqualTo(2.0f));
             Assert.IsInstanceOf(typeof(FunctionCall), fcall.Arguments[1]);
             fcall = (FunctionCall)(fcall.Arguments[1]);
             Assert.IsInstanceOf<Literal>(fcall.Function);
             literal = (Literal)fcall.Function;
-            Assert.AreSame(MultiplicationOperation.Value, literal.Value);
-            Assert.AreEqual(2, fcall.Arguments.Count);
+            Assert.That(literal.Value,
+                Is.SameAs(MultiplicationOperation.Value));
+            Assert.That(fcall.Arguments.Count, Is.EqualTo(2));
             Assert.IsInstanceOf(typeof(VariableAccess), fcall.Arguments[0]);
-            Assert.AreEqual("b", (fcall.Arguments[0] as VariableAccess).VariableName);
+            Assert.That((fcall.Arguments[0] as VariableAccess).VariableName,
+                Is.EqualTo("b"));
             Assert.IsInstanceOf(typeof(FunctionCall), fcall.Arguments[1]);
             fcall = (FunctionCall)(fcall.Arguments[1]);
             Assert.IsInstanceOf<Literal>(fcall.Function);
             literal = (Literal)fcall.Function;
-            Assert.AreSame(ExponentOperation.Value, literal.Value);
-            Assert.AreEqual(2, fcall.Arguments.Count);
+            Assert.That(literal.Value, Is.SameAs(ExponentOperation.Value));
+            Assert.That(fcall.Arguments.Count, Is.EqualTo(2));
             Assert.IsInstanceOf(typeof(Literal), fcall.Arguments[0]);
-            Assert.AreEqual(3.0f,
-                ((Literal) fcall.Arguments[0]).Value.ToFloat());
+            Assert.That(((Literal) fcall.Arguments[0]).Value.ToFloat(),
+                Is.EqualTo(3.0f));
             Assert.IsInstanceOf(typeof(VariableAccess), fcall.Arguments[1]);
-            Assert.AreEqual("c", (fcall.Arguments[1] as VariableAccess).VariableName);
+            Assert.That((fcall.Arguments[1] as VariableAccess).VariableName,
+                Is.EqualTo("c"));
 
         }
 
@@ -420,47 +449,51 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             var fcall = (expr as FunctionCall);
             Assert.IsInstanceOf<Literal>(fcall.Function);
             var literal = (Literal)fcall.Function;
-            Assert.AreSame(BitwiseOrOperation.Value, literal.Value);
-            Assert.AreEqual(2, fcall.Arguments.Count);
+            Assert.That(literal.Value, Is.SameAs(BitwiseOrOperation.Value));
+            Assert.That(fcall.Arguments.Count, Is.EqualTo(2));
             Assert.IsInstanceOf(typeof(VariableAccess), fcall.Arguments[1]);
-            Assert.AreEqual("c", (fcall.Arguments[1] as VariableAccess).VariableName);
+            Assert.That((fcall.Arguments[1] as VariableAccess).VariableName,
+                Is.EqualTo("c"));
             Assert.IsInstanceOf(typeof(FunctionCall), fcall.Arguments[0]);
             fcall = (fcall.Arguments[0] as FunctionCall);
             Assert.IsInstanceOf<Literal>(fcall.Function);
             literal = (Literal)fcall.Function;
-            Assert.AreSame(BitwiseAndOperation.Value, literal.Value);
-            Assert.AreEqual(2, fcall.Arguments.Count);
+            Assert.That(literal.Value, Is.SameAs(BitwiseAndOperation.Value));
+            Assert.That(fcall.Arguments.Count, Is.EqualTo(2));
             Assert.IsInstanceOf(typeof(Literal), fcall.Arguments[1]);
-            Assert.AreEqual(3.0f,
-                ((Literal) fcall.Arguments[1]).Value.ToFloat());
+            Assert.That(((Literal) fcall.Arguments[1]).Value.ToFloat(),
+                Is.EqualTo(3.0f));
             Assert.IsInstanceOf(typeof(FunctionCall), fcall.Arguments[0]);
             fcall = (fcall.Arguments[0] as FunctionCall);
             Assert.IsInstanceOf<Literal>(fcall.Function);
             literal = (Literal)fcall.Function;
-            Assert.AreSame(AdditionOperation.Value, literal.Value);
-            Assert.AreEqual(2, fcall.Arguments.Count);
+            Assert.That(literal.Value, Is.SameAs(AdditionOperation.Value));
+            Assert.That(fcall.Arguments.Count, Is.EqualTo(2));
             Assert.IsInstanceOf(typeof(VariableAccess), fcall.Arguments[1]);
-            Assert.AreEqual("b", (fcall.Arguments[1] as VariableAccess).VariableName);
+            Assert.That((fcall.Arguments[1] as VariableAccess).VariableName,
+                Is.EqualTo("b"));
             Assert.IsInstanceOf(typeof(FunctionCall), fcall.Arguments[0]);
             fcall = (fcall.Arguments[0] as FunctionCall);
             Assert.IsInstanceOf<Literal>(fcall.Function);
             literal = (Literal)fcall.Function;
-            Assert.AreSame(MultiplicationOperation.Value, literal.Value);
-            Assert.AreEqual(2, fcall.Arguments.Count);
+            Assert.That(literal.Value,
+                Is.SameAs(MultiplicationOperation.Value));
+            Assert.That(fcall.Arguments.Count, Is.EqualTo(2));
             Assert.IsInstanceOf(typeof(Literal), fcall.Arguments[1]);
-            Assert.AreEqual(2.0f,
-                ((Literal) fcall.Arguments[1]).Value.ToFloat());
+            Assert.That(((Literal) fcall.Arguments[1]).Value.ToFloat(),
+                Is.EqualTo(2.0f));
             Assert.IsInstanceOf(typeof(FunctionCall), fcall.Arguments[0]);
             fcall = (fcall.Arguments[0] as FunctionCall);
             Assert.IsInstanceOf<Literal>(fcall.Function);
             literal = (Literal)fcall.Function;
-            Assert.AreSame(ExponentOperation.Value, literal.Value);
-            Assert.AreEqual(2, fcall.Arguments.Count);
+            Assert.That(literal.Value, Is.SameAs(ExponentOperation.Value));
+            Assert.That(fcall.Arguments.Count, Is.EqualTo(2));
             Assert.IsInstanceOf(typeof(VariableAccess), fcall.Arguments[1]);
-            Assert.AreEqual("a", (fcall.Arguments[1] as VariableAccess).VariableName);
+            Assert.That((fcall.Arguments[1] as VariableAccess).VariableName,
+                Is.EqualTo("a"));
             Assert.IsInstanceOf(typeof(Literal), fcall.Arguments[0]);
-            Assert.AreEqual(1.0f,
-                ((Literal) fcall.Arguments[0]).Value.ToFloat());
+            Assert.That(((Literal) fcall.Arguments[0]).Value.ToFloat(),
+                Is.EqualTo(1.0f));
         }
 
         [Test]
@@ -474,11 +507,11 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             var fcall = (FunctionCall)expr;
             Assert.IsInstanceOf<VariableAccess>(fcall.Function);
             var va = (VariableAccess)fcall.Function;
-            Assert.AreEqual("sin", va.VariableName);
-            Assert.AreEqual(1, fcall.Arguments.Count);
+            Assert.That(va.VariableName, Is.EqualTo("sin"));
+            Assert.That(fcall.Arguments.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<VariableAccess>(fcall.Arguments[0]);
             va = (VariableAccess)fcall.Arguments[0];
-            Assert.AreEqual("pi", va.VariableName);
+            Assert.That(va.VariableName, Is.EqualTo("pi"));
         }
 
         [Test]
@@ -493,8 +526,8 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             var call = (FunctionCall)expr;
             Assert.IsInstanceOf<VariableAccess>(call.Function);
             var target = (VariableAccess)call.Function;
-            Assert.AreEqual("derive", target.VariableName);
-            Assert.AreEqual(2, call.Arguments.Count);
+            Assert.That(target.VariableName, Is.EqualTo("derive"));
+            Assert.That(call.Arguments.Count, Is.EqualTo(2));
         }
 
         [Test]
@@ -509,8 +542,8 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             var call = (FunctionCall)expr;
             Assert.IsInstanceOf<VariableAccess>(call.Function);
             var target = (VariableAccess)call.Function;
-            Assert.AreEqual("if", target.VariableName);
-            Assert.AreEqual(3, call.Arguments.Count);
+            Assert.That(target.VariableName, Is.EqualTo("if"));
+            Assert.That(call.Arguments.Count, Is.EqualTo(3));
         }
 
         [Test]
@@ -526,10 +559,10 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             var fc = (FunctionCall)expr;
             Assert.IsInstanceOf<VariableAccess>(fc.Function);
             var va = (VariableAccess)fc.Function;
-            Assert.AreEqual("f", va.VariableName);
+            Assert.That(va.VariableName, Is.EqualTo("f"));
             Assert.IsInstanceOf<Literal>(fc.Arguments[0]);
-            Assert.AreEqual(0,
-                ((Literal)fc.Arguments[0]).Value.ToNumber().Value);
+            Assert.That(((Literal)fc.Arguments[0]).Value.ToNumber().Value,
+                Is.EqualTo(0));
         }
 
         public class CustomAsdfFunction : Function
@@ -564,13 +597,13 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
 
             Assert.IsInstanceOf(typeof(FunctionCall), expr);
             var fcall = (expr as FunctionCall);
-            Assert.AreEqual(2, fcall.Arguments.Count);
+            Assert.That(fcall.Arguments.Count, Is.EqualTo(2));
             Assert.IsInstanceOf(typeof(Literal), fcall.Arguments[0]);
             Assert.IsInstanceOf(typeof(Literal), fcall.Arguments[1]);
-            Assert.AreEqual(1f,
-                ((Literal) fcall.Arguments[0]).Value.ToFloat());
-            Assert.AreEqual(2f,
-                ((Literal) fcall.Arguments[1]).Value.ToFloat());
+            Assert.That(((Literal) fcall.Arguments[0]).Value.ToFloat(),
+                Is.EqualTo(1f));
+            Assert.That(((Literal) fcall.Arguments[1]).Value.ToFloat(),
+                Is.EqualTo(2f));
         }
 
         class CountArgsFunction : Function
@@ -609,7 +642,7 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             // then
             Assert.IsInstanceOf(typeof(FunctionCall), expr);
             var fcall = (FunctionCall)expr;
-            Assert.AreEqual(0, fcall.Arguments.Count);
+            Assert.That(fcall.Arguments.Count, Is.EqualTo(0));
         }
 
         [Test]
@@ -623,10 +656,10 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             // then
             Assert.IsInstanceOf(typeof(FunctionCall), expr);
             var fcall = (FunctionCall)expr;
-            Assert.AreEqual(1, fcall.Arguments.Count);
+            Assert.That(fcall.Arguments.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<Literal>(fcall.Arguments[0]);
-            Assert.AreEqual(1f,
-                ((Literal) fcall.Arguments[0]).Value.ToFloat());
+            Assert.That(((Literal) fcall.Arguments[0]).Value.ToFloat(),
+                Is.EqualTo(1f));
         }
 
         [Test]
@@ -640,13 +673,13 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             // then
             Assert.IsInstanceOf(typeof(FunctionCall), expr);
             var fcall = (FunctionCall)expr;
-            Assert.AreEqual(2, fcall.Arguments.Count);
+            Assert.That(fcall.Arguments.Count, Is.EqualTo(2));
             Assert.IsInstanceOf<Literal>(fcall.Arguments[0]);
             Assert.IsInstanceOf<Literal>(fcall.Arguments[1]);
-            Assert.AreEqual(1f,
-                ((Literal) fcall.Arguments[0]).Value.ToFloat());
-            Assert.AreEqual(2f,
-                ((Literal) fcall.Arguments[1]).Value.ToFloat());
+            Assert.That(((Literal) fcall.Arguments[0]).Value.ToFloat(),
+                Is.EqualTo(1f));
+            Assert.That(((Literal) fcall.Arguments[1]).Value.ToFloat(),
+                Is.EqualTo(2f));
         }
 
         [Test]
@@ -660,16 +693,16 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             // then
             Assert.IsInstanceOf(typeof(FunctionCall), expr);
             var fcall = (FunctionCall)expr;
-            Assert.AreEqual(3, fcall.Arguments.Count);
+            Assert.That(fcall.Arguments.Count, Is.EqualTo(3));
             Assert.IsInstanceOf<Literal>(fcall.Arguments[0]);
             Assert.IsInstanceOf<Literal>(fcall.Arguments[1]);
             Assert.IsInstanceOf<Literal>(fcall.Arguments[2]);
-            Assert.AreEqual(1f,
-                ((Literal) fcall.Arguments[0]).Value.ToFloat());
-            Assert.AreEqual(2f,
-                ((Literal) fcall.Arguments[1]).Value.ToFloat());
-            Assert.AreEqual(3f,
-                ((Literal) fcall.Arguments[2]).Value.ToFloat());
+            Assert.That(((Literal) fcall.Arguments[0]).Value.ToFloat(),
+                Is.EqualTo(1f));
+            Assert.That(((Literal) fcall.Arguments[1]).Value.ToFloat(),
+                Is.EqualTo(2f));
+            Assert.That(((Literal) fcall.Arguments[2]).Value.ToFloat(),
+                Is.EqualTo(3f));
         }
 
         [Test]
@@ -683,19 +716,19 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             // then
             Assert.IsInstanceOf(typeof(FunctionCall), expr);
             var fcall = (FunctionCall)expr;
-            Assert.AreEqual(4, fcall.Arguments.Count);
+            Assert.That(fcall.Arguments.Count, Is.EqualTo(4));
             Assert.IsInstanceOf<Literal>(fcall.Arguments[0]);
             Assert.IsInstanceOf<Literal>(fcall.Arguments[1]);
             Assert.IsInstanceOf<Literal>(fcall.Arguments[2]);
             Assert.IsInstanceOf<Literal>(fcall.Arguments[3]);
-            Assert.AreEqual(1f,
-                ((Literal) fcall.Arguments[0]).Value.ToFloat());
-            Assert.AreEqual(2f,
-                ((Literal) fcall.Arguments[1]).Value.ToFloat());
-            Assert.AreEqual(3f,
-                ((Literal) fcall.Arguments[2]).Value.ToFloat());
-            Assert.AreEqual(4f,
-                ((Literal) fcall.Arguments[3]).Value.ToFloat());
+            Assert.That(((Literal) fcall.Arguments[0]).Value.ToFloat(),
+                Is.EqualTo(1f));
+            Assert.That(((Literal) fcall.Arguments[1]).Value.ToFloat(),
+                Is.EqualTo(2f));
+            Assert.That(((Literal) fcall.Arguments[2]).Value.ToFloat(),
+                Is.EqualTo(3f));
+            Assert.That(((Literal) fcall.Arguments[3]).Value.ToFloat(),
+                Is.EqualTo(4f));
         }
 
         [Test]
@@ -709,10 +742,10 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             // then
             Assert.IsInstanceOf(typeof(FunctionCall), expr);
             var call1 = (FunctionCall)expr;
-            Assert.AreEqual(2, call1.Arguments.Count);
+            Assert.That(call1.Arguments.Count, Is.EqualTo(2));
             Assert.IsInstanceOf<FunctionCall>(call1.Function);
             var call2 = (FunctionCall)call1.Function;
-            Assert.AreEqual(1, call2.Arguments.Count);
+            Assert.That(call2.Arguments.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<VariableAccess>(call2.Function);
         }
 
@@ -727,10 +760,10 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             // then
             Assert.IsInstanceOf(typeof(FunctionCall), expr);
             var call1 = (FunctionCall)expr;
-            Assert.AreEqual(2, call1.Arguments.Count);
+            Assert.That(call1.Arguments.Count, Is.EqualTo(2));
             Assert.IsInstanceOf<FunctionCall>(call1.Function);
             var call2 = (FunctionCall)call1.Function;
-            Assert.AreEqual(1, call2.Arguments.Count);
+            Assert.That(call2.Arguments.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<VariableAccess>(call2.Function);
         }
 
@@ -745,10 +778,10 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             // then
             Assert.IsInstanceOf(typeof(FunctionCall), expr);
             var call1 = (FunctionCall)expr;
-            Assert.AreEqual(2, call1.Arguments.Count);
+            Assert.That(call1.Arguments.Count, Is.EqualTo(2));
             Assert.IsInstanceOf<ComponentAccess>(call1.Function);
             var ca = (ComponentAccess)call1.Function;
-            Assert.AreEqual(1, ca.Indexes.Count);
+            Assert.That(ca.Indexes.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<VariableAccess>(ca.Expr);
         }
 
@@ -765,27 +798,31 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             ComponentAccess ca = null;
             Assert.IsInstanceOf<FunctionCall>(expr);
             call = (FunctionCall)expr;
-            Assert.AreEqual(0,call.Arguments.Count);
+            Assert.That(call.Arguments.Count,
+                Is.EqualTo(0));
             Assert.IsInstanceOf<FunctionCall>(call.Function);
 
             call = (FunctionCall)call.Function;
-            Assert.AreEqual(4,call.Arguments.Count);
+            Assert.That(call.Arguments.Count,
+                Is.EqualTo(4));
             Assert.IsInstanceOf<ComponentAccess>(call.Function);
 
             ca =(ComponentAccess)call.Function;
-            Assert.AreEqual(3,ca.Indexes.Count);
+            Assert.That(ca.Indexes.Count,
+                Is.EqualTo(3));
             Assert.IsInstanceOf<FunctionCall>(ca.Expr);
 
             call = (FunctionCall)ca.Expr;
-            Assert.AreEqual(2,call.Arguments.Count);
+            Assert.That(call.Arguments.Count,
+                Is.EqualTo(2));
             Assert.IsInstanceOf<ComponentAccess>(call.Function);
 
             ca = (ComponentAccess)call.Function;
-            Assert.AreEqual(1, ca.Indexes.Count);
+            Assert.That(ca.Indexes.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<VariableAccess>(ca.Expr);
 
             var va = (VariableAccess)ca.Expr;
-            Assert.AreEqual("a", va.VariableName);
+            Assert.That(va.VariableName, Is.EqualTo("a"));
         }
 
         [Test]
@@ -802,10 +839,11 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             var fcall = (FunctionCall)expr;
             Assert.IsInstanceOf<Literal>(fcall.Function);
             var literal = (Literal)fcall.Function;
-            Assert.AreSame(NegationOperation.Value, literal.Value);
-            Assert.AreEqual(1, fcall.Arguments.Count);
+            Assert.That(literal.Value, Is.SameAs(NegationOperation.Value));
+            Assert.That(fcall.Arguments.Count, Is.EqualTo(1));
             Assert.IsInstanceOf(typeof(VariableAccess), fcall.Arguments[0]);
-            Assert.AreEqual("a", (fcall.Arguments[0] as VariableAccess).VariableName);
+            Assert.That((fcall.Arguments[0] as VariableAccess).VariableName,
+                Is.EqualTo("a"));
         }
 
         [Test]
@@ -820,8 +858,8 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             Assert.IsInstanceOf<Literal>(result);
             var literal = (Literal) result;
             Assert.IsTrue(literal.Value.IsString(null));
-            Assert.AreEqual("value",
-                literal.Value.ToStringValue().Value);
+            Assert.That(literal.Value.ToStringValue().Value,
+                Is.EqualTo("value"));
         }
 
         [Test]
@@ -836,8 +874,8 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             Assert.IsInstanceOf<Literal>(result);
             var literal = (Literal) result;
             Assert.IsTrue(literal.Value.IsString(null));
-            Assert.AreEqual("value",
-                literal.Value.ToStringValue().Value);
+            Assert.That(literal.Value.ToStringValue().Value,
+                Is.EqualTo("value"));
         }
 
         [Test]
@@ -851,13 +889,16 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             // then
             Assert.IsInstanceOf<VectorExpression>(result);
             var ve = (VectorExpression) result;
-            Assert.AreEqual(3, ve.Length);
+            Assert.That(ve.Length, Is.EqualTo(3));
             Assert.IsInstanceOf<Literal>(ve[0]);
-            Assert.AreEqual(1,((Literal)ve[0]).Value.ToFloat());
+            Assert.That(((Literal)ve[0]).Value.ToFloat(),
+                Is.EqualTo(1));
             Assert.IsInstanceOf<Literal>(ve[1]);
-            Assert.AreEqual(2,((Literal)ve[1]).Value.ToFloat());
+            Assert.That(((Literal)ve[1]).Value.ToFloat(),
+                Is.EqualTo(2));
             Assert.IsInstanceOf<Literal>(ve[2]);
-            Assert.AreEqual(3,((Literal)ve[2]).Value.ToFloat());
+            Assert.That(((Literal)ve[2]).Value.ToFloat(),
+                Is.EqualTo(3));
         }
 
         [Test]
@@ -871,13 +912,16 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             // then
             Assert.IsInstanceOf<VectorExpression>(result);
             var ve = (VectorExpression) result;
-            Assert.AreEqual(3, ve.Length);
+            Assert.That(ve.Length, Is.EqualTo(3));
             Assert.IsInstanceOf<Literal>(ve[0]);
-            Assert.AreEqual(1,((Literal)ve[0]).Value.ToFloat());
+            Assert.That(((Literal)ve[0]).Value.ToFloat(),
+                Is.EqualTo(1));
             Assert.IsInstanceOf<Literal>(ve[1]);
-            Assert.AreEqual(2,((Literal)ve[1]).Value.ToFloat());
+            Assert.That(((Literal)ve[1]).Value.ToFloat(),
+                Is.EqualTo(2));
             Assert.IsInstanceOf<Literal>(ve[2]);
-            Assert.AreEqual(3,((Literal)ve[2]).Value.ToFloat());
+            Assert.That(((Literal)ve[2]).Value.ToFloat(),
+                Is.EqualTo(3));
         }
 
         [Test]
@@ -891,16 +935,16 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             // then
             Assert.IsInstanceOf<MatrixExpression>(result);
             var me = (MatrixExpression) result;
-            Assert.AreEqual(2, me.RowCount);
-            Assert.AreEqual(2, me.ColumnCount);
+            Assert.That(me.RowCount, Is.EqualTo(2));
+            Assert.That(me.ColumnCount, Is.EqualTo(2));
             Assert.IsInstanceOf<Literal>(me[0, 0]);
-            Assert.AreEqual(1, ((Literal) me[0, 0]).Value.ToFloat());
+            Assert.That(((Literal) me[0, 0]).Value.ToFloat(), Is.EqualTo(1));
             Assert.IsInstanceOf<Literal>(me[0, 1]);
-            Assert.AreEqual(2, ((Literal) me[0, 1]).Value.ToFloat());
+            Assert.That(((Literal) me[0, 1]).Value.ToFloat(), Is.EqualTo(2));
             Assert.IsInstanceOf<Literal>(me[1, 0]);
-            Assert.AreEqual(3, ((Literal) me[1, 0]).Value.ToFloat());
+            Assert.That(((Literal) me[1, 0]).Value.ToFloat(), Is.EqualTo(3));
             Assert.IsInstanceOf<Literal>(me[1, 1]);
-            Assert.AreEqual(4, ((Literal) me[1, 1]).Value.ToFloat());
+            Assert.That(((Literal) me[1, 1]).Value.ToFloat(), Is.EqualTo(4));
         }
 
         [Test]
@@ -914,16 +958,16 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             // then
             Assert.IsInstanceOf<MatrixExpression>(result);
             var me = (MatrixExpression) result;
-            Assert.AreEqual(2, me.RowCount);
-            Assert.AreEqual(2, me.ColumnCount);
+            Assert.That(me.RowCount, Is.EqualTo(2));
+            Assert.That(me.ColumnCount, Is.EqualTo(2));
             Assert.IsInstanceOf<Literal>(me[0, 0]);
-            Assert.AreEqual(1, ((Literal) me[0, 0]).Value.ToFloat());
+            Assert.That(((Literal) me[0, 0]).Value.ToFloat(), Is.EqualTo(1));
             Assert.IsInstanceOf<Literal>(me[0, 1]);
-            Assert.AreEqual(2, ((Literal) me[0, 1]).Value.ToFloat());
+            Assert.That(((Literal) me[0, 1]).Value.ToFloat(), Is.EqualTo(2));
             Assert.IsInstanceOf<Literal>(me[1, 0]);
-            Assert.AreEqual(3, ((Literal) me[1, 0]).Value.ToFloat());
+            Assert.That(((Literal) me[1, 0]).Value.ToFloat(), Is.EqualTo(3));
             Assert.IsInstanceOf<Literal>(me[1, 1]);
-            Assert.AreEqual(4, ((Literal) me[1, 1]).Value.ToFloat());
+            Assert.That(((Literal) me[1, 1]).Value.ToFloat(), Is.EqualTo(4));
         }
 
         [Test]
@@ -937,16 +981,16 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             // then
             Assert.IsInstanceOf<MatrixExpression>(result);
             var me = (MatrixExpression) result;
-            Assert.AreEqual(2, me.RowCount);
-            Assert.AreEqual(2, me.ColumnCount);
+            Assert.That(me.RowCount, Is.EqualTo(2));
+            Assert.That(me.ColumnCount, Is.EqualTo(2));
             Assert.IsInstanceOf<Literal>(me[0, 0]);
-            Assert.AreEqual(1, ((Literal) me[0, 0]).Value.ToFloat());
+            Assert.That(((Literal) me[0, 0]).Value.ToFloat(), Is.EqualTo(1));
             Assert.IsInstanceOf<Literal>(me[0, 1]);
-            Assert.AreEqual(2, ((Literal) me[0, 1]).Value.ToFloat());
+            Assert.That(((Literal) me[0, 1]).Value.ToFloat(), Is.EqualTo(2));
             Assert.IsInstanceOf<Literal>(me[1, 0]);
-            Assert.AreEqual(3, ((Literal) me[1, 0]).Value.ToFloat());
+            Assert.That(((Literal) me[1, 0]).Value.ToFloat(), Is.EqualTo(3));
             Assert.IsInstanceOf<Literal>(me[1, 1]);
-            Assert.AreEqual(4, ((Literal) me[1, 1]).Value.ToFloat());
+            Assert.That(((Literal) me[1, 1]).Value.ToFloat(), Is.EqualTo(4));
         }
 
         [Test]
@@ -960,16 +1004,16 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             // then
             Assert.IsInstanceOf<MatrixExpression>(result);
             var me = (MatrixExpression) result;
-            Assert.AreEqual(2, me.RowCount);
-            Assert.AreEqual(2, me.ColumnCount);
+            Assert.That(me.RowCount, Is.EqualTo(2));
+            Assert.That(me.ColumnCount, Is.EqualTo(2));
             Assert.IsInstanceOf<Literal>(me[0, 0]);
-            Assert.AreEqual(1, ((Literal) me[0, 0]).Value.ToFloat());
+            Assert.That(((Literal) me[0, 0]).Value.ToFloat(), Is.EqualTo(1));
             Assert.IsInstanceOf<Literal>(me[0, 1]);
-            Assert.AreEqual(2, ((Literal) me[0, 1]).Value.ToFloat());
+            Assert.That(((Literal) me[0, 1]).Value.ToFloat(), Is.EqualTo(2));
             Assert.IsInstanceOf<Literal>(me[1, 0]);
-            Assert.AreEqual(3, ((Literal) me[1, 0]).Value.ToFloat());
+            Assert.That(((Literal) me[1, 0]).Value.ToFloat(), Is.EqualTo(3));
             Assert.IsInstanceOf<Literal>(me[1, 1]);
-            Assert.AreEqual(4, ((Literal) me[1, 1]).Value.ToFloat());
+            Assert.That(((Literal) me[1, 1]).Value.ToFloat(), Is.EqualTo(4));
         }
 
         [Test]
@@ -983,16 +1027,16 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             // then
             Assert.IsInstanceOf<MatrixExpression>(result);
             var me = (MatrixExpression) result;
-            Assert.AreEqual(2, me.RowCount);
-            Assert.AreEqual(2, me.ColumnCount);
+            Assert.That(me.RowCount, Is.EqualTo(2));
+            Assert.That(me.ColumnCount, Is.EqualTo(2));
             Assert.IsInstanceOf<Literal>(me[0, 0]);
-            Assert.AreEqual(1, ((Literal) me[0, 0]).Value.ToFloat());
+            Assert.That(((Literal) me[0, 0]).Value.ToFloat(), Is.EqualTo(1));
             Assert.IsInstanceOf<Literal>(me[0, 1]);
-            Assert.AreEqual(2, ((Literal) me[0, 1]).Value.ToFloat());
+            Assert.That(((Literal) me[0, 1]).Value.ToFloat(), Is.EqualTo(2));
             Assert.IsInstanceOf<Literal>(me[1, 0]);
-            Assert.AreEqual(3, ((Literal) me[1, 0]).Value.ToFloat());
+            Assert.That(((Literal) me[1, 0]).Value.ToFloat(), Is.EqualTo(3));
             Assert.IsInstanceOf<Literal>(me[1, 1]);
-            Assert.AreEqual(4, ((Literal) me[1, 1]).Value.ToFloat());
+            Assert.That(((Literal) me[1, 1]).Value.ToFloat(), Is.EqualTo(4));
         }
 
         [Test]
@@ -1006,16 +1050,16 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             // then
             Assert.IsInstanceOf<MatrixExpression>(result);
             var me = (MatrixExpression) result;
-            Assert.AreEqual(2, me.RowCount);
-            Assert.AreEqual(2, me.ColumnCount);
+            Assert.That(me.RowCount, Is.EqualTo(2));
+            Assert.That(me.ColumnCount, Is.EqualTo(2));
             Assert.IsInstanceOf<Literal>(me[0, 0]);
-            Assert.AreEqual(1, ((Literal) me[0, 0]).Value.ToFloat());
+            Assert.That(((Literal) me[0, 0]).Value.ToFloat(), Is.EqualTo(1));
             Assert.IsInstanceOf<Literal>(me[0, 1]);
-            Assert.AreEqual(0, ((Literal) me[0, 1]).Value.ToFloat());
+            Assert.That(((Literal) me[0, 1]).Value.ToFloat(), Is.EqualTo(0));
             Assert.IsInstanceOf<Literal>(me[1, 0]);
-            Assert.AreEqual(3, ((Literal) me[1, 0]).Value.ToFloat());
+            Assert.That(((Literal) me[1, 0]).Value.ToFloat(), Is.EqualTo(3));
             Assert.IsInstanceOf<Literal>(me[1, 1]);
-            Assert.AreEqual(4, ((Literal) me[1, 1]).Value.ToFloat());
+            Assert.That(((Literal) me[1, 1]).Value.ToFloat(), Is.EqualTo(4));
         }
 
         [Test]
@@ -1029,14 +1073,14 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             // then
             Assert.IsInstanceOf<MatrixExpression>(result);
             var me = (MatrixExpression) result;
-            Assert.AreEqual(1, me.RowCount);
-            Assert.AreEqual(3, me.ColumnCount);
+            Assert.That(me.RowCount, Is.EqualTo(1));
+            Assert.That(me.ColumnCount, Is.EqualTo(3));
             Assert.IsInstanceOf<Literal>(me[0, 0]);
-            Assert.AreEqual(1, ((Literal) me[0, 0]).Value.ToFloat());
+            Assert.That(((Literal) me[0, 0]).Value.ToFloat(), Is.EqualTo(1));
             Assert.IsInstanceOf<Literal>(me[0, 1]);
-            Assert.AreEqual(2, ((Literal) me[0, 1]).Value.ToFloat());
+            Assert.That(((Literal) me[0, 1]).Value.ToFloat(), Is.EqualTo(2));
             Assert.IsInstanceOf<Literal>(me[0, 2]);
-            Assert.AreEqual(3, ((Literal) me[0, 2]).Value.ToFloat());
+            Assert.That(((Literal) me[0, 2]).Value.ToFloat(), Is.EqualTo(3));
         }
 
         [Test]
@@ -1051,11 +1095,11 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             Assert.IsInstanceOf<ComponentAccess>(result);
             var ca = (ComponentAccess) result;
             Assert.IsInstanceOf<VariableAccess>(ca.Expr);
-            Assert.AreEqual("a",
-                ((VariableAccess)ca.Expr).VariableName);
-            Assert.AreEqual(1, ca.Indexes.Count);
-            Assert.AreEqual(1,
-                ((Literal)ca.Indexes[0]).Value.ToFloat());
+            Assert.That(((VariableAccess)ca.Expr).VariableName,
+                Is.EqualTo("a"));
+            Assert.That(ca.Indexes.Count, Is.EqualTo(1));
+            Assert.That(((Literal)ca.Indexes[0]).Value.ToFloat(),
+                Is.EqualTo(1));
         }
 
         [Test]
@@ -1071,14 +1115,15 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             var fc = (FunctionCall) result;
             Assert.IsInstanceOf<Literal>(fc.Function);
             var literal = (Literal)fc.Function;
-            Assert.AreSame(EqualComparisonOperation.Value, literal.Value);
-            Assert.AreEqual(2, fc.Arguments.Count);
+            Assert.That(literal.Value,
+                Is.SameAs(EqualComparisonOperation.Value));
+            Assert.That(fc.Arguments.Count, Is.EqualTo(2));
             Assert.IsInstanceOf<VariableAccess>(fc.Arguments[0]);
-            Assert.AreEqual("a",
-                ((VariableAccess)fc.Arguments[0]).VariableName);
+            Assert.That(((VariableAccess)fc.Arguments[0]).VariableName,
+                Is.EqualTo("a"));
             Assert.IsInstanceOf<VariableAccess>(fc.Arguments[1]);
-            Assert.AreEqual("b",
-                ((VariableAccess)fc.Arguments[1]).VariableName);
+            Assert.That(((VariableAccess)fc.Arguments[1]).VariableName,
+                Is.EqualTo("b"));
         }
 
         [Test]
@@ -1094,14 +1139,15 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             var fc = (FunctionCall) result;
             Assert.IsInstanceOf<Literal>(fc.Function);
             var literal = (Literal)fc.Function;
-            Assert.AreSame(NotEqualComparisonOperation.Value, literal.Value);
-            Assert.AreEqual(2, fc.Arguments.Count);
+            Assert.That(literal.Value,
+                Is.SameAs(NotEqualComparisonOperation.Value));
+            Assert.That(fc.Arguments.Count, Is.EqualTo(2));
             Assert.IsInstanceOf<VariableAccess>(fc.Arguments[0]);
-            Assert.AreEqual("a",
-                ((VariableAccess)fc.Arguments[0]).VariableName);
+            Assert.That(((VariableAccess)fc.Arguments[0]).VariableName,
+                Is.EqualTo("a"));
             Assert.IsInstanceOf<VariableAccess>(fc.Arguments[1]);
-            Assert.AreEqual("b",
-                ((VariableAccess)fc.Arguments[1]).VariableName);
+            Assert.That(((VariableAccess)fc.Arguments[1]).VariableName,
+                Is.EqualTo("b"));
         }
 
         [Test]
@@ -1117,15 +1163,15 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             var fc = (FunctionCall) result;
             Assert.IsInstanceOf<Literal>(fc.Function);
             var literal = (Literal)fc.Function;
-            Assert.AreSame(LessThanComparisonOperation.Value,
-                literal.Value);
-            Assert.AreEqual(2, fc.Arguments.Count);
+            Assert.That(literal.Value,
+                Is.SameAs(LessThanComparisonOperation.Value));
+            Assert.That(fc.Arguments.Count, Is.EqualTo(2));
             Assert.IsInstanceOf<VariableAccess>(fc.Arguments[0]);
-            Assert.AreEqual("a",
-                ((VariableAccess)fc.Arguments[0]).VariableName);
+            Assert.That(((VariableAccess)fc.Arguments[0]).VariableName,
+                Is.EqualTo("a"));
             Assert.IsInstanceOf<VariableAccess>(fc.Arguments[1]);
-            Assert.AreEqual("b",
-                ((VariableAccess)fc.Arguments[1]).VariableName);
+            Assert.That(((VariableAccess)fc.Arguments[1]).VariableName,
+                Is.EqualTo("b"));
         }
 
         [Test]
@@ -1141,15 +1187,15 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             var fc = (FunctionCall) result;
             Assert.IsInstanceOf<Literal>(fc.Function);
             var literal = (Literal)fc.Function;
-            Assert.AreSame(LessThanOrEqualComparisonOperation.Value,
-                literal.Value);
-            Assert.AreEqual(2, fc.Arguments.Count);
+            Assert.That(literal.Value,
+                Is.SameAs(LessThanOrEqualComparisonOperation.Value));
+            Assert.That(fc.Arguments.Count, Is.EqualTo(2));
             Assert.IsInstanceOf<VariableAccess>(fc.Arguments[0]);
-            Assert.AreEqual("a",
-                ((VariableAccess)fc.Arguments[0]).VariableName);
+            Assert.That(((VariableAccess)fc.Arguments[0]).VariableName,
+                Is.EqualTo("a"));
             Assert.IsInstanceOf<VariableAccess>(fc.Arguments[1]);
-            Assert.AreEqual("b",
-                ((VariableAccess)fc.Arguments[1]).VariableName);
+            Assert.That(((VariableAccess)fc.Arguments[1]).VariableName,
+                Is.EqualTo("b"));
         }
 
         [Test]
@@ -1165,15 +1211,15 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             var fc = (FunctionCall) result;
             Assert.IsInstanceOf<Literal>(fc.Function);
             var literal = (Literal)fc.Function;
-            Assert.AreSame(GreaterThanComparisonOperation.Value,
-                literal.Value);
-            Assert.AreEqual(2, fc.Arguments.Count);
+            Assert.That(literal.Value,
+                Is.SameAs(GreaterThanComparisonOperation.Value));
+            Assert.That(fc.Arguments.Count, Is.EqualTo(2));
             Assert.IsInstanceOf<VariableAccess>(fc.Arguments[0]);
-            Assert.AreEqual("a",
-                ((VariableAccess)fc.Arguments[0]).VariableName);
+            Assert.That(((VariableAccess)fc.Arguments[0]).VariableName,
+                Is.EqualTo("a"));
             Assert.IsInstanceOf<VariableAccess>(fc.Arguments[1]);
-            Assert.AreEqual("b",
-                ((VariableAccess)fc.Arguments[1]).VariableName);
+            Assert.That(((VariableAccess)fc.Arguments[1]).VariableName,
+                Is.EqualTo("b"));
         }
 
         [Test]
@@ -1189,15 +1235,15 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             var fc = (FunctionCall) result;
             Assert.IsInstanceOf<Literal>(fc.Function);
             var literal = (Literal)fc.Function;
-            Assert.AreSame(GreaterThanOrEqualComparisonOperation.Value,
-                literal.Value);
-            Assert.AreEqual(2, fc.Arguments.Count);
+            Assert.That(literal.Value,
+                Is.SameAs(GreaterThanOrEqualComparisonOperation.Value));
+            Assert.That(fc.Arguments.Count, Is.EqualTo(2));
             Assert.IsInstanceOf<VariableAccess>(fc.Arguments[0]);
-            Assert.AreEqual("a",
-                ((VariableAccess)fc.Arguments[0]).VariableName);
+            Assert.That(((VariableAccess)fc.Arguments[0]).VariableName,
+                Is.EqualTo("a"));
             Assert.IsInstanceOf<VariableAccess>(fc.Arguments[1]);
-            Assert.AreEqual("b",
-                ((VariableAccess)fc.Arguments[1]).VariableName);
+            Assert.That(((VariableAccess)fc.Arguments[1]).VariableName,
+                Is.EqualTo("b"));
         }
 
         [Test]
@@ -1216,15 +1262,15 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             var result = parser.GetCommands(input, cs);
             // then
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, result.Length);
+            Assert.That(result.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<FuncAssignCommandData>(result[0]);
             var udf = ((FuncAssignCommandData)result[0]).Func;
-            Assert.AreEqual("f", udf.Name);
-            Assert.AreEqual(1, udf.Argnames.Length);
-            Assert.AreEqual("x", udf.Argnames[0]);
+            Assert.That(udf.Name, Is.EqualTo("f"));
+            Assert.That(udf.Argnames.Length, Is.EqualTo(1));
+            Assert.That(udf.Argnames[0], Is.EqualTo("x"));
             Assert.IsInstanceOf<VariableAccess>(udf.Expression);
             var va = (VariableAccess)udf.Expression;
-            Assert.AreEqual("x", va.VariableName);
+            Assert.That(va.VariableName, Is.EqualTo("x"));
         }
 
         [Test]
@@ -1243,71 +1289,71 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             var result = parser.GetCommands(input, cs);
             // then
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, result.Length);
+            Assert.That(result.Length, Is.EqualTo(1));
             Assert.IsInstanceOf<FuncAssignCommandData>(result[0]);
             var udf = ((FuncAssignCommandData)result[0]).Func;
-            Assert.AreEqual("f", udf.Name);
-            Assert.AreEqual(1, udf.Argnames.Length);
-            Assert.AreEqual("x", udf.Argnames[0]);
+            Assert.That(udf.Name, Is.EqualTo("f"));
+            Assert.That(udf.Argnames.Length, Is.EqualTo(1));
+            Assert.That(udf.Argnames[0], Is.EqualTo("x"));
             Assert.IsInstanceOf<FunctionCall>(udf.Expression);
             var call = (FunctionCall)udf.Expression;
             Assert.IsInstanceOf<VariableAccess>(call.Function);
-            Assert.AreEqual("if",
-                ((VariableAccess)call.Function).VariableName);
-            Assert.AreEqual(3, call.Arguments.Count);
+            Assert.That(((VariableAccess)call.Function).VariableName,
+                Is.EqualTo("if"));
+            Assert.That(call.Arguments.Count, Is.EqualTo(3));
 
             Assert.IsInstanceOf<FunctionCall>(call.Arguments[0]);
             var call2 = (FunctionCall)call.Arguments[0];
             Assert.IsInstanceOf<Literal>(call2.Function);
-            Assert.AreSame(EqualComparisonOperation.Value,
-                ((Literal)call2.Function).Value);
+            Assert.That(((Literal)call2.Function).Value,
+                Is.SameAs(EqualComparisonOperation.Value));
             Assert.IsInstanceOf<VariableAccess>(call2.Arguments[0]);
-            Assert.AreEqual("x",
-                ((VariableAccess)call2.Arguments[0]).VariableName);
+            Assert.That(((VariableAccess)call2.Arguments[0]).VariableName,
+                Is.EqualTo("x"));
             Assert.IsInstanceOf<Literal>(call2.Arguments[1]);
-            Assert.AreEqual(0,
-                ((Literal)call2.Arguments[1]).Value.ToNumber().Value);
+            Assert.That(((Literal)call2.Arguments[1]).Value.ToNumber().Value,
+                Is.EqualTo(0));
 
             Assert.IsInstanceOf<Literal>(call.Arguments[1]);
-            Assert.AreEqual(0,
-                ((Literal)call.Arguments[1]).Value.ToNumber().Value);
+            Assert.That(((Literal)call.Arguments[1]).Value.ToNumber().Value,
+                Is.EqualTo(0));
 
             Assert.IsInstanceOf<FunctionCall>(call.Arguments[2]);
             call2 = (FunctionCall)call.Arguments[2];
             Assert.IsInstanceOf<Literal>(call2.Function);
-            Assert.AreSame(AdditionOperation.Value,
-                ((Literal)call2.Function).Value);
-            Assert.AreEqual(2, call2.Arguments.Count);
+            Assert.That(((Literal)call2.Function).Value,
+                Is.SameAs(AdditionOperation.Value));
+            Assert.That(call2.Arguments.Count, Is.EqualTo(2));
             Assert.IsInstanceOf<Literal>(call2.Arguments[0]);
-            Assert.AreEqual(1,
-                ((Literal)call2.Arguments[0]).Value.ToNumber().Value);
+            Assert.That(((Literal)call2.Arguments[0]).Value.ToNumber().Value,
+                Is.EqualTo(1));
             Assert.IsInstanceOf<FunctionCall>(call2.Arguments[1]);
 
             var call3 = (FunctionCall)call2.Arguments[1];
             Assert.IsInstanceOf<VariableAccess>(call3.Function);
-            Assert.AreEqual("f",
-                ((VariableAccess)call3.Function).VariableName);
-            Assert.AreEqual(1, call3.Arguments.Count);
+            Assert.That(((VariableAccess)call3.Function).VariableName,
+                Is.EqualTo("f"));
+            Assert.That(call3.Arguments.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<FunctionCall>(call3.Arguments[0]);
 
             var call4 = (FunctionCall)call3.Arguments[0];
             Assert.IsInstanceOf<VariableAccess>(call4.Function);
-            Assert.AreEqual("floor",
-                ((VariableAccess)call4.Function).VariableName);
-            Assert.AreEqual(1, call4.Arguments.Count);
+            Assert.That(((VariableAccess)call4.Function).VariableName,
+                Is.EqualTo("floor"));
+            Assert.That(call4.Arguments.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<FunctionCall>(call4.Arguments[0]);
 
             var call5 = (FunctionCall)call4.Arguments[0];
             Assert.IsInstanceOf<Literal>(call5.Function);
-            Assert.AreSame(DivisionOperation.Value,
-                ((Literal)call5.Function).Value);
-            Assert.AreEqual(2, call5.Arguments.Count);
+            Assert.That(((Literal)call5.Function).Value,
+                Is.SameAs(DivisionOperation.Value));
+            Assert.That(call5.Arguments.Count, Is.EqualTo(2));
             Assert.IsInstanceOf<VariableAccess>(call5.Arguments[0]);
-            Assert.AreEqual("x",
-                ((VariableAccess)call5.Arguments[0]).VariableName);
+            Assert.That(((VariableAccess)call5.Arguments[0]).VariableName,
+                Is.EqualTo("x"));
             Assert.IsInstanceOf<Literal>(call5.Arguments[1]);
-            Assert.AreEqual(10,
-                ((Literal)call5.Arguments[1]).Value.ToNumber().Value);
+            Assert.That(((Literal)call5.Arguments[1]).Value.ToNumber().Value,
+                Is.EqualTo(10));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/TransformersT/ApplyVariablesTransformT/ApplyVariablesTransformTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/TransformersT/ApplyVariablesTransformT/ApplyVariablesTransformTest.cs
@@ -42,7 +42,7 @@ namespace MetaphysicsIndustries.Solus.Test.TransformersT.
             // when
             var result = tf.Transform(expr, env);
             // then
-            Assert.AreSame(expr, result);
+            Assert.That(result, Is.SameAs(expr));
         }
 
         [Test]
@@ -55,7 +55,7 @@ namespace MetaphysicsIndustries.Solus.Test.TransformersT.
             // when
             var result = tf.Transform(expr, env);
             // then
-            Assert.AreSame(expr, result);
+            Assert.That(result, Is.SameAs(expr));
         }
 
         [Test]
@@ -70,7 +70,7 @@ namespace MetaphysicsIndustries.Solus.Test.TransformersT.
             // when
             var result = tf.Transform(expr, env);
             // then
-            Assert.AreSame(expr2, result);
+            Assert.That(result, Is.SameAs(expr2));
         }
 
         [Test]
@@ -87,7 +87,7 @@ namespace MetaphysicsIndustries.Solus.Test.TransformersT.
             // then
             Assert.IsInstanceOf<Literal>(result);
             var literal = (Literal)result;
-            Assert.AreEqual(literal.Value, value);
+            Assert.That(value, Is.EqualTo(literal.Value));
         }
 
         [Test]
@@ -106,15 +106,15 @@ namespace MetaphysicsIndustries.Solus.Test.TransformersT.
             // when
             var result = tf.Transform(expr, env);
             // then
-            Assert.AreNotSame(expr, result);
+            Assert.That(result, Is.Not.SameAs(expr));
             Assert.IsInstanceOf<MatrixExpression>(result);
             var me = (MatrixExpression)result;
-            Assert.AreEqual(1, me.RowCount);
-            Assert.AreEqual(2, me.ColumnCount);
-            Assert.AreEqual(3,
-                ((Literal)me[0, 0]).Value.ToNumber().Value);
-            Assert.AreEqual(4,
-                ((Literal)me[0, 1]).Value.ToNumber().Value);
+            Assert.That(me.RowCount, Is.EqualTo(1));
+            Assert.That(me.ColumnCount, Is.EqualTo(2));
+            Assert.That(((Literal)me[0, 0]).Value.ToNumber().Value,
+                Is.EqualTo(3));
+            Assert.That(((Literal)me[0, 1]).Value.ToNumber().Value,
+                Is.EqualTo(4));
         }
 
         [Test]
@@ -132,14 +132,14 @@ namespace MetaphysicsIndustries.Solus.Test.TransformersT.
             // when
             var result = tf.Transform(expr, env);
             // then
-            Assert.AreNotSame(expr, result);
+            Assert.That(result, Is.Not.SameAs(expr));
             Assert.IsInstanceOf<MatrixExpression>(result);
             var me = (MatrixExpression)result;
-            Assert.AreEqual(1, me.RowCount);
-            Assert.AreEqual(2, me.ColumnCount);
-            Assert.AreEqual(3,
-                ((Literal)me[0, 0]).Value.ToNumber().Value);
-            Assert.AreSame(expr2, me[0, 1]);
+            Assert.That(me.RowCount, Is.EqualTo(1));
+            Assert.That(me.ColumnCount, Is.EqualTo(2));
+            Assert.That(((Literal)me[0, 0]).Value.ToNumber().Value,
+                Is.EqualTo(3));
+            Assert.That(expr2, Is.SameAs(me[0, 1]));
         }
 
         [Test]
@@ -154,7 +154,7 @@ namespace MetaphysicsIndustries.Solus.Test.TransformersT.
             // when
             var result = tf.Transform(expr, env);
             // then
-            Assert.AreSame(expr, result);
+            Assert.That(result, Is.SameAs(expr));
         }
 
         [Test]
@@ -173,14 +173,14 @@ namespace MetaphysicsIndustries.Solus.Test.TransformersT.
             // when
             var result = tf.Transform(expr, env);
             // then
-            Assert.AreNotSame(expr, result);
+            Assert.That(result, Is.Not.SameAs(expr));
             Assert.IsInstanceOf<VectorExpression>(result);
             var ve = (VectorExpression)result;
-            Assert.AreEqual(2, ve.Length);
-            Assert.AreEqual(3,
-                ((Literal)ve[0]).Value.ToNumber().Value);
-            Assert.AreEqual(4,
-                ((Literal)ve[1]).Value.ToNumber().Value);
+            Assert.That(ve.Length, Is.EqualTo(2));
+            Assert.That(((Literal)ve[0]).Value.ToNumber().Value,
+                Is.EqualTo(3));
+            Assert.That(((Literal)ve[1]).Value.ToNumber().Value,
+                Is.EqualTo(4));
         }
 
         [Test]
@@ -198,13 +198,13 @@ namespace MetaphysicsIndustries.Solus.Test.TransformersT.
             // when
             var result = tf.Transform(expr, env);
             // then
-            Assert.AreNotSame(expr, result);
+            Assert.That(result, Is.Not.SameAs(expr));
             Assert.IsInstanceOf<VectorExpression>(result);
             var ve = (VectorExpression)result;
-            Assert.AreEqual(2, ve.Length);
-            Assert.AreEqual(3,
-                ((Literal)ve[0]).Value.ToNumber().Value);
-            Assert.AreSame(expr2, ve[1]);
+            Assert.That(ve.Length, Is.EqualTo(2));
+            Assert.That(((Literal)ve[0]).Value.ToNumber().Value,
+                Is.EqualTo(3));
+            Assert.That(ve[1], Is.SameAs(expr2));
         }
 
         [Test]
@@ -219,7 +219,7 @@ namespace MetaphysicsIndustries.Solus.Test.TransformersT.
             // when
             var result = tf.Transform(expr, env);
             // then
-            Assert.AreSame(expr, result);
+            Assert.That(result, Is.SameAs(expr));
         }
 
         [Test]
@@ -238,7 +238,7 @@ namespace MetaphysicsIndustries.Solus.Test.TransformersT.
             // when
             var result = tf.Transform(expr, env);
             // then
-            Assert.AreSame(expr, result);
+            Assert.That(result, Is.SameAs(expr));
         }
 
         [Test]
@@ -265,7 +265,7 @@ namespace MetaphysicsIndustries.Solus.Test.TransformersT.
             var result = tf.Transform(expr, env);
             // then
             Assert.IsInstanceOf<ComponentAccess>(result);
-            Assert.AreNotSame(expr, result);
+            Assert.That(result, Is.Not.SameAs(expr));
             var ca = (ComponentAccess)result;
             Assert.IsInstanceOf<Literal>(ca.Expr);
             Assert.IsInstanceOf<Literal>(ca.Indexes[0]);
@@ -291,9 +291,9 @@ namespace MetaphysicsIndustries.Solus.Test.TransformersT.
             var result = tf.Transform(expr, env);
             // then
             Assert.IsInstanceOf<ComponentAccess>(result);
-            Assert.AreNotSame(expr, result);
+            Assert.That(result, Is.Not.SameAs(expr));
             var ca = (ComponentAccess)result;
-            Assert.AreSame(expr.Expr, ca.Expr);
+            Assert.That(ca.Expr, Is.SameAs(expr.Expr));
             Assert.IsInstanceOf<Literal>(ca.Indexes[0]);
             Assert.IsInstanceOf<Literal>(ca.Indexes[1]);
         }
@@ -321,11 +321,11 @@ namespace MetaphysicsIndustries.Solus.Test.TransformersT.
             var result = tf.Transform(expr, env);
             // then
             Assert.IsInstanceOf<ComponentAccess>(result);
-            Assert.AreNotSame(expr, result);
+            Assert.That(result, Is.Not.SameAs(expr));
             var ca = (ComponentAccess)result;
             Assert.IsInstanceOf<Literal>(ca.Expr);
             Assert.IsInstanceOf<Literal>(ca.Indexes[0]);
-            Assert.AreSame(expr.Indexes[1], ca.Indexes[1]);
+            Assert.That(ca.Indexes[1], Is.SameAs(expr.Indexes[1]));
         }
 
         [Test]
@@ -346,9 +346,9 @@ namespace MetaphysicsIndustries.Solus.Test.TransformersT.
             var result = tf.Transform(expr, env);
             // then
             Assert.IsInstanceOf<FunctionCall>(result);
-            Assert.AreNotSame(expr, result);
+            Assert.That(result, Is.Not.SameAs(expr));
             var fc = (FunctionCall)result;
-            Assert.AreSame(expr.Function, fc.Function);
+            Assert.That(fc.Function, Is.SameAs(expr.Function));
             Assert.IsInstanceOf<Literal>(fc.Arguments[0]);
             Assert.IsInstanceOf<Literal>(fc.Arguments[1]);
             Assert.IsInstanceOf<Literal>(fc.Arguments[2]);
@@ -372,12 +372,12 @@ namespace MetaphysicsIndustries.Solus.Test.TransformersT.
             var result = tf.Transform(expr, env);
             // then
             Assert.IsInstanceOf<FunctionCall>(result);
-            Assert.AreNotSame(expr, result);
+            Assert.That(result, Is.Not.SameAs(expr));
             var fc = (FunctionCall)result;
-            Assert.AreSame(expr.Function, fc.Function);
+            Assert.That(fc.Function, Is.SameAs(expr.Function));
             Assert.IsInstanceOf<Literal>(fc.Arguments[0]);
             Assert.IsInstanceOf<Literal>(fc.Arguments[1]);
-            Assert.AreSame(expr2, fc.Arguments[2]);
+            Assert.That(fc.Arguments[2], Is.SameAs(expr2));
         }
 
         [Test]
@@ -394,7 +394,7 @@ namespace MetaphysicsIndustries.Solus.Test.TransformersT.
             // when
             var result = tf.Transform(expr, env);
             // then
-            Assert.AreSame(expr, result);
+            Assert.That(result, Is.SameAs(expr));
         }
         [Test]
         public void TransformIntervalWithNoneMissingYieldsTransformed()
@@ -413,7 +413,7 @@ namespace MetaphysicsIndustries.Solus.Test.TransformersT.
             var result = tf.Transform(expr, env);
             // then
             Assert.IsInstanceOf<IntervalExpression>(result);
-            Assert.AreNotSame(expr, result);
+            Assert.That(result, Is.Not.SameAs(expr));
             var interval = (IntervalExpression)result;
             Assert.IsInstanceOf<Literal>(interval.LowerBound);
             Assert.IsInstanceOf<Literal>(interval.UpperBound);
@@ -436,10 +436,10 @@ namespace MetaphysicsIndustries.Solus.Test.TransformersT.
             var result = tf.Transform(expr, env);
             // then
             Assert.IsInstanceOf<IntervalExpression>(result);
-            Assert.AreNotSame(expr, result);
+            Assert.That(result, Is.Not.SameAs(expr));
             var interval = (IntervalExpression)result;
             Assert.IsInstanceOf<Literal>(interval.LowerBound);
-            Assert.AreSame(expr2,interval.UpperBound);
+            Assert.That(interval.UpperBound, Is.SameAs(expr2));
         }
 
         [Test]
@@ -456,7 +456,7 @@ namespace MetaphysicsIndustries.Solus.Test.TransformersT.
             // when
             var result = tf.Transform(expr, env);
             // then
-            Assert.AreSame(expr, result);
+            Assert.That(result, Is.SameAs(expr));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/ValuesT/IntervalT/EqualsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ValuesT/IntervalT/EqualsTest.cs
@@ -37,7 +37,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsTrue(i1.Equals(i2));
             Assert.IsTrue(i1.Equals((object)i2));
-            Assert.AreEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -49,7 +49,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsTrue(i1.Equals(i2));
             Assert.IsTrue(i1.Equals((object)i2));
-            Assert.AreEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -61,7 +61,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsTrue(i1.Equals(i2));
             Assert.IsTrue(i1.Equals((object)i2));
-            Assert.AreEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -73,7 +73,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsTrue(i1.Equals(i2));
             Assert.IsTrue(i1.Equals((object)i2));
-            Assert.AreEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -85,7 +85,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsTrue(i1.Equals(i2));
             Assert.IsTrue(i1.Equals((object)i2));
-            Assert.AreEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -97,7 +97,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsTrue(i1.Equals(i2));
             Assert.IsTrue(i1.Equals((object)i2));
-            Assert.AreEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -109,7 +109,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsTrue(i1.Equals(i2));
             Assert.IsTrue(i1.Equals((object)i2));
-            Assert.AreEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -121,7 +121,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsTrue(i1.Equals(i2));
             Assert.IsTrue(i1.Equals((object)i2));
-            Assert.AreEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -133,7 +133,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -145,7 +145,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -157,7 +157,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -169,7 +169,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -181,7 +181,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -193,7 +193,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -205,7 +205,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -217,7 +217,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -229,7 +229,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -241,7 +241,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -253,7 +253,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -265,7 +265,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -277,7 +277,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -289,7 +289,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -301,7 +301,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -313,7 +313,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -325,7 +325,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -337,7 +337,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -349,7 +349,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -361,7 +361,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -373,7 +373,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -385,7 +385,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -397,7 +397,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -409,7 +409,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -421,7 +421,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -433,7 +433,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -445,7 +445,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -457,7 +457,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -469,7 +469,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -481,7 +481,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -493,7 +493,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -505,7 +505,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -517,7 +517,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -529,7 +529,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -541,7 +541,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -553,7 +553,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -565,7 +565,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -577,7 +577,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -589,7 +589,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -601,7 +601,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -613,7 +613,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -625,7 +625,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -637,7 +637,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -649,7 +649,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -661,7 +661,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -673,7 +673,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -685,7 +685,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -697,7 +697,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -709,7 +709,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -721,7 +721,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -733,7 +733,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -745,7 +745,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -757,7 +757,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -769,7 +769,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -781,7 +781,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]
@@ -793,7 +793,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // expect
             Assert.IsFalse(i1.Equals(i2));
             Assert.IsFalse(i1.Equals((object)i2));
-            Assert.AreNotEqual(i1.GetHashCode(), i2.GetHashCode());
+            Assert.That(i2.GetHashCode(), Is.Not.EqualTo(i1.GetHashCode()));
         }
 
         [Test]

--- a/MetaphysicsIndustries.Solus.Test/ValuesT/IntervalT/IntervalTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ValuesT/IntervalT/IntervalTest.cs
@@ -36,9 +36,9 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // when
             var result = new Interval(1, false, 2, true, false);
             // then
-            Assert.AreEqual(1, result.LowerBound);
+            Assert.That(result.LowerBound, Is.EqualTo(1));
             Assert.IsFalse(result.OpenLowerBound);
-            Assert.AreEqual(2, result.UpperBound);
+            Assert.That(result.UpperBound, Is.EqualTo(2));
             Assert.IsTrue(result.OpenUpperBound);
             Assert.IsFalse(result.IsIntegerInterval);
         }
@@ -59,10 +59,10 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             //       consistent.
             // TODO: Create some exception classes for bad types, values,
             //       and/or arguments
-            Assert.AreEqual("lowerBound", ex.ParamName);
-            Assert.AreEqual(
-                "Not a number: lowerBound",
-                ex.Message);
+            Assert.That(ex.ParamName, Is.EqualTo("lowerBound"));
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Not a number: lowerBound"));
         }
 
         [Test]
@@ -75,10 +75,10 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
                     var i = new Interval(1, false, float.NaN, false, false);
                 });
             // and
-            Assert.AreEqual("upperBound", ex.ParamName);
-            Assert.AreEqual(
-                "Not a number: upperBound",
-                ex.Message);
+            Assert.That(ex.ParamName, Is.EqualTo("upperBound"));
+            Assert.That(
+                ex.Message,
+                Is.EqualTo("Not a number: upperBound"));
         }
 
         [Test]
@@ -111,9 +111,9 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // when
             var result = new Interval(2, false, 1, true, false);
             // then
-            Assert.AreEqual(1, result.LowerBound);
+            Assert.That(result.LowerBound, Is.EqualTo(1));
             Assert.IsTrue(result.OpenLowerBound);
-            Assert.AreEqual(2, result.UpperBound);
+            Assert.That(result.UpperBound, Is.EqualTo(2));
             Assert.IsFalse(result.OpenUpperBound);
         }
 
@@ -123,9 +123,9 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // when
             var result = new Interval(3, true, 4, false, true);
             // then
-            Assert.AreEqual(3, result.LowerBound);
+            Assert.That(result.LowerBound, Is.EqualTo(3));
             Assert.IsTrue(result.OpenLowerBound);
-            Assert.AreEqual(4, result.UpperBound);
+            Assert.That(result.UpperBound, Is.EqualTo(4));
             Assert.IsFalse(result.OpenUpperBound);
             Assert.IsTrue(result.IsIntegerInterval);
         }
@@ -139,7 +139,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // given
             var interval = new Interval(1, false, 3, false, false);
             // expect
-            Assert.AreEqual(2, interval.Length);
+            Assert.That(interval.Length, Is.EqualTo(2));
         }
 
         [Test]
@@ -148,9 +148,9 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // when
             var result = Interval.Integer(1, 3);
             // then
-            Assert.AreEqual(1, result.LowerBound);
+            Assert.That(result.LowerBound, Is.EqualTo(1));
             Assert.IsFalse(result.OpenLowerBound);
-            Assert.AreEqual(3, result.UpperBound);
+            Assert.That(result.UpperBound, Is.EqualTo(3));
             Assert.IsFalse(result.OpenUpperBound);
             Assert.IsTrue(result.IsIntegerInterval);
         }
@@ -163,9 +163,9 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // when
             var result = interval.Round();
             // then
-            Assert.AreEqual(1, result.LowerBound);
+            Assert.That(result.LowerBound, Is.EqualTo(1));
             Assert.IsFalse(result.OpenLowerBound);
-            Assert.AreEqual(3, result.UpperBound);
+            Assert.That(result.UpperBound, Is.EqualTo(3));
             Assert.IsFalse(result.OpenUpperBound);
             Assert.IsTrue(result.IsIntegerInterval);
         }
@@ -182,7 +182,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // when
             var result = interval.CalcDelta(2);
             // then
-            Assert.AreEqual(2, result, 0.000001f);
+            Assert.That(result, Is.EqualTo(2).Within(0.000001f));
         }
 
         [Test]
@@ -193,7 +193,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // when
             var result = interval.CalcDelta(3);
             // then
-            Assert.AreEqual(1, result, 0.000001f);
+            Assert.That(result, Is.EqualTo(1).Within(0.000001f));
         }
 
         [Test]
@@ -204,7 +204,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.IntervalT
             // when
             var result = interval.CalcDelta(101);
             // then
-            Assert.AreEqual(0.02f, result, 0.000001f);
+            Assert.That(result, Is.EqualTo(0.02f).Within(0.000001f));
         }
 
         [Test]

--- a/MetaphysicsIndustries.Solus.Test/ValuesT/MathObjectHelperT/MathObjectHelperTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ValuesT/MathObjectHelperT/MathObjectHelperTest.cs
@@ -37,7 +37,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.MathObjectHelperT
             // when
             var result = mo.ToNumber();
             // then
-            Assert.AreEqual(123, result.Value);
+            Assert.That(result.Value, Is.EqualTo(123));
         }
 
         [Test]
@@ -57,7 +57,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.MathObjectHelperT
             // when
             var result = value.ToNumber();
             // then
-            Assert.AreEqual(123.45f, result.Value);
+            Assert.That(result.Value, Is.EqualTo(123.45f));
         }
 
         [Test]
@@ -68,7 +68,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.MathObjectHelperT
             // when
             var result = value.ToNumber();
             // then
-            Assert.AreEqual(123f, result.Value);
+            Assert.That(result.Value, Is.EqualTo(123f));
         }
 
         [Test]
@@ -79,7 +79,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.MathObjectHelperT
             // when
             var result = value.ToNumber();
             // then
-            Assert.AreEqual(123f, result.Value);
+            Assert.That(result.Value, Is.EqualTo(123f));
         }
 
         [Test]
@@ -89,7 +89,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.MathObjectHelperT
             var mo = new MockMathObject(true, false,
                 false, 0);
             // expect
-            Assert.AreEqual(Types.Scalar, mo.GetMathType());
+            Assert.That(mo.GetMathType(), Is.EqualTo(Types.Scalar));
         }
 
         [Test]
@@ -99,7 +99,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.MathObjectHelperT
             var mo = new MockMathObject(false, true,
                 false, 1);
             // expect
-            Assert.AreEqual(Types.Vector, mo.GetMathType());
+            Assert.That(mo.GetMathType(), Is.EqualTo(Types.Vector));
         }
 
         [Test]
@@ -109,7 +109,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.MathObjectHelperT
             var mo = new MockMathObject(false, false,
                 true, 2);
             // expect
-            Assert.AreEqual(Types.Matrix, mo.GetMathType());
+            Assert.That(mo.GetMathType(), Is.EqualTo(Types.Matrix));
         }
 
         [Test]
@@ -119,7 +119,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.MathObjectHelperT
             var mo = new MockMathObject(false, false,
                 false, 0);
             // expect
-            Assert.AreEqual(Types.Unknown, mo.GetMathType());
+            Assert.That(mo.GetMathType(), Is.EqualTo(Types.Unknown));
         }
 
         [Test]
@@ -130,7 +130,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.MathObjectHelperT
             // when
             var result = mo.ToStringValue();
             // then
-            Assert.AreEqual("abc", result.Value);
+            Assert.That(result.Value, Is.EqualTo("abc"));
         }
 
         [Test]
@@ -150,7 +150,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.MathObjectHelperT
             // when
             var result = value.ToStringValue();
             // then
-            Assert.AreEqual("def", result.Value);
+            Assert.That(result.Value, Is.EqualTo("def"));
         }
 
         [Test]
@@ -159,7 +159,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.MathObjectHelperT
             // given
             var mo = new MockMathObject(false, isString: true);
             // expect
-            Assert.AreEqual(Types.String, mo.GetMathType());
+            Assert.That(mo.GetMathType(), Is.EqualTo(Types.String));
         }
 
         [Test]
@@ -170,10 +170,10 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.MathObjectHelperT
             // when
             var result = values.ToMathObjects();
             // then
-            Assert.AreEqual(3, result.Length);
-            Assert.AreEqual(1, result[0].ToNumber().Value);
-            Assert.AreEqual(2, result[1].ToNumber().Value);
-            Assert.AreEqual(3, result[2].ToNumber().Value);
+            Assert.That(result.Length, Is.EqualTo(3));
+            Assert.That(result[0].ToNumber().Value, Is.EqualTo(1));
+            Assert.That(result[1].ToNumber().Value, Is.EqualTo(2));
+            Assert.That(result[2].ToNumber().Value, Is.EqualTo(3));
         }
 
         [Test]
@@ -189,14 +189,14 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.MathObjectHelperT
             // when
             var result = values.ToMathObjects();
             // then
-            Assert.AreEqual(3, result.GetLength(0));
-            Assert.AreEqual(2, result.GetLength(1));
-            Assert.AreEqual(1, result[0, 0].ToNumber().Value);
-            Assert.AreEqual(2, result[0, 1].ToNumber().Value);
-            Assert.AreEqual(3, result[1, 0].ToNumber().Value);
-            Assert.AreEqual(4, result[1, 1].ToNumber().Value);
-            Assert.AreEqual(5, result[2, 0].ToNumber().Value);
-            Assert.AreEqual(6, result[2, 1].ToNumber().Value);
+            Assert.That(result.GetLength(0), Is.EqualTo(3));
+            Assert.That(result.GetLength(1), Is.EqualTo(2));
+            Assert.That(result[0, 0].ToNumber().Value, Is.EqualTo(1));
+            Assert.That(result[0, 1].ToNumber().Value, Is.EqualTo(2));
+            Assert.That(result[1, 0].ToNumber().Value, Is.EqualTo(3));
+            Assert.That(result[1, 1].ToNumber().Value, Is.EqualTo(4));
+            Assert.That(result[2, 0].ToNumber().Value, Is.EqualTo(5));
+            Assert.That(result[2, 1].ToNumber().Value, Is.EqualTo(6));
         }
 
         [Test]
@@ -207,10 +207,13 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.MathObjectHelperT
             // when
             var result = values.ToVector();
             // then
-            Assert.AreEqual(3, result.Length);
-            Assert.AreEqual(1.2f,result[0].ToFloat());
-            Assert.AreEqual(3.4f,result[1].ToFloat());
-            Assert.AreEqual(5.6f,result[2].ToFloat());
+            Assert.That(result.Length, Is.EqualTo(3));
+            Assert.That(result[0].ToFloat(),
+                Is.EqualTo(1.2f));
+            Assert.That(result[1].ToFloat(),
+                Is.EqualTo(3.4f));
+            Assert.That(result[2].ToFloat(),
+                Is.EqualTo(5.6f));
         }
 
         [Test]
@@ -221,10 +224,13 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.MathObjectHelperT
             // when
             var result = values.ToVector();
             // then
-            Assert.AreEqual(3, result.Length);
-            Assert.AreEqual(1,result[0].ToFloat());
-            Assert.AreEqual(2,result[1].ToFloat());
-            Assert.AreEqual(3,result[2].ToFloat());
+            Assert.That(result.Length, Is.EqualTo(3));
+            Assert.That(result[0].ToFloat(),
+                Is.EqualTo(1));
+            Assert.That(result[1].ToFloat(),
+                Is.EqualTo(2));
+            Assert.That(result[2].ToFloat(),
+                Is.EqualTo(3));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/ValuesT/MatrixT/MatrixTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ValuesT/MatrixT/MatrixTest.cs
@@ -42,23 +42,23 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.MatrixT
             // when
             var result = new Matrix(values);
             // then
-            Assert.AreEqual(2, result.RowCount);
-            Assert.AreEqual(2, result.ColumnCount);
-            Assert.AreEqual(Types.Scalar, result.ComponentType);
-            Assert.AreEqual(1, result[0, 0].ToNumber().Value);
-            Assert.AreEqual(2, result[0, 1].ToNumber().Value);
-            Assert.AreEqual(3, result[1, 0].ToNumber().Value);
-            Assert.AreEqual(4, result[1, 1].ToNumber().Value);
+            Assert.That(result.RowCount, Is.EqualTo(2));
+            Assert.That(result.ColumnCount, Is.EqualTo(2));
+            Assert.That(result.ComponentType, Is.EqualTo(Types.Scalar));
+            Assert.That(result[0, 0].ToNumber().Value, Is.EqualTo(1));
+            Assert.That(result[0, 1].ToNumber().Value, Is.EqualTo(2));
+            Assert.That(result[1, 0].ToNumber().Value, Is.EqualTo(3));
+            Assert.That(result[1, 1].ToNumber().Value, Is.EqualTo(4));
             Assert.IsFalse(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsTrue(result.IsMatrix(null));
-            Assert.AreEqual(2, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(2));
             Assert.IsFalse(result.IsString(null));
-            Assert.AreEqual(2, result.GetDimension(null, 0));
-            Assert.AreEqual(2, result.GetDimension(null, 1));
+            Assert.That(result.GetDimension(null, 0), Is.EqualTo(2));
+            Assert.That(result.GetDimension(null, 1), Is.EqualTo(2));
             Assert.IsNull(result.GetDimension(null, -1));
             Assert.IsNull(result.GetDimension(null, 3));
-            Assert.AreEqual(new[] {2, 2}, result.GetDimensions(null));
+            Assert.That(result.GetDimensions(null), Is.EqualTo(new[] {2, 2}));
         }
 
         [Test]
@@ -73,12 +73,12 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.MatrixT
             // when
             var result = new Matrix(values);
             // then
-            Assert.AreEqual(2, result.RowCount);
-            Assert.AreEqual(2, result.ColumnCount);
-            Assert.AreEqual(1, result[0, 0].ToNumber().Value);
-            Assert.AreEqual(2, result[0, 1].ToNumber().Value);
-            Assert.AreEqual(3, result[1, 0].ToNumber().Value);
-            Assert.AreEqual(4, result[1, 1].ToNumber().Value);
+            Assert.That(result.RowCount, Is.EqualTo(2));
+            Assert.That(result.ColumnCount, Is.EqualTo(2));
+            Assert.That(result[0, 0].ToNumber().Value, Is.EqualTo(1));
+            Assert.That(result[0, 1].ToNumber().Value, Is.EqualTo(2));
+            Assert.That(result[1, 0].ToNumber().Value, Is.EqualTo(3));
+            Assert.That(result[1, 1].ToNumber().Value, Is.EqualTo(4));
         }
 
         [Test]
@@ -94,14 +94,14 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.MatrixT
             // when
             var result = new Matrix(values);
             // then
-            Assert.AreEqual(3, result.RowCount);
-            Assert.AreEqual(2, result.ColumnCount);
-            Assert.AreEqual(1, result[0, 0].ToNumber().Value);
-            Assert.AreEqual(2, result[0, 1].ToNumber().Value);
-            Assert.AreEqual(3, result[1, 0].ToNumber().Value);
-            Assert.AreEqual(4, result[1, 1].ToNumber().Value);
-            Assert.AreEqual(5, result[2, 0].ToNumber().Value);
-            Assert.AreEqual(6, result[2, 1].ToNumber().Value);
+            Assert.That(result.RowCount, Is.EqualTo(3));
+            Assert.That(result.ColumnCount, Is.EqualTo(2));
+            Assert.That(result[0, 0].ToNumber().Value, Is.EqualTo(1));
+            Assert.That(result[0, 1].ToNumber().Value, Is.EqualTo(2));
+            Assert.That(result[1, 0].ToNumber().Value, Is.EqualTo(3));
+            Assert.That(result[1, 1].ToNumber().Value, Is.EqualTo(4));
+            Assert.That(result[2, 0].ToNumber().Value, Is.EqualTo(5));
+            Assert.That(result[2, 1].ToNumber().Value, Is.EqualTo(6));
         }
 
         [Test]
@@ -116,7 +116,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.MatrixT
             // when
             var result = new Matrix(values);
             // then
-            Assert.AreEqual(Types.Mixed, result.ComponentType);
+            Assert.That(result.ComponentType, Is.EqualTo(Types.Mixed));
         }
 
         [Test]
@@ -132,7 +132,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.MatrixT
             // when
             var result = value.ToString();
             // then
-            Assert.AreEqual("[1, 2; 3, 4; 5, 6]", result);
+            Assert.That(result, Is.EqualTo("[1, 2; 3, 4; 5, 6]"));
         }
 
         [Test]
@@ -157,8 +157,8 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.MatrixT
             // when
             var result = value.ToString();
             // then
-            Assert.AreEqual("[\"one\", [2, 2, 2]; 3, [4, 5; 6, 7]]",
-                result);
+            Assert.That(result,
+                Is.EqualTo("[\"one\", [2, 2, 2]; 3, [4, 5; 6, 7]]"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/ValuesT/NumberT/NumberTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ValuesT/NumberT/NumberTest.cs
@@ -35,11 +35,11 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.NumberT
             // when
             var result = new Number();
             // then
-            Assert.AreEqual(0, result.Value);
+            Assert.That(result.Value, Is.EqualTo(0));
             Assert.IsTrue(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsFalse(result.IsString(null));
             Assert.IsNull(result.GetDimension(null, 0));
             Assert.IsNull(result.GetDimensions(null));
@@ -51,7 +51,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.NumberT
             // when
             var result = new Number(123);
             // then
-            Assert.AreEqual(123, result.Value);
+            Assert.That(result.Value, Is.EqualTo(123));
         }
 
         [Test]
@@ -62,7 +62,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.NumberT
             // when
             var result = value.ToString();
             // then
-            Assert.AreEqual("123.45", result);
+            Assert.That(result, Is.EqualTo("123.45"));
         }
 
         [Test]
@@ -73,7 +73,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.NumberT
             // when
             var result = value.ToString();
             // then
-            Assert.AreEqual("π", result);
+            Assert.That(result, Is.EqualTo("π"));
         }
 
         [Test]
@@ -84,7 +84,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.NumberT
             // when
             var result = value.ToString();
             // then
-            Assert.AreEqual("e", result);
+            Assert.That(result, Is.EqualTo("e"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/ValuesT/StringValueT/StringValueTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ValuesT/StringValueT/StringValueTest.cs
@@ -40,10 +40,10 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.StringValueT
             Assert.IsFalse(result.IsScalar(null));
             Assert.IsFalse(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(0, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(0));
             Assert.IsTrue(result.IsString(null));
-            Assert.AreEqual(0, result.GetDimension(null, 0));
-            Assert.AreEqual(new[] {0}, result.GetDimensions(null));
+            Assert.That(result.GetDimension(null, 0), Is.EqualTo(0));
+            Assert.That(result.GetDimensions(null), Is.EqualTo(new[] {0}));
         }
 
         [Test]
@@ -52,9 +52,9 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.StringValueT
             // when
             var result = new StringValue("abc");
             // then
-            Assert.AreEqual("abc", result.Value);
-            Assert.AreEqual(3, result.GetDimension(null, 0));
-            Assert.AreEqual(new[] {3}, result.GetDimensions(null));
+            Assert.That(result.Value, Is.EqualTo("abc"));
+            Assert.That(result.GetDimension(null, 0), Is.EqualTo(3));
+            Assert.That(result.GetDimensions(null), Is.EqualTo(new[] {3}));
         }
 
         [Test]
@@ -83,7 +83,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.StringValueT
             // when
             var result = value.ToString();
             // then
-            Assert.AreEqual("\"abc\"", result);
+            Assert.That(result, Is.EqualTo("\"abc\""));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/ValuesT/VarIntervalT/VarIntervalTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ValuesT/VarIntervalT/VarIntervalTest.cs
@@ -37,8 +37,8 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.VarIntervalT
             // when
             var result = new VarInterval(varname, interval);
             // then
-            Assert.AreEqual("a", result.Variable);
-            Assert.AreEqual(interval, result.Interval);
+            Assert.That(result.Variable, Is.EqualTo("a"));
+            Assert.That(result.Interval, Is.EqualTo(interval));
         }
 
         [Test]
@@ -49,10 +49,10 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.VarIntervalT
             // when
             var result = new VarInterval(varname, 1.1f, 3.1f);
             // then
-            Assert.AreEqual("a", result.Variable);
-            Assert.AreEqual(1.1f, result.Interval.LowerBound);
+            Assert.That(result.Variable, Is.EqualTo("a"));
+            Assert.That(result.Interval.LowerBound, Is.EqualTo(1.1f));
             Assert.IsFalse(result.Interval.OpenLowerBound);
-            Assert.AreEqual(3.1f, result.Interval.UpperBound);
+            Assert.That(result.Interval.UpperBound, Is.EqualTo(3.1f));
             Assert.IsFalse(result.Interval.OpenUpperBound);
             Assert.IsFalse(result.Interval.IsIntegerInterval);
         }
@@ -67,7 +67,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.VarIntervalT
             // when
             var result = vi.ToString();
             // then
-            Assert.AreEqual("1.1 < a < 3.1", result);
+            Assert.That(result, Is.EqualTo("1.1 < a < 3.1"));
         }
 
         [Test]
@@ -80,7 +80,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.VarIntervalT
             // when
             var result = vi.ToString();
             // then
-            Assert.AreEqual("1.1 < a <= 3.1", result);
+            Assert.That(result, Is.EqualTo("1.1 < a <= 3.1"));
         }
 
         [Test]
@@ -93,7 +93,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.VarIntervalT
             // when
             var result = vi.ToString();
             // then
-            Assert.AreEqual("1.1 <= a < 3.1", result);
+            Assert.That(result, Is.EqualTo("1.1 <= a < 3.1"));
         }
 
         [Test]
@@ -106,7 +106,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.VarIntervalT
             // when
             var result = vi.ToString();
             // then
-            Assert.AreEqual("1.1 <= a <= 3.1", result);
+            Assert.That(result, Is.EqualTo("1.1 <= a <= 3.1"));
         }
 
         // TODO: string representation doesn't show integer
@@ -121,7 +121,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.VarIntervalT
             // when
             var result = vi.ToString();
             // then
-            Assert.AreEqual("1.1 <= a <= 3.1", result);
+            Assert.That(result, Is.EqualTo("1.1 <= a <= 3.1"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/ValuesT/Vector2T/Vector2Test.cs
+++ b/MetaphysicsIndustries.Solus.Test/ValuesT/Vector2T/Vector2Test.cs
@@ -34,24 +34,25 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.Vector2T
             // when
             var result = new Vector2(1, 2);
             // then
-            Assert.AreEqual(1, result.X);
-            Assert.AreEqual(2, result.Y);
+            Assert.That(result.X, Is.EqualTo(1));
+            Assert.That(result.Y, Is.EqualTo(2));
             // and
             Assert.IsFalse(result.IsScalar(null));
             Assert.IsTrue(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(1, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(1));
             Assert.IsFalse(result.IsString(null));
             Assert.IsNull(result.GetDimension(null, -1));
-            Assert.AreEqual(2, result.GetDimension(null, 0));
+            Assert.That(result.GetDimension(null, 0), Is.EqualTo(2));
             Assert.IsNull(result.GetDimension(null, 1));
-            Assert.AreEqual(new int[1] { 2 }, result.GetDimensions(null));
-            Assert.AreEqual(2, result.GetVectorLength(null));
+            Assert.That(result.GetDimensions(null),
+                Is.EqualTo(new int[1] { 2 }));
+            Assert.That(result.GetVectorLength(null), Is.EqualTo(2));
             Assert.IsFalse(result.IsInterval(null));
             Assert.IsFalse(result.IsFunction(null));
             Assert.IsFalse(result.IsExpression(null));
             Assert.IsTrue(result.IsConcrete);
-            Assert.AreEqual("", result.DocString);
+            Assert.That(result.DocString, Is.EqualTo(""));
         }
 
         [Test]
@@ -62,8 +63,8 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.Vector2T
             // when
             var result = -v;
             // then
-            Assert.AreEqual(-1, result.X);
-            Assert.AreEqual(-2, result.Y);
+            Assert.That(result.X, Is.EqualTo(-1));
+            Assert.That(result.Y, Is.EqualTo(-2));
         }
 
         [Test]
@@ -75,8 +76,8 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.Vector2T
             // when
             var result = u - v;
             // then
-            Assert.AreEqual(3, result.X);
-            Assert.AreEqual(4, result.Y);
+            Assert.That(result.X, Is.EqualTo(3));
+            Assert.That(result.Y, Is.EqualTo(4));
         }
 
         [Test]
@@ -88,8 +89,8 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.Vector2T
             // when
             var result = u + v;
             // then
-            Assert.AreEqual(5, result.X);
-            Assert.AreEqual(8, result.Y);
+            Assert.That(result.X, Is.EqualTo(5));
+            Assert.That(result.Y, Is.EqualTo(8));
         }
 
         [Test]
@@ -100,8 +101,8 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.Vector2T
             // when
             var result = v * 2;
             // then
-            Assert.AreEqual(2, result.X);
-            Assert.AreEqual(4, result.Y);
+            Assert.That(result.X, Is.EqualTo(2));
+            Assert.That(result.Y, Is.EqualTo(4));
         }
 
         [Test]
@@ -112,8 +113,8 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.Vector2T
             // when
             var result = 2 * v;
             // then
-            Assert.AreEqual(2, result.X);
-            Assert.AreEqual(4, result.Y);
+            Assert.That(result.X, Is.EqualTo(2));
+            Assert.That(result.Y, Is.EqualTo(4));
         }
 
         [Test]
@@ -124,8 +125,8 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.Vector2T
             // when
             var result = v / 2;
             // then
-            Assert.AreEqual(0.5f, result.X);
-            Assert.AreEqual(1, result.Y);
+            Assert.That(result.X, Is.EqualTo(0.5f));
+            Assert.That(result.Y, Is.EqualTo(1));
         }
 
         [Test]

--- a/MetaphysicsIndustries.Solus.Test/ValuesT/Vector3T/Vector3Test.cs
+++ b/MetaphysicsIndustries.Solus.Test/ValuesT/Vector3T/Vector3Test.cs
@@ -34,25 +34,26 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.Vector3T
             // when
             var result = new Vector3(1, 2, 3);
             // then
-            Assert.AreEqual(1, result.X);
-            Assert.AreEqual(2, result.Y);
-            Assert.AreEqual(3, result.Z);
+            Assert.That(result.X, Is.EqualTo(1));
+            Assert.That(result.Y, Is.EqualTo(2));
+            Assert.That(result.Z, Is.EqualTo(3));
             // and
             Assert.IsFalse(result.IsScalar(null));
             Assert.IsTrue(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(1, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(1));
             Assert.IsFalse(result.IsString(null));
             Assert.IsNull(result.GetDimension(null, -1));
-            Assert.AreEqual(3, result.GetDimension(null, 0));
+            Assert.That(result.GetDimension(null, 0), Is.EqualTo(3));
             Assert.IsNull(result.GetDimension(null, 1));
-            Assert.AreEqual(new int[1] { 3 }, result.GetDimensions(null));
-            Assert.AreEqual(3, result.GetVectorLength(null));
+            Assert.That(result.GetDimensions(null),
+                Is.EqualTo(new int[1] { 3 }));
+            Assert.That(result.GetVectorLength(null), Is.EqualTo(3));
             Assert.IsFalse(result.IsInterval(null));
             Assert.IsFalse(result.IsFunction(null));
             Assert.IsFalse(result.IsExpression(null));
             Assert.IsTrue(result.IsConcrete);
-            Assert.AreEqual("", result.DocString);
+            Assert.That(result.DocString, Is.EqualTo(""));
         }
 
         [Test]
@@ -63,9 +64,9 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.Vector3T
             // when
             var result = -v;
             // then
-            Assert.AreEqual(-1, result.X);
-            Assert.AreEqual(-2, result.Y);
-            Assert.AreEqual(-3, result.Z);
+            Assert.That(result.X, Is.EqualTo(-1));
+            Assert.That(result.Y, Is.EqualTo(-2));
+            Assert.That(result.Z, Is.EqualTo(-3));
         }
 
         [Test]
@@ -77,9 +78,9 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.Vector3T
             // when
             var result = u - v;
             // then
-            Assert.AreEqual(3, result.X);
-            Assert.AreEqual(4, result.Y);
-            Assert.AreEqual(5, result.Z);
+            Assert.That(result.X, Is.EqualTo(3));
+            Assert.That(result.Y, Is.EqualTo(4));
+            Assert.That(result.Z, Is.EqualTo(5));
         }
 
         [Test]
@@ -91,9 +92,9 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.Vector3T
             // when
             var result = u + v;
             // then
-            Assert.AreEqual(5, result.X);
-            Assert.AreEqual(8, result.Y);
-            Assert.AreEqual(11, result.Z);
+            Assert.That(result.X, Is.EqualTo(5));
+            Assert.That(result.Y, Is.EqualTo(8));
+            Assert.That(result.Z, Is.EqualTo(11));
         }
 
         [Test]
@@ -104,9 +105,9 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.Vector3T
             // when
             var result = v * 2;
             // then
-            Assert.AreEqual(2, result.X);
-            Assert.AreEqual(4, result.Y);
-            Assert.AreEqual(6, result.Z);
+            Assert.That(result.X, Is.EqualTo(2));
+            Assert.That(result.Y, Is.EqualTo(4));
+            Assert.That(result.Z, Is.EqualTo(6));
         }
 
         [Test]
@@ -117,9 +118,9 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.Vector3T
             // when
             var result = 2 * v;
             // then
-            Assert.AreEqual(2, result.X);
-            Assert.AreEqual(4, result.Y);
-            Assert.AreEqual(6, result.Z);
+            Assert.That(result.X, Is.EqualTo(2));
+            Assert.That(result.Y, Is.EqualTo(4));
+            Assert.That(result.Z, Is.EqualTo(6));
         }
 
         [Test]
@@ -130,9 +131,9 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.Vector3T
             // when
             var result = v / 2;
             // then
-            Assert.AreEqual(0.5f, result.X);
-            Assert.AreEqual(1, result.Y);
-            Assert.AreEqual(1.5f, result.Z);
+            Assert.That(result.X, Is.EqualTo(0.5f));
+            Assert.That(result.Y, Is.EqualTo(1));
+            Assert.That(result.Z, Is.EqualTo(1.5f));
         }
 
         [Test]

--- a/MetaphysicsIndustries.Solus.Test/ValuesT/VectorT/VectorTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ValuesT/VectorT/VectorTest.cs
@@ -38,20 +38,20 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.VectorT
             // when
             var result = new Vector(values);
             // then
-            Assert.AreEqual(3, result.Length);
-            Assert.AreEqual(Types.Scalar, result.ComponentType);
-            Assert.AreEqual(1, result[0].ToNumber().Value);
-            Assert.AreEqual(2, result[1].ToNumber().Value);
-            Assert.AreEqual(3, result[2].ToNumber().Value);
+            Assert.That(result.Length, Is.EqualTo(3));
+            Assert.That(result.ComponentType, Is.EqualTo(Types.Scalar));
+            Assert.That(result[0].ToNumber().Value, Is.EqualTo(1));
+            Assert.That(result[1].ToNumber().Value, Is.EqualTo(2));
+            Assert.That(result[2].ToNumber().Value, Is.EqualTo(3));
             Assert.IsFalse(result.IsScalar(null));
             Assert.IsTrue(result.IsVector(null));
             Assert.IsFalse(result.IsMatrix(null));
-            Assert.AreEqual(1, result.GetTensorRank(null));
+            Assert.That(result.GetTensorRank(null), Is.EqualTo(1));
             Assert.IsFalse(result.IsString(null));
-            Assert.AreEqual(3, result.GetDimension(null, 0));
+            Assert.That(result.GetDimension(null, 0), Is.EqualTo(3));
             Assert.IsNull(result.GetDimension(null, -1));
             Assert.IsNull(result.GetDimension(null, 2));
-            Assert.AreEqual(new[] {3}, result.GetDimensions(null));
+            Assert.That(result.GetDimensions(null), Is.EqualTo(new[] {3}));
         }
 
         [Test]
@@ -62,10 +62,10 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.VectorT
             // when
             var result = new Vector(values);
             // then
-            Assert.AreEqual(3, result.Length);
-            Assert.AreEqual(1, result[0].ToNumber().Value);
-            Assert.AreEqual(2, result[1].ToNumber().Value);
-            Assert.AreEqual(3, result[2].ToNumber().Value);
+            Assert.That(result.Length, Is.EqualTo(3));
+            Assert.That(result[0].ToNumber().Value, Is.EqualTo(1));
+            Assert.That(result[1].ToNumber().Value, Is.EqualTo(2));
+            Assert.That(result[2].ToNumber().Value, Is.EqualTo(3));
         }
 
         [Test]
@@ -80,7 +80,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.VectorT
             // when
             var result = new Vector(values);
             // then
-            Assert.AreEqual(Types.Mixed, result.ComponentType);
+            Assert.That(result.ComponentType, Is.EqualTo(Types.Mixed));
         }
 
         [Test]
@@ -94,7 +94,7 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.VectorT
             // when
             var result = v.ToString();
             // then
-            Assert.AreEqual("[1, 2, 3]", result);
+            Assert.That(result, Is.EqualTo("[1, 2, 3]"));
         }
 
         [Test]
@@ -117,9 +117,10 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.VectorT
             // when
             var result = v.ToString();
             // then
-            Assert.AreEqual(
-                "[1, \"two\", [\"t\", \"h\", \"r\", \"e\", \"e\"]]",
-                result);
+            Assert.That(
+                result,
+                Is.EqualTo(
+                    "[1, \"two\", [\"t\", \"h\", \"r\", \"e\", \"e\"]]"));
         }
     }
 }


### PR DESCRIPTION
This PR changes the tests to use a constraint model, so as to get rid of a large number of warnings from nunit.