### PR TITLE
Tensor arithmetic

### DIFF
--- a/Compiler/ILCompiler.Expressions.ComponentAccess.cs
+++ b/Compiler/ILCompiler.Expressions.ComponentAccess.cs
@@ -40,15 +40,17 @@ namespace MetaphysicsIndustries.Solus.Compiler
         }
 
         public IlExpression ConvertToIlExpression(ComponentAccess expr,
-            NascentMethod nm, VariableIdentityMap variables)
+            NascentMethod nm, SolusEnvironment env,
+            VariableIdentityMap variables)
         {
-            var expr2 = ConvertToIlExpression(expr.Expr, nm, variables);
+            var expr2 = ConvertToIlExpression(expr.Expr, nm, env, variables);
             var indexes2 = new IlExpression[expr.Indexes.Count];
             int i;
             for (i = 0; i < indexes2.Length; i++)
             {
                 indexes2[i] = new ConvertI4IlExpression(
-                    ConvertToIlExpression(expr.Indexes[i], nm, variables));
+                    ConvertToIlExpression(expr.Indexes[i], nm, env,
+                        variables));
             }
 
             // TODO: check expr.ResultType against the number of indexes

--- a/Compiler/ILCompiler.Expressions.FunctionCall.cs
+++ b/Compiler/ILCompiler.Expressions.FunctionCall.cs
@@ -32,11 +32,12 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             FunctionCall expr, NascentMethod nm,
-            VariableIdentityMap variables)
+            SolusEnvironment env, VariableIdentityMap variables)
         {
             if (expr.Function is Literal literal &&
                 literal.Value is Function f)
-                return ConvertToIlExpression(f, nm, variables, expr.Arguments);
+                return ConvertToIlExpression(f, nm, env, variables,
+                    expr.Arguments);
 
             // TODO:
             throw new NotImplementedException(

--- a/Compiler/ILCompiler.Expressions.Literal.cs
+++ b/Compiler/ILCompiler.Expressions.Literal.cs
@@ -31,7 +31,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             Literal expr, NascentMethod nm,
-            VariableIdentityMap variables)
+            SolusEnvironment env, VariableIdentityMap variables)
         {
             // TODO: work out how to use `variables` in place of null `env`
 

--- a/Compiler/ILCompiler.Expressions.MatrixExpression.cs
+++ b/Compiler/ILCompiler.Expressions.MatrixExpression.cs
@@ -29,7 +29,8 @@ namespace MetaphysicsIndustries.Solus.Compiler
     public partial class ILCompiler
     {
         public IlExpression ConvertToIlExpression(MatrixExpression expr,
-            NascentMethod nm, VariableIdentityMap variables)
+            NascentMethod nm, SolusEnvironment env,
+            VariableIdentityMap variables)
         {
             var arrayType = typeof(float[,]);
             var ctor = arrayType.GetConstructor(
@@ -51,7 +52,8 @@ namespace MetaphysicsIndustries.Solus.Compiler
                         dup,
                         new LoadConstantIlExpression(r),
                         new LoadConstantIlExpression(c),
-                        ConvertToIlExpression(expr[r, c], nm, variables)));
+                        ConvertToIlExpression(expr[r, c], nm, env,
+                            variables)));
             return new IlExpressionSequence(seq);
         }
     }

--- a/Compiler/ILCompiler.Expressions.VariableAccess.cs
+++ b/Compiler/ILCompiler.Expressions.VariableAccess.cs
@@ -30,7 +30,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             VariableAccess expr, NascentMethod nm,
-            VariableIdentityMap variables)
+            SolusEnvironment env, VariableIdentityMap variables)
         {
             var vi = variables[expr.VariableName];
             if (vi.Source == VariableSource.Param)

--- a/Compiler/ILCompiler.Expressions.VectorExpression.cs
+++ b/Compiler/ILCompiler.Expressions.VectorExpression.cs
@@ -29,7 +29,8 @@ namespace MetaphysicsIndustries.Solus.Compiler
     public partial class ILCompiler
     {
         public IlExpression ConvertToIlExpression(VectorExpression expr,
-            NascentMethod nm, VariableIdentityMap variables)
+            NascentMethod nm, SolusEnvironment env,
+            VariableIdentityMap variables)
         {
             var seq = new List<IlExpression>();
             var newarr = new NewArrIlExpression(
@@ -42,7 +43,8 @@ namespace MetaphysicsIndustries.Solus.Compiler
                     new StoreElemIlExpression(
                         array_: new DupIlExpression(newarr),
                         index: new LoadConstantIlExpression(i),
-                        value: ConvertToIlExpression(expr[i], nm, variables)));
+                        value: ConvertToIlExpression(expr[i], nm, env,
+                            variables)));
 
             return new IlExpressionSequence(seq);
         }

--- a/Compiler/ILCompiler.Expressions.cs
+++ b/Compiler/ILCompiler.Expressions.cs
@@ -31,22 +31,22 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             Expression expr, NascentMethod nm,
-            VariableIdentityMap variables)
+            SolusEnvironment env, VariableIdentityMap variables)
         {
             if (expr is FunctionCall call)
-                return ConvertToIlExpression(call, nm, variables);
+                return ConvertToIlExpression(call, nm, env, variables);
             if (expr is Literal lit)
-                return ConvertToIlExpression(lit, nm, variables);
+                return ConvertToIlExpression(lit, nm, env, variables);
             if (expr is VariableAccess va)
-                return ConvertToIlExpression(va, nm, variables);
+                return ConvertToIlExpression(va, nm, env, variables);
             if (expr is ComponentAccess ca)
-                return ConvertToIlExpression(ca, nm, variables);
+                return ConvertToIlExpression(ca, nm, env, variables);
             if (expr is VectorExpression ve)
-                return ConvertToIlExpression(ve, nm, variables);
+                return ConvertToIlExpression(ve, nm, env, variables);
             if (expr is MatrixExpression me)
-                return ConvertToIlExpression(me, nm, variables);
+                return ConvertToIlExpression(me, nm, env, variables);
             if (expr is IntervalExpression ie)
-                return ConvertToIlExpression(ie, nm, variables);
+                return ConvertToIlExpression(ie, nm, env, variables);
             throw new ArgumentException(
                 $"Unsupported expression type: \"{expr}\"", nameof(expr));
         }
@@ -54,11 +54,14 @@ namespace MetaphysicsIndustries.Solus.Compiler
         // TODO: copy-paste IlCompiler.Expressions.*.cs here
 
         public IlExpression ConvertToIlExpression(IntervalExpression expr,
-            NascentMethod nm, VariableIdentityMap variables)
+            NascentMethod nm, SolusEnvironment env,
+            VariableIdentityMap variables)
         {
-            var lower = ConvertToIlExpression(expr.LowerBound, nm, variables);
+            var lower = ConvertToIlExpression(expr.LowerBound, nm, env,
+                variables);
             var isLowerOpen = new LoadConstantIlExpression(expr.OpenLowerBound);
-            var upper = ConvertToIlExpression(expr.UpperBound, nm, variables);
+            var upper = ConvertToIlExpression(expr.UpperBound, nm, env,
+                variables);
             var isUpperOpen = new LoadConstantIlExpression(expr.OpenUpperBound);
             // TODO: IsIntegerInterval ?
             var stuple = typeof(STuple<float, bool, float, bool>);

--- a/Compiler/ILCompiler.Functions.AbsoluteValueFunction.cs
+++ b/Compiler/ILCompiler.Functions.AbsoluteValueFunction.cs
@@ -32,12 +32,12 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             AbsoluteValueFunction func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
             return new CallIlExpression(
                 new Func<double, double>(Math.Abs),
-                ConvertToIlExpression(arguments[0], nm, variables));
+                ConvertToIlExpression(arguments[0], nm, env, variables));
         }
     }
 }

--- a/Compiler/ILCompiler.Functions.AdditionOperation.cs
+++ b/Compiler/ILCompiler.Functions.AdditionOperation.cs
@@ -34,12 +34,12 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             AdditionOperation func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
             IlExpression expr = new RawInstructions();
 
-            var argType = arguments[0].GetResultType(null);
+            var argType = arguments[0].GetResultType(env);
             if (argType.IsSubsetOf(Reals.Value)){
                 bool first = true;
                 foreach (var arg in arguments)
@@ -52,15 +52,17 @@ namespace MetaphysicsIndustries.Solus.Compiler
                     {
                         expr = new SubIlExpression(expr,
                             ConvertToIlExpression(call.Arguments[0], nm,
-                                variables));
+                                env, variables));
                     }
                     else
                     {
                         if (first)
-                            expr = ConvertToIlExpression(arg, nm, variables);
+                            expr = ConvertToIlExpression(arg, nm, env,
+                                variables);
                         else
                             expr = new AddIlExpression(expr,
-                                ConvertToIlExpression(arg, nm, variables));
+                                ConvertToIlExpression(arg, nm, env,
+                                    variables));
                         first = false;
                     }
                 }
@@ -73,7 +75,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 var stloc = new StoreLocalIlExpression(
                     destLocal,
                     ConvertToIlExpression(
-                        new Literal(Vector.Zero(n)), nm, variables));
+                        new Literal(Vector.Zero(n)), nm, env, variables));
                 seq.Add(stloc);
                 var addendLocal =
                     nm.CreateLocal(typeof(float[]), "vectorAddend");
@@ -82,7 +84,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
                     seq.Add(
                         new StoreLocalIlExpression(
                             addendLocal,
-                            ConvertToIlExpression(arg, nm, variables)));
+                            ConvertToIlExpression(arg, nm, env, variables)));
                     // TODO: logic to choose between a loop (e.g.
                     //       WhileLoopConstruct) and a hard-coded sequence of
                     //       instructions, or something in between, like a
@@ -114,7 +116,8 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 var stloc = new StoreLocalIlExpression(
                     destLocal,
                     ConvertToIlExpression(
-                        new Literal(Matrix.Zero(nr, nc)), nm, variables));
+                        new Literal(Matrix.Zero(nr, nc)),
+                        nm, env, variables));
                 seq.Add(stloc);
                 var addendLocal =
                     nm.CreateLocal(typeof(float[]), "addend");
@@ -123,7 +126,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
                     seq.Add(
                         new StoreLocalIlExpression(
                             addendLocal,
-                            ConvertToIlExpression(arg, nm, variables)));
+                            ConvertToIlExpression(arg, nm, env, variables)));
                     // TODO: logic to choose between loops (e.g.
                     //       WhileLoopConstruct) and a hard-coded sequence of
                     //       instructions, or something in between, like

--- a/Compiler/ILCompiler.Functions.ArccosecantFunction.cs
+++ b/Compiler/ILCompiler.Functions.ArccosecantFunction.cs
@@ -32,7 +32,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             ArccosecantFunction func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new CallIlExpression(
@@ -40,7 +40,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
                     "Asin", new [] { typeof(float) }),
                 new DivIlExpression(
                     new LoadConstantIlExpression(1f),
-                    ConvertToIlExpression(arguments[0], nm, variables)));
+                    ConvertToIlExpression(arguments[0], nm, env, variables)));
             return expr;
         }
     }

--- a/Compiler/ILCompiler.Functions.ArccosineFunction.cs
+++ b/Compiler/ILCompiler.Functions.ArccosineFunction.cs
@@ -33,7 +33,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             ArccosineFunction func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var excType = typeof(OperandException);
@@ -45,7 +45,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Acos));
             var seq = new List<IlExpression>();
-            var arg = ConvertToIlExpression(arguments[0], nm, variables);
+            var arg = ConvertToIlExpression(arguments[0], nm, env, variables);
             seq.Add(arg);
             seq.Add(
                 new CompareLessThanIlExpression(

--- a/Compiler/ILCompiler.Functions.ArccotangentFunction.cs
+++ b/Compiler/ILCompiler.Functions.ArccotangentFunction.cs
@@ -32,13 +32,13 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             ArccotangentFunction func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new CallIlExpression(
                 new Func<double, double, double>(Math.Atan2),
                 new LoadConstantIlExpression(1f),
-                ConvertToIlExpression(arguments[0], nm, variables));
+                ConvertToIlExpression(arguments[0], nm, env, variables));
             return expr;
         }
     }

--- a/Compiler/ILCompiler.Functions.ArcsecantFunction.cs
+++ b/Compiler/ILCompiler.Functions.ArcsecantFunction.cs
@@ -32,14 +32,14 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             ArcsecantFunction func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Acos),
                 new DivIlExpression(
                     new LoadConstantIlExpression(1f),
-                    ConvertToIlExpression(arguments[0], nm,
+                    ConvertToIlExpression(arguments[0], nm, env,
                         variables)));
             return expr;
         }

--- a/Compiler/ILCompiler.Functions.ArcsineFunction.cs
+++ b/Compiler/ILCompiler.Functions.ArcsineFunction.cs
@@ -33,10 +33,10 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             ArcsineFunction func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
-            var arg = ConvertToIlExpression(arguments[0], nm, variables);
+            var arg = ConvertToIlExpression(arguments[0], nm, env, variables);
 
             var excType = typeof(OperandException);
             var ctor = excType.GetConstructor(

--- a/Compiler/ILCompiler.Functions.Arctangent2Function.cs
+++ b/Compiler/ILCompiler.Functions.Arctangent2Function.cs
@@ -32,13 +32,13 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             Arctangent2Function func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new CallIlExpression(
                 new Func<double, double, double>(Math.Atan2),
-                ConvertToIlExpression(arguments[0], nm, variables),
-                ConvertToIlExpression(arguments[1], nm, variables));
+                ConvertToIlExpression(arguments[0], nm, env, variables),
+                ConvertToIlExpression(arguments[1], nm, env, variables));
             return expr;
         }
     }

--- a/Compiler/ILCompiler.Functions.ArctangentFunction.cs
+++ b/Compiler/ILCompiler.Functions.ArctangentFunction.cs
@@ -32,12 +32,12 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             ArctangentFunction func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Atan),
-                ConvertToIlExpression(arguments[0], nm, variables));
+                ConvertToIlExpression(arguments[0], nm, env, variables));
             return expr;
         }
     }

--- a/Compiler/ILCompiler.Functions.BitwiseAndOperation.cs
+++ b/Compiler/ILCompiler.Functions.BitwiseAndOperation.cs
@@ -31,16 +31,16 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             BitwiseAndOperation func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new ConvertR4IlExpression(
                 new AndIlExpression(
                     new ConvertI4IlExpression(
-                        ConvertToIlExpression(arguments[0], nm,
+                        ConvertToIlExpression(arguments[0], nm, env,
                             variables)),
                     new ConvertI4IlExpression(
-                        ConvertToIlExpression(arguments[1], nm,
+                        ConvertToIlExpression(arguments[1], nm, env,
                             variables))));
             return expr;
         }

--- a/Compiler/ILCompiler.Functions.BitwiseOrOperation.cs
+++ b/Compiler/ILCompiler.Functions.BitwiseOrOperation.cs
@@ -31,16 +31,16 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             BitwiseOrOperation func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new ConvertR4IlExpression(
                 new OrIlExpression(
                     new ConvertI4IlExpression(
-                        ConvertToIlExpression(arguments[0], nm,
+                        ConvertToIlExpression(arguments[0], nm, env,
                             variables)),
                     new ConvertI4IlExpression(
-                        ConvertToIlExpression(arguments[1], nm,
+                        ConvertToIlExpression(arguments[1], nm, env,
                             variables))));
             return expr;
         }

--- a/Compiler/ILCompiler.Functions.CeilingFunction.cs
+++ b/Compiler/ILCompiler.Functions.CeilingFunction.cs
@@ -32,12 +32,12 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             CeilingFunction func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Ceiling),
-                ConvertToIlExpression(arguments[0], nm, variables));
+                ConvertToIlExpression(arguments[0], nm, env, variables));
             return expr;
         }
     }

--- a/Compiler/ILCompiler.Functions.CosecantFunction.cs
+++ b/Compiler/ILCompiler.Functions.CosecantFunction.cs
@@ -32,14 +32,14 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             CosecantFunction func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new DivIlExpression(
                 new LoadConstantIlExpression(1f),
                 new CallIlExpression(
                     new Func<double, double>(Math.Sin),
-                    ConvertToIlExpression(arguments[0], nm,
+                    ConvertToIlExpression(arguments[0], nm, env,
                         variables)));
             return expr;
         }

--- a/Compiler/ILCompiler.Functions.CosineFunction.cs
+++ b/Compiler/ILCompiler.Functions.CosineFunction.cs
@@ -32,12 +32,12 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             CosineFunction func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Cos),
-                ConvertToIlExpression(arguments[0], nm, variables));
+                ConvertToIlExpression(arguments[0], nm,  env,variables));
             return expr;
         }
     }

--- a/Compiler/ILCompiler.Functions.CotangentFunction.cs
+++ b/Compiler/ILCompiler.Functions.CotangentFunction.cs
@@ -32,14 +32,14 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             CotangentFunction func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new DivIlExpression(
                 new LoadConstantIlExpression(1f),
                 new CallIlExpression(
                     new Func<double, double>(Math.Tan),
-                    ConvertToIlExpression(arguments[0], nm, variables)));
+                    ConvertToIlExpression(arguments[0], nm,  env,variables)));
             return expr;
         }
     }

--- a/Compiler/ILCompiler.Functions.DistFunction.cs
+++ b/Compiler/ILCompiler.Functions.DistFunction.cs
@@ -32,12 +32,12 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             DistFunction func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
-            var x = ConvertToIlExpression(arguments[0], nm,
+            var x = ConvertToIlExpression(arguments[0], nm, env,
                 variables);
-            var y = ConvertToIlExpression(arguments[1], nm,
+            var y = ConvertToIlExpression(arguments[1], nm, env,
                 variables);
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Sqrt),

--- a/Compiler/ILCompiler.Functions.DistSqFunction.cs
+++ b/Compiler/ILCompiler.Functions.DistSqFunction.cs
@@ -31,12 +31,12 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             DistSqFunction func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
-            var x = ConvertToIlExpression(arguments[0], nm,
+            var x = ConvertToIlExpression(arguments[0], nm, env,
                 variables);
-            var y = ConvertToIlExpression(arguments[1], nm,
+            var y = ConvertToIlExpression(arguments[1], nm, env,
                 variables);
             var expr = new AddIlExpression(
                 new MulIlExpression(

--- a/Compiler/ILCompiler.Functions.DivisionOperation.cs
+++ b/Compiler/ILCompiler.Functions.DivisionOperation.cs
@@ -33,12 +33,12 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             DivisionOperation func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
-            var left = ConvertToIlExpression(arguments[0], nm,
+            var left = ConvertToIlExpression(arguments[0], nm, env,
                 variables);
-            var right = ConvertToIlExpression(arguments[1], nm,
+            var right = ConvertToIlExpression(arguments[1], nm, env,
                 variables);
 
             var excType = typeof(OperandException);

--- a/Compiler/ILCompiler.Functions.EqualComparisonOperation.cs
+++ b/Compiler/ILCompiler.Functions.EqualComparisonOperation.cs
@@ -34,11 +34,11 @@ namespace MetaphysicsIndustries.Solus.Compiler
         public IlExpression ConvertToIlExpression(
             EqualComparisonOperation func,
             NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
-            var a = ConvertToIlExpression(arguments[0], nm, variables);
-            var b = ConvertToIlExpression(arguments[1], nm, variables);
+            var a = ConvertToIlExpression(arguments[0], nm, env, variables);
+            var b = ConvertToIlExpression(arguments[1], nm, env, variables);
             var seq = new List<IlExpression>();
             if (a.ResultType != b.ResultType)
             {

--- a/Compiler/ILCompiler.Functions.ExponentOperation.cs
+++ b/Compiler/ILCompiler.Functions.ExponentOperation.cs
@@ -32,13 +32,13 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             ExponentOperation func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
             return new CallIlExpression(
                 new Func<double, double, double>(Math.Pow),
-                ConvertToIlExpression(arguments[0], nm, variables),
-                ConvertToIlExpression(arguments[1], nm, variables));
+                ConvertToIlExpression(arguments[0], nm, env, variables),
+                ConvertToIlExpression(arguments[1], nm, env, variables));
         }
     }
 }

--- a/Compiler/ILCompiler.Functions.FactorialFunction.cs
+++ b/Compiler/ILCompiler.Functions.FactorialFunction.cs
@@ -32,14 +32,14 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             FactorialFunction func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var product = nm.CreateLocal(typeof(float), "product");
             var n = nm.CreateLocal(typeof(float), "n");
             // n = ...
             var initN = new StoreLocalIlExpression(
-                n, ConvertToIlExpression(arguments[0], nm, variables));
+                n, ConvertToIlExpression(arguments[0], nm, env, variables));
             // product = 1
             var initProduct = new StoreLocalIlExpression(
                 product, new LoadConstantIlExpression(1f));

--- a/Compiler/ILCompiler.Functions.FloorFunction.cs
+++ b/Compiler/ILCompiler.Functions.FloorFunction.cs
@@ -32,12 +32,12 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             FloorFunction func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Floor),
-                ConvertToIlExpression(arguments[0], nm, variables));
+                ConvertToIlExpression(arguments[0], nm, env, variables));
             return expr;
         }
     }

--- a/Compiler/ILCompiler.Functions.GreaterThanComparisonOperation.cs
+++ b/Compiler/ILCompiler.Functions.GreaterThanComparisonOperation.cs
@@ -32,12 +32,12 @@ namespace MetaphysicsIndustries.Solus.Compiler
         public IlExpression ConvertToIlExpression(
             GreaterThanComparisonOperation func,
             NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new CompareGreaterThanIlExpression(
-                ConvertToIlExpression(arguments[0], nm, variables),
-                ConvertToIlExpression(arguments[1], nm, variables));
+                ConvertToIlExpression(arguments[0], nm, env, variables),
+                ConvertToIlExpression(arguments[1], nm, env, variables));
             return expr;
         }
     }

--- a/Compiler/ILCompiler.Functions.GreaterThanOrEqualComparisonOperation.cs
+++ b/Compiler/ILCompiler.Functions.GreaterThanOrEqualComparisonOperation.cs
@@ -32,15 +32,15 @@ namespace MetaphysicsIndustries.Solus.Compiler
         public IlExpression ConvertToIlExpression(
             GreaterThanOrEqualComparisonOperation func,
             NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new CompareEqualIlExpression(
                 new LoadConstantIlExpression(0),
                 new CompareLessThanIlExpression(
-                    ConvertToIlExpression(arguments[0], nm,
+                    ConvertToIlExpression(arguments[0], nm, env,
                         variables),
-                    ConvertToIlExpression(arguments[1], nm,
+                    ConvertToIlExpression(arguments[1], nm, env,
                         variables)));
             return expr;
         }

--- a/Compiler/ILCompiler.Functions.LessThanComparisonOperation.cs
+++ b/Compiler/ILCompiler.Functions.LessThanComparisonOperation.cs
@@ -32,12 +32,12 @@ namespace MetaphysicsIndustries.Solus.Compiler
         public IlExpression ConvertToIlExpression(
             LessThanComparisonOperation func,
             NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new CompareLessThanIlExpression(
-                ConvertToIlExpression(arguments[0], nm, variables),
-                ConvertToIlExpression(arguments[1], nm, variables));
+                ConvertToIlExpression(arguments[0], nm, env, variables),
+                ConvertToIlExpression(arguments[1], nm, env, variables));
             return expr;
         }
     }

--- a/Compiler/ILCompiler.Functions.LessThanOrEqualComparisonOperation.cs
+++ b/Compiler/ILCompiler.Functions.LessThanOrEqualComparisonOperation.cs
@@ -32,14 +32,14 @@ namespace MetaphysicsIndustries.Solus.Compiler
         public IlExpression ConvertToIlExpression(
             LessThanOrEqualComparisonOperation func,
             NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new CompareEqualIlExpression(
                 new LoadConstantIlExpression(0),
                 new CompareGreaterThanIlExpression(
-                    ConvertToIlExpression(arguments[0], nm, variables),
-                    ConvertToIlExpression(arguments[1], nm, variables)));
+                    ConvertToIlExpression(arguments[0], nm, env, variables),
+                    ConvertToIlExpression(arguments[1], nm, env, variables)));
             return expr;
         }
     }

--- a/Compiler/ILCompiler.Functions.LoadImageFunction.cs
+++ b/Compiler/ILCompiler.Functions.LoadImageFunction.cs
@@ -32,7 +32,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             LoadImageFunction func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
             throw new NotImplementedException();

--- a/Compiler/ILCompiler.Functions.Log10Function.cs
+++ b/Compiler/ILCompiler.Functions.Log10Function.cs
@@ -33,10 +33,10 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             Log10Function func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
-            var arg = ConvertToIlExpression(arguments[0], nm,
+            var arg = ConvertToIlExpression(arguments[0], nm, env,
                 variables);
 
             var excType = typeof(OperandException);

--- a/Compiler/ILCompiler.Functions.Log2Function.cs
+++ b/Compiler/ILCompiler.Functions.Log2Function.cs
@@ -33,10 +33,10 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             Log2Function func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
-            var arg = ConvertToIlExpression(arguments[0], nm,
+            var arg = ConvertToIlExpression(arguments[0], nm, env,
                 variables);
 
             var excType = typeof(OperandException);

--- a/Compiler/ILCompiler.Functions.LogarithmFunction.cs
+++ b/Compiler/ILCompiler.Functions.LogarithmFunction.cs
@@ -33,14 +33,14 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             LogarithmFunction func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var excType = typeof(OperandException);
             var ctor = excType.GetConstructor(
                 new Type[] { typeof(string), typeof(Exception) });
 
-            var arg = ConvertToIlExpression(arguments[0], nm,
+            var arg = ConvertToIlExpression(arguments[0], nm, env,
                 variables);
 
             var checkArgNotPos = new IfThenElseConstruct(
@@ -54,7 +54,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
                             "Argument must be positive"),
                         new LoadNullIlExpression())));
 
-            var base_ = ConvertToIlExpression(arguments[1], nm,
+            var base_ = ConvertToIlExpression(arguments[1], nm, env,
                 variables);
 
             var checkBaseNotPos = new IfThenElseConstruct(

--- a/Compiler/ILCompiler.Functions.LogicalAndOperation.cs
+++ b/Compiler/ILCompiler.Functions.LogicalAndOperation.cs
@@ -31,7 +31,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             LogicalAndOperation func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new CompareEqualIlExpression(
@@ -41,11 +41,11 @@ namespace MetaphysicsIndustries.Solus.Compiler
                         new LoadConstantIlExpression(0),
                         new ConvertI4IlExpression(
                             ConvertToIlExpression(arguments[0],
-                                nm, variables))),
+                                nm, env, variables))),
                     new CompareEqualIlExpression(
                         new LoadConstantIlExpression(0),
                         new ConvertI4IlExpression(
-                            ConvertToIlExpression(arguments[1], nm,
+                            ConvertToIlExpression(arguments[1], nm, env,
                                 variables)))));
             return expr;
         }

--- a/Compiler/ILCompiler.Functions.LogicalOrOperation.cs
+++ b/Compiler/ILCompiler.Functions.LogicalOrOperation.cs
@@ -31,7 +31,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             LogicalOrOperation func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new CompareLessThanIlExpression(
@@ -39,12 +39,12 @@ namespace MetaphysicsIndustries.Solus.Compiler
                     new CompareEqualIlExpression(
                         new LoadConstantIlExpression(0),
                         new ConvertI4IlExpression(
-                            ConvertToIlExpression(arguments[0], nm,
+                            ConvertToIlExpression(arguments[0], nm, env,
                                 variables))),
                     new CompareEqualIlExpression(
                         new LoadConstantIlExpression(0),
                         new ConvertI4IlExpression(
-                            ConvertToIlExpression(arguments[1], nm,
+                            ConvertToIlExpression(arguments[1], nm, env,
                                 variables)))),
                 new LoadConstantIlExpression(2));
             return expr;

--- a/Compiler/ILCompiler.Functions.MaximumFiniteFunction.cs
+++ b/Compiler/ILCompiler.Functions.MaximumFiniteFunction.cs
@@ -32,7 +32,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             MaximumFiniteFunction func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var exprs = new List<IlExpression>(8 * arguments.Count + 7);
@@ -41,7 +41,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
             IlExpression first = nop;
             for (int i = arguments.Count - 1; i >= 0; i--)
             {
-                var calcArg = ConvertToIlExpression(arguments[i], nm,
+                var calcArg = ConvertToIlExpression(arguments[i], nm, env,
                     variables);
                 var call1 = new CallIlExpression(
                     new Func<float, bool>(float.IsInfinity),

--- a/Compiler/ILCompiler.Functions.MaximumFunction.cs
+++ b/Compiler/ILCompiler.Functions.MaximumFunction.cs
@@ -32,10 +32,10 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             MaximumFunction func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
-            var expr = ConvertToIlExpression(arguments[0], nm,
+            var expr = ConvertToIlExpression(arguments[0], nm, env,
                 variables);
             int i;
             for (i = 1; i < arguments.Count; i++)
@@ -43,7 +43,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 expr = new CallIlExpression(
                     new Func<float, float, float>(Math.Max),
                     expr,
-                    ConvertToIlExpression(arguments[i], nm, variables));
+                    ConvertToIlExpression(arguments[i], nm, env, variables));
             }
 
             return expr;

--- a/Compiler/ILCompiler.Functions.MinimumFiniteFunction.cs
+++ b/Compiler/ILCompiler.Functions.MinimumFiniteFunction.cs
@@ -32,7 +32,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             MinimumFiniteFunction func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var exprs = new List<IlExpression>(8 * arguments.Count + 7);
@@ -41,7 +41,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
             IlExpression first = nop;
             for (int i = arguments.Count - 1; i >= 0; i--)
             {
-                var calcArg = ConvertToIlExpression(arguments[i], nm,
+                var calcArg = ConvertToIlExpression(arguments[i], nm, env,
                     variables);
                 var call1 = new CallIlExpression(
                     new Func<float, bool>(float.IsInfinity),

--- a/Compiler/ILCompiler.Functions.MinimumFunction.cs
+++ b/Compiler/ILCompiler.Functions.MinimumFunction.cs
@@ -32,10 +32,10 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             MinimumFunction func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
-            var expr = ConvertToIlExpression(arguments[0], nm,
+            var expr = ConvertToIlExpression(arguments[0], nm, env,
                 variables);
             int i;
             for (i = 1; i < arguments.Count; i++)
@@ -43,7 +43,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 expr = new CallIlExpression(
                     new Func<float, float, float>(Math.Min),
                     expr,
-                    ConvertToIlExpression(arguments[i], nm, variables));
+                    ConvertToIlExpression(arguments[i], nm, env, variables));
             }
 
             return expr;

--- a/Compiler/ILCompiler.Functions.ModularDivision.cs
+++ b/Compiler/ILCompiler.Functions.ModularDivision.cs
@@ -33,7 +33,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             ModularDivision func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var excType = typeof(OperandException);
@@ -42,11 +42,11 @@ namespace MetaphysicsIndustries.Solus.Compiler
 
             var left =
                 new ConvertI4IlExpression(
-                    ConvertToIlExpression(arguments[0], nm,
+                    ConvertToIlExpression(arguments[0], nm, env,
                         variables));
             var right =
                 new ConvertI4IlExpression(
-                    ConvertToIlExpression(arguments[1], nm,
+                    ConvertToIlExpression(arguments[1], nm, env,
                         variables));
 
             var checkZero = new IfThenElseConstruct(

--- a/Compiler/ILCompiler.Functions.MultiplicationOperation.cs
+++ b/Compiler/ILCompiler.Functions.MultiplicationOperation.cs
@@ -31,16 +31,16 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             MultiplicationOperation func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
-            var expr = ConvertToIlExpression(arguments[0], nm,
+            var expr = ConvertToIlExpression(arguments[0], nm, env,
                 variables);
             int i;
             for (i = 1; i < arguments.Count; i++)
                 expr = new MulIlExpression(
                     expr,
-                    ConvertToIlExpression(arguments[i], nm, variables));
+                    ConvertToIlExpression(arguments[i], nm, env, variables));
             return expr;
         }
     }

--- a/Compiler/ILCompiler.Functions.NaturalLogarithmFunction.cs
+++ b/Compiler/ILCompiler.Functions.NaturalLogarithmFunction.cs
@@ -33,7 +33,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             NaturalLogarithmFunction func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
 
@@ -41,7 +41,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
             var ctor = excType.GetConstructor(
                 new Type[] { typeof(string), typeof(Exception) });
 
-            var arg = ConvertToIlExpression(arguments[0], nm,
+            var arg = ConvertToIlExpression(arguments[0], nm, env,
                 variables);
 
             var checkNotPos = new IfThenElseConstruct(

--- a/Compiler/ILCompiler.Functions.NegationOperation.cs
+++ b/Compiler/ILCompiler.Functions.NegationOperation.cs
@@ -31,11 +31,11 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             NegationOperation func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new NegIlExpression(
-                ConvertToIlExpression(arguments[0], nm,
+                ConvertToIlExpression(arguments[0], nm, env,
                     variables));
             return expr;
         }

--- a/Compiler/ILCompiler.Functions.NotEqualComparisonOperation.cs
+++ b/Compiler/ILCompiler.Functions.NotEqualComparisonOperation.cs
@@ -34,11 +34,11 @@ namespace MetaphysicsIndustries.Solus.Compiler
         public IlExpression ConvertToIlExpression(
             NotEqualComparisonOperation func,
             NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
-            var a = ConvertToIlExpression(arguments[0], nm, variables);
-            var b = ConvertToIlExpression(arguments[1], nm, variables);
+            var a = ConvertToIlExpression(arguments[0], nm, env, variables);
+            var b = ConvertToIlExpression(arguments[1], nm, env, variables);
             var seq = new List<IlExpression>();
             if (a.ResultType != b.ResultType)
             {

--- a/Compiler/ILCompiler.Functions.SecantFunction.cs
+++ b/Compiler/ILCompiler.Functions.SecantFunction.cs
@@ -32,14 +32,14 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             SecantFunction func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new DivIlExpression(
                 new LoadConstantIlExpression(1f),
                 new CallIlExpression(
                     new Func<double, double>(Math.Cos),
-                    ConvertToIlExpression(arguments[0], nm,
+                    ConvertToIlExpression(arguments[0], nm, env,
                         variables)));
             return expr;
         }

--- a/Compiler/ILCompiler.Functions.SineFunction.cs
+++ b/Compiler/ILCompiler.Functions.SineFunction.cs
@@ -32,12 +32,12 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             SineFunction func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Sin),
-                ConvertToIlExpression(arguments[0], nm,
+                ConvertToIlExpression(arguments[0], nm, env,
                     variables));
             return expr;
         }

--- a/Compiler/ILCompiler.Functions.SizeFunction.cs
+++ b/Compiler/ILCompiler.Functions.SizeFunction.cs
@@ -32,10 +32,10 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             SizeFunction func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
-            var arg = ConvertToIlExpression(arguments[0], nm,
+            var arg = ConvertToIlExpression(arguments[0], nm, env,
                 variables);
             if (arg.ResultType == typeof(byte) ||
                 arg.ResultType == typeof(sbyte) ||

--- a/Compiler/ILCompiler.Functions.TangentFunction.cs
+++ b/Compiler/ILCompiler.Functions.TangentFunction.cs
@@ -32,12 +32,12 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             TangentFunction func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new CallIlExpression(
                 new Func<double, double>(Math.Tan),
-                ConvertToIlExpression(arguments[0], nm, variables));
+                ConvertToIlExpression(arguments[0], nm, env, variables));
             return expr;
         }
     }

--- a/Compiler/ILCompiler.Functions.UnitStepFunction.cs
+++ b/Compiler/ILCompiler.Functions.UnitStepFunction.cs
@@ -31,13 +31,14 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             UnitStepFunction func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
             var expr = new ConvertR4IlExpression(
                 new CompareLessThanIlExpression(
                     new CompareLessThanIlExpression(
-                        ConvertToIlExpression(arguments[0], nm, variables),
+                        ConvertToIlExpression(arguments[0], nm, env,
+                            variables),
                         new LoadConstantIlExpression(0f)),
                     new LoadConstantIlExpression(1)));
             return expr;

--- a/Compiler/ILCompiler.Functions.UserDefinedFunction.cs
+++ b/Compiler/ILCompiler.Functions.UserDefinedFunction.cs
@@ -32,22 +32,24 @@ namespace MetaphysicsIndustries.Solus.Compiler
     {
         public IlExpression ConvertToIlExpression(
             UserDefinedFunction func, NascentMethod nm,
-            VariableIdentityMap variables,
+            SolusEnvironment env, VariableIdentityMap variables,
             List<Expression> arguments)
         {
             // TODO: the variables in the udf definition should be
             //       implemented as locals
             int i;
             var seq = new List<IlExpression>();
+            var env2 = env.CreateChildEnvironment();
             var variables2 = variables.CreateChild();
             for (i = 0; i < func.Parameters.Count; i++)
             {
                 var name = func.Parameters[i].Name;
                 var value = arguments[i];
-                var arg = ConvertToIlExpression(arguments[i], nm,
+                var arg = ConvertToIlExpression(arguments[i], nm, env,
                     variables);
                 var varType = arg.ResultType;
                 var local = nm.CreateLocal(varType, name);
+                env2.SetVariableType(name, func.Parameters[i].Type);
                 variables2.SetVariable(name, new VariableIdentity
                 {
                     Name = name,
@@ -59,7 +61,7 @@ namespace MetaphysicsIndustries.Solus.Compiler
                 seq.Add(new StoreLocalIlExpression(local, arg));
             }
 
-            var ilexpr = ConvertToIlExpression(func.Expression, nm,
+            var ilexpr = ConvertToIlExpression(func.Expression, nm, env2,
                 variables2);
             seq.Add(ilexpr);
             return new IlExpressionSequence(seq);

--- a/Compiler/ILCompiler.Functions.cs
+++ b/Compiler/ILCompiler.Functions.cs
@@ -33,151 +33,152 @@ namespace MetaphysicsIndustries.Solus.Compiler
         public IlExpression ConvertToIlExpression(
             Function func,
             NascentMethod nm,
+            SolusEnvironment env,
             VariableIdentityMap variables,
             List<Expression> arguments)
         {
             switch (func)
             {
                 case AbsoluteValueFunction ff:
-                    return ConvertToIlExpression(ff, nm, variables,
+                    return ConvertToIlExpression(ff, nm, env, variables,
                         arguments);
                 case AdditionOperation ao:
-                    return ConvertToIlExpression(ao, nm, variables,
+                    return ConvertToIlExpression(ao, nm, env, variables,
                         arguments);
                 case ArccosecantFunction ff:
-                    return ConvertToIlExpression(ff, nm, variables,
+                    return ConvertToIlExpression(ff, nm, env, variables,
                         arguments);
                 case ArccosineFunction ff:
-                    return ConvertToIlExpression(ff, nm, variables,
+                    return ConvertToIlExpression(ff, nm, env, variables,
                         arguments);
                 case ArccotangentFunction ff:
-                    return ConvertToIlExpression(ff, nm, variables,
+                    return ConvertToIlExpression(ff, nm, env, variables,
                         arguments);
                 case ArcsecantFunction ff:
-                    return ConvertToIlExpression(ff, nm, variables,
+                    return ConvertToIlExpression(ff, nm, env, variables,
                         arguments);
                 case ArcsineFunction ff:
-                    return ConvertToIlExpression(ff, nm, variables,
+                    return ConvertToIlExpression(ff, nm, env, variables,
                         arguments);
                 case Arctangent2Function ff:
-                    return ConvertToIlExpression(ff, nm, variables,
+                    return ConvertToIlExpression(ff, nm, env, variables,
                         arguments);
                 case ArctangentFunction ff:
-                    return ConvertToIlExpression(ff, nm, variables,
+                    return ConvertToIlExpression(ff, nm, env, variables,
                         arguments);
                 case BitwiseAndOperation ff:
-                    return ConvertToIlExpression(ff, nm, variables,
+                    return ConvertToIlExpression(ff, nm, env, variables,
                         arguments);
                 case BitwiseOrOperation ff:
-                    return ConvertToIlExpression(ff, nm, variables,
+                    return ConvertToIlExpression(ff, nm, env, variables,
                         arguments);
                 case CeilingFunction ff:
-                    return ConvertToIlExpression(ff, nm, variables,
+                    return ConvertToIlExpression(ff, nm, env, variables,
                         arguments);
                 case CosecantFunction ff:
-                    return ConvertToIlExpression(ff, nm, variables,
+                    return ConvertToIlExpression(ff, nm, env, variables,
                         arguments);
                 case CosineFunction c:
-                    return ConvertToIlExpression(c, nm, variables,
+                    return ConvertToIlExpression(c, nm, env, variables,
                         arguments);
                 case CotangentFunction ff:
-                    return ConvertToIlExpression(ff, nm, variables,
+                    return ConvertToIlExpression(ff, nm, env, variables,
                         arguments);
                 case DistFunction ff:
-                    return ConvertToIlExpression(ff, nm, variables,
+                    return ConvertToIlExpression(ff, nm, env, variables,
                         arguments);
                 case DistSqFunction ff:
-                    return ConvertToIlExpression(ff, nm, variables,
+                    return ConvertToIlExpression(ff, nm, env, variables,
                         arguments);
                 case DivisionOperation ff:
-                    return ConvertToIlExpression(ff, nm, variables,
+                    return ConvertToIlExpression(ff, nm, env, variables,
                         arguments);
                 case EqualComparisonOperation ff:
-                    return ConvertToIlExpression(ff, nm, variables,
+                    return ConvertToIlExpression(ff, nm, env, variables,
                         arguments);
                 case ExponentOperation eo:
-                    return ConvertToIlExpression(eo, nm, variables,
+                    return ConvertToIlExpression(eo, nm, env, variables,
                         arguments);
                 case FactorialFunction ff:
-                    return ConvertToIlExpression(ff, nm, variables,
+                    return ConvertToIlExpression(ff, nm, env, variables,
                         arguments);
                 case FloorFunction ff:
-                    return ConvertToIlExpression(ff, nm, variables,
+                    return ConvertToIlExpression(ff, nm, env, variables,
                         arguments);
                 case GreaterThanComparisonOperation ff:
-                    return ConvertToIlExpression(ff, nm, variables,
+                    return ConvertToIlExpression(ff, nm, env, variables,
                         arguments);
                 case GreaterThanOrEqualComparisonOperation ff:
-                    return ConvertToIlExpression(ff, nm, variables,
+                    return ConvertToIlExpression(ff, nm, env, variables,
                         arguments);
                 case LessThanComparisonOperation ff:
-                    return ConvertToIlExpression(ff, nm, variables,
+                    return ConvertToIlExpression(ff, nm, env, variables,
                         arguments);
                 case LessThanOrEqualComparisonOperation ff:
-                    return ConvertToIlExpression(ff, nm, variables,
+                    return ConvertToIlExpression(ff, nm, env, variables,
                         arguments);
                 case LoadImageFunction ff:
-                    return ConvertToIlExpression(ff, nm, variables,
+                    return ConvertToIlExpression(ff, nm, env, variables,
                         arguments);
                 case Log10Function ff:
-                    return ConvertToIlExpression(ff, nm, variables,
+                    return ConvertToIlExpression(ff, nm, env, variables,
                         arguments);
                 case Log2Function ff:
-                    return ConvertToIlExpression(ff, nm, variables,
+                    return ConvertToIlExpression(ff, nm, env, variables,
                         arguments);
                 case LogarithmFunction ff:
-                    return ConvertToIlExpression(ff, nm, variables,
+                    return ConvertToIlExpression(ff, nm, env, variables,
                         arguments);
                 case LogicalAndOperation ff:
-                    return ConvertToIlExpression(ff, nm, variables,
+                    return ConvertToIlExpression(ff, nm, env, variables,
                         arguments);
                 case LogicalOrOperation ff:
-                    return ConvertToIlExpression(ff, nm, variables,
+                    return ConvertToIlExpression(ff, nm, env, variables,
                         arguments);
                 case MaximumFiniteFunction ff:
-                    return ConvertToIlExpression(ff, nm, variables,
+                    return ConvertToIlExpression(ff, nm, env, variables,
                         arguments);
                 case MaximumFunction ff:
-                    return ConvertToIlExpression(ff, nm, variables,
+                    return ConvertToIlExpression(ff, nm, env, variables,
                         arguments);
                 case MinimumFiniteFunction ff:
-                    return ConvertToIlExpression(ff, nm, variables,
+                    return ConvertToIlExpression(ff, nm, env, variables,
                         arguments);
                 case MinimumFunction ff:
-                    return ConvertToIlExpression(ff, nm, variables,
+                    return ConvertToIlExpression(ff, nm, env, variables,
                         arguments);
                 case ModularDivision ff:
-                    return ConvertToIlExpression(ff, nm, variables,
+                    return ConvertToIlExpression(ff, nm, env, variables,
                         arguments);
                 case MultiplicationOperation mo:
-                    return ConvertToIlExpression(mo, nm, variables,
+                    return ConvertToIlExpression(mo, nm, env, variables,
                         arguments);
                 case NaturalLogarithmFunction ff:
-                    return ConvertToIlExpression(ff, nm, variables,
+                    return ConvertToIlExpression(ff, nm, env, variables,
                         arguments);
                 case NegationOperation no:
-                    return ConvertToIlExpression(no, nm, variables,
+                    return ConvertToIlExpression(no, nm, env, variables,
                         arguments);
                 case NotEqualComparisonOperation ff:
-                    return ConvertToIlExpression(ff, nm, variables,
+                    return ConvertToIlExpression(ff, nm, env, variables,
                         arguments);
                 case SecantFunction ff:
-                    return ConvertToIlExpression(ff, nm, variables,
+                    return ConvertToIlExpression(ff, nm, env, variables,
                         arguments);
                 case SineFunction s:
-                    return ConvertToIlExpression(s, nm, variables,
+                    return ConvertToIlExpression(s, nm, env, variables,
                         arguments);
                 case SizeFunction ff:
-                    return ConvertToIlExpression(ff, nm, variables,
+                    return ConvertToIlExpression(ff, nm, env, variables,
                         arguments);
                 case TangentFunction ff:
-                    return ConvertToIlExpression(ff, nm, variables,
+                    return ConvertToIlExpression(ff, nm, env, variables,
                         arguments);
                 case UnitStepFunction usf:
-                    return ConvertToIlExpression(usf, nm, variables,
+                    return ConvertToIlExpression(usf, nm, env, variables,
                         arguments);
                 case UserDefinedFunction udf:
-                    return ConvertToIlExpression(udf, nm, variables,
+                    return ConvertToIlExpression(udf, nm, env, variables,
                         arguments);
                 default:
                     // if (func.ProvidesCustomCall)

--- a/Compiler/VariableIdentity.cs
+++ b/Compiler/VariableIdentity.cs
@@ -27,7 +27,6 @@ namespace MetaphysicsIndustries.Solus.Compiler
     public class VariableIdentity
     {
         public string Name;
-        public ISet MathType;
         public Type IlType;
         public IMathObject Value;
         public VariableSource Source;

--- a/Compiler/gen_delegate_types.py
+++ b/Compiler/gen_delegate_types.py
@@ -1,0 +1,17 @@
+template = 'public delegate TResult CompiledExpression<{}TResult>({});'
+for i in range(100):
+    x = ['public delegate TResult CompiledExpression<']
+    for j in range(i):
+        x.append('in T')
+        x.append(str(j))
+        x.append(', ')
+    x.append('out TResult>(')
+    for j in range(i):
+        x.append('T')
+        x.append(str(j))
+        x.append(' arg')
+        x.append(str(j))
+        if j < i - 1:
+            x.append(', ')
+    x.append(');')
+    print(''.join(x))

--- a/Evaluators/BasicEvaluator.Functions.cs
+++ b/Evaluators/BasicEvaluator.Functions.cs
@@ -367,7 +367,8 @@ namespace MetaphysicsIndustries.Solus.Evaluators
         public IMathObject CallFunction(LoadImageFunction f,
             IMathObject[] args, SolusEnvironment env)
         {
-            throw new NotImplementedException();
+            var filename = args[0].ToStringValue().Value;
+            return LoadImageFunction.LoadImage(filename);
         }
 
         public IMathObject CallFunction(Log10Function f, IMathObject[] args,

--- a/Evaluators/BasicEvaluator.Functions.cs
+++ b/Evaluators/BasicEvaluator.Functions.cs
@@ -69,6 +69,26 @@ namespace MetaphysicsIndustries.Solus.Evaluators
                 return result.ToVector();
             }
 
+            if (type is Matrices ms)
+            {
+                var R = ms.RowCount;
+                var C = ms.ColumnCount;
+                int i, r, c;
+                var result = new float[R, C];
+                for (r = 0; r < R; r++)
+                for (c = 0; c < C; c++)
+                    result[r, c] = 0;
+                for (i = 0; i < args.Length; i++)
+                {
+                    var arg = args[i].ToMatrix();
+                    for (r = 0; r < R; r++)
+                    for (c = 0; c < C; c++)
+                        result[r, c] += arg[r, c].ToNumber().Value;
+                }
+
+                return result.ToMatrix();
+            }
+
             throw new TypeException(
                 $"Type not supported: {type.DisplayName}");
         }

--- a/Evaluators/BasicEvaluator.Functions.cs
+++ b/Evaluators/BasicEvaluator.Functions.cs
@@ -41,13 +41,36 @@ namespace MetaphysicsIndustries.Solus.Evaluators
             // TODO: vector
             // TODO: matrix
             // TODO: string?
-            float sum = 0;
-            foreach (var arg in args)
+            var type = args[0].GetMathType();
+            if (type == Reals.Value)
             {
-                sum += arg.ToNumber().Value;
+                float sum = 0;
+                foreach (var arg in args)
+                {
+                    sum += arg.ToNumber().Value;
+                }
+                return sum.ToNumber();
             }
 
-            return sum.ToNumber();
+            if (type is Vectors vs)
+            {
+                var N = vs.Dimension;
+                int i,j;
+                var result = new float[N];
+                for (j = 0; j < N; j++)
+                    result[j] = 0;
+                for (i = 0; i < args.Length; i++)
+                {
+                    var arg = args[i].ToVector();
+                    for (j = 0; j < N; j++)
+                        result[j] += arg[j].ToNumber().Value;
+                }
+
+                return result.ToVector();
+            }
+
+            throw new TypeException(
+                $"Type not supported: {type.DisplayName}");
         }
 
         public IMathObject CallFunction(ArccosecantFunction f,

--- a/Evaluators/BasicEvaluator.Functions.cs
+++ b/Evaluators/BasicEvaluator.Functions.cs
@@ -20,6 +20,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using MetaphysicsIndustries.Solus.Exceptions;
 using MetaphysicsIndustries.Solus.Functions;
 using MetaphysicsIndustries.Solus.Sets;
@@ -507,17 +508,169 @@ namespace MetaphysicsIndustries.Solus.Evaluators
             return ((long)x % (long)y).ToNumber();
         }
 
+        public static IMatrix MultMatrices(IMatrix a, IMatrix b)
+        {
+            var values = new float[a.RowCount, b.ColumnCount];
+            for (var r = 0; r < a.RowCount; r++)
+            for (var c = 0; c < b.ColumnCount; c++)
+            {
+                values[r, c] = 0;
+                int k;
+                for (k = 0; k < a.ColumnCount; k++)
+                    values[r, c] += a[r, k].ToFloat() * b[k, c].ToFloat();
+            }
+
+            return new Matrix(values);
+        }
+
+        public static IVector MultMatrixVector(IMatrix m, IVector v)
+        {
+            var values = new float[m.RowCount];
+            for (var r = 0; r < m.RowCount; r++)
+            {
+                values[r] = 0;
+                int k;
+                for (k = 0; k < m.ColumnCount; k++)
+                    values[r] += m[r, k].ToFloat() * v[k].ToFloat();
+            }
+
+            return new Vector(values);
+        }
+
+        public static IMatrix MultMatrixScalar(IMatrix m, float s)
+        {
+            var values = new float[m.RowCount, m.ColumnCount];
+            for (var r = 0; r < m.RowCount; r++)
+            for (var c = 0; c < m.ColumnCount; c++)
+                values[r, c] = m[r, c].ToFloat() * s;
+            return new Matrix(values);
+        }
+
+        public static IVector MultVectorScalar(IVector v, float s)
+        {
+            var values = new float[v.Length];
+            for (var i = 0; i < v.Length; i++)
+                values[i] = v[i].ToFloat() * s;
+            return new Vector(values);
+        }
+
         public IMathObject CallFunction(MultiplicationOperation f,
             IMathObject[] args, SolusEnvironment env)
         {
-            float value = 1;
-            int i;
-            for (i = 0; i < args.Length; i++)
+            var hasMatrix = false;
+            var hasVector = false;
+            var hasScalar = false;
+            var nonScalars = new List<IMathObject>();
+            foreach (var arg in args)
             {
-                value *= args[i].ToNumber().Value;
+                if (arg.IsIsScalar(env))
+                {
+                    hasScalar = true;
+                }
+                else if (arg.IsIsVector(env))
+                {
+                    hasVector = true;
+                    nonScalars.Add(arg);
+                }
+                else if (arg.IsIsMatrix(env))
+                {
+                    hasMatrix = true;
+                    nonScalars.Add(arg);
+                }
             }
 
-            return value.ToNumber();
+            float scalarValue = 1;
+            foreach (var arg in args)
+                if (arg.IsIsScalar(env))
+                    scalarValue *= arg.ToNumber().Value;
+
+            // ss+ -> scalar
+            // s+m+s -> matrix with scalar
+            // s+vs+ -> vector with scalar
+            // s*vs*vs* -> error, unless row*column
+            // s*vs*v(s*v)+s* -> error
+            // (s*m)+s* -> matmult, possibly w/scalar
+            // (s*m)+s*vs* s*v(s*m)+s* -> matvec, possibly w/scalar
+            //
+            // generally, all scalars can be shifted to the left
+            // if there's more than one vector anywhere, probably an error
+            // if there are more than two vectors, error
+            // vectors and matrices must remain in order
+            if (hasScalar && !hasMatrix && !hasVector)
+                // simple scalar multiplication
+                return scalarValue.ToNumber();
+
+            if (hasMatrix)
+            {
+                // check for more than one vector
+                var foundVector = false;
+                var vectorIndex = -1;
+                for (var i = 0; i < nonScalars.Count; i++)
+                {
+                    var arg = nonScalars[i];
+                    if (arg.IsIsVector(env))
+                    {
+                        if (foundVector)
+                            throw new TypeException("More than one vector");
+                        foundVector = true;
+                        vectorIndex = i;
+                    }
+                }
+
+                if (foundVector)
+                {
+                    if (vectorIndex == 0)
+                    {
+                        // vm+
+                        // vector is 1xM row vector
+                        // first matrix is MxN
+                        // last matrix is LxK
+                        // result is 1xK vector
+                        throw new NotImplementedException();
+                    }
+
+                    if (vectorIndex == nonScalars.Count - 1)
+                    {
+                        // m+v
+                        // first matrix is LxK
+                        // last matrix is MxN
+                        // vector is Nx1 column vector
+                        // result is Lx1 vector
+                        var value = nonScalars[0].ToMatrix();
+                        int i;
+                        for (i = 1; i < nonScalars.Count - 1; i++)
+                            value = MultMatrices(value, nonScalars[i].ToMatrix());
+                        var rv = MultMatrixVector(value, nonScalars[i].ToVector());
+                        if (hasScalar)
+                            rv = MultVectorScalar(rv, scalarValue);
+                        return rv;
+                    }
+
+                    // m+vm+
+                    // last of the first
+                    throw new NotImplementedException();
+                }
+                else
+                {
+                    // m+
+                    // first matrix is LxK
+                    // last matrix is MxN
+                    // result is LxN matrix
+                    var value = nonScalars[0].ToMatrix();
+                    for (var i = 1; i < nonScalars.Count; i++)
+                        value = MultMatrices(value, nonScalars[i].ToMatrix());
+                    if (hasScalar)
+                        value = MultMatrixScalar(value, scalarValue);
+                    return value;
+                }
+            }
+            else if (hasVector)
+                // one vector with any number of scalars
+                // s+vs*
+                // vs+
+                return MultVectorScalar(nonScalars[0].ToVector(), scalarValue);
+
+            throw new TypeException("???");
         }
 
         public IMathObject CallFunction(NaturalLogarithmFunction f,

--- a/Evaluators/BasicEvaluator.cs
+++ b/Evaluators/BasicEvaluator.cs
@@ -78,6 +78,11 @@ namespace MetaphysicsIndustries.Solus.Evaluators
         public IMathObject Call(Function f, IMathObject[] args,
             SolusEnvironment env)
         {
+            // TODO: Check before calling the function. This method is called
+            //       by e.g. FunctionCall.Simplify without any kind of
+            //       expression check beforehand. Create a protected/private
+            //       Call_NoCheck(...) or similar method that does the below,
+            //       and make the public Call(...) call that.
             switch (f)
             {
                 case AbsoluteValueFunction ff:
@@ -210,6 +215,8 @@ namespace MetaphysicsIndustries.Solus.Evaluators
 
         public Expression Simplify(Expression expr, SolusEnvironment env)
         {
+            // TODO: Move Simplify et al to a separate class
+            // TODO: check the expression before simplifying
             CleanUpTransformer cleanup = new CleanUpTransformer();
             return cleanup.CleanUp(expr.Simplify(env));
         }

--- a/Evaluators/CompilingEvaluator.cs
+++ b/Evaluators/CompilingEvaluator.cs
@@ -59,18 +59,16 @@ namespace MetaphysicsIndustries.Solus.Evaluators
                 var value = env.GetVariable(varName);
                 if (value.IsIsExpression(env))
                     value = ((Expression)value).GetResultType(env);
-                var mathType = value.GetMathType();
                 variables[varName] = new VariableIdentity
                 {
                     Name = varName,
-                    MathType = mathType,
                     // IlType =
                     Value = value,
                     Source = VariableSource.Param
                 };
             }
 
-            var compiled = _compiler.Compile(expr, variables);
+            var compiled = _compiler.Compile(expr, env, variables);
             return compiled.Evaluate(env);
         }
 
@@ -101,7 +99,6 @@ namespace MetaphysicsIndustries.Solus.Evaluators
                     variables[varName] = new VariableIdentity
                     {
                         Name = varName,
-                        MathType = Reals.Value,
                         Source = VariableSource.Param
                     };
                 else
@@ -113,7 +110,6 @@ namespace MetaphysicsIndustries.Solus.Evaluators
                     variables[varName] = new VariableIdentity
                     {
                         Name = varName,
-                        MathType = mathType,
                         // IlType =
                         Value = value,
                         Source = VariableSource.Param
@@ -125,8 +121,9 @@ namespace MetaphysicsIndustries.Solus.Evaluators
 
             var env2 = env.CreateChildEnvironment();
             env2.RemoveVariable(interval.Variable);
+            env2.SetVariableType(interval.Variable, Reals.Value);
             var expr2 = Simplify(expr, env2);
-            var compiled = _compiler.Compile(expr2, variables);
+            var compiled = _compiler.Compile(expr2, env2, variables);
             object[] varValuesInOrder = null;
             compiled.CompileEnvironment(env2, ref varValuesInOrder);
 
@@ -169,7 +166,6 @@ namespace MetaphysicsIndustries.Solus.Evaluators
                     variables[varName] = new VariableIdentity
                     {
                         Name = varName,
-                        MathType = Reals.Value,
                         Source = VariableSource.Param
                     };
                 else
@@ -177,11 +173,9 @@ namespace MetaphysicsIndustries.Solus.Evaluators
                     var value = env.GetVariable(varName);
                     if (value.IsIsExpression(env))
                         value = ((Expression)value).GetResultType(env);
-                    var mathType = value.GetMathType();
                     variables[varName] = new VariableIdentity
                     {
                         Name = varName,
-                        MathType = mathType,
                         // IlType =
                         Value = value,
                         Source = VariableSource.Param
@@ -194,9 +188,11 @@ namespace MetaphysicsIndustries.Solus.Evaluators
 
             var env2 = env.CreateChildEnvironment();
             env2.RemoveVariable(interval1.Variable);
+            env2.SetVariableType(interval1.Variable, Reals.Value);
             env2.RemoveVariable(interval2.Variable);
+            env2.SetVariableType(interval2.Variable, Reals.Value);
             var expr2 = Simplify(expr, env2);
-            var compiled = _compiler.Compile(expr2, variables);
+            var compiled = _compiler.Compile(expr2, env2, variables);
             object[] varValuesInOrder = null;
             compiled.CompileEnvironment(env2, ref varValuesInOrder);
 
@@ -251,7 +247,6 @@ namespace MetaphysicsIndustries.Solus.Evaluators
                     variables[varName] = new VariableIdentity
                     {
                         Name = varName,
-                        MathType = Reals.Value,
                         Source = VariableSource.Param
                     };
                 else
@@ -276,10 +271,13 @@ namespace MetaphysicsIndustries.Solus.Evaluators
 
             var env2 = env.CreateChildEnvironment();
             env2.RemoveVariable(interval1.Variable);
+            env2.SetVariableType(interval1.Variable, Reals.Value);
             env2.RemoveVariable(interval2.Variable);
+            env2.SetVariableType(interval2.Variable, Reals.Value);
             env2.RemoveVariable(interval3.Variable);
+            env2.SetVariableType(interval3.Variable, Reals.Value);
             var expr2 = Simplify(expr, env2);
-            var compiled = _compiler.Compile(expr2, variables);
+            var compiled = _compiler.Compile(expr2, env2, variables);
             object[] varValuesInOrder = null;
             compiled.CompileEnvironment(env2, ref varValuesInOrder);
 

--- a/Expressions/Expression.cs
+++ b/Expressions/Expression.cs
@@ -108,6 +108,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
         /// was called on, if it can't be simplified further.</returns>
         public virtual Expression Simplify(SolusEnvironment env)
         {
+            // TODO: check the expression before simplifying
             return this;
         }
 

--- a/Expressions/ExpressionChecker.cs
+++ b/Expressions/ExpressionChecker.cs
@@ -362,6 +362,45 @@ namespace MetaphysicsIndustries.Solus.Expressions
                             $"but got {argResultTypes[i].DisplayName}");
                     }
             }
+            else if (ft is AdditionOperation.AdditionFunctionType aft)
+            {
+                if (argResultTypes.Length < 2)
+                    throw new TypeException(
+                        null,
+                        $"Wrong number of arguments given to " +
+                        $"{f.DisplayName} (expected at least " +
+                        $"2 but got {args.Count})");
+                var argType = argResultTypes[0];
+                if (!argType.IsSubsetOf(Reals.Value) &&
+                    !(argType is Vectors) &&
+                    // is subset of any Vectors instance? what about a subset
+                    // of a Vectors instance?
+                    //
+                    // for now we cheat and rely on the fact that AllVectors
+                    // and Vectors are the only vector types, and AllMatrices
+                    // and Matrices are the only matrix types.
+                    !(argType is Matrices))
+                    throw new TypeException(
+                        null,
+                        $"Wrong argument type at index 0: expected " +
+                        $"Real or Vector or Matrix, but got " +
+                        $"{argType.DisplayName}");
+                for (i = 0; i < argResultTypes.Length; i++)
+                    // again, if each individual argument reported a type that
+                    // was a different subset of some vector space, that would
+                    // be ok. but we only have Vectors, so we don't have to
+                    // deal with that now. In the future, we'll have to make
+                    // the decision below based on the subset of a broader,
+                    // containing type, such as R^N
+                    if (argResultTypes[i] != argType)
+                    {
+                        throw new TypeException(
+                            null,
+                            $"Wrong argument type at index {i}: " +
+                            $"expected {argType.DisplayName} " +
+                            $"but got {argResultTypes[i].DisplayName}");
+                    }
+            }
             // TODO: AllVectorFunctions ?
             // TODO: AllRealFunctions ?
             // TODO: AllFunctions ?

--- a/Expressions/ExpressionChecker.cs
+++ b/Expressions/ExpressionChecker.cs
@@ -193,30 +193,6 @@ namespace MetaphysicsIndustries.Solus.Expressions
 
             var args = expr.Arguments;
 
-            if (f is IAssociativeCommutativeOperation)
-            {
-                if (args.Count < 2)
-                {
-                    throw new ArgumentException(
-                        $"Wrong number of arguments given to " +
-                        $"{f.DisplayName} (given {args.Count}, require at " +
-                        $"least 2)");
-                }
-
-                for (i = 0; i < args.Count; i++)
-                {
-                    var argtype = args[i].GetResultType(env);
-                    if (!argtype.IsSubsetOf(Reals.Value))
-                        throw new TypeException(
-                            null,
-                            $"Argument {i} wrong type: expected " +
-                            $"{Reals.Value.DisplayName} but got " +
-                            $"{argtype.DisplayName}");
-                }
-
-                return;
-            }
-
             switch (f)
             {
                 // case AbsoluteValueFunction ff:

--- a/Expressions/ExpressionChecker.cs
+++ b/Expressions/ExpressionChecker.cs
@@ -193,7 +193,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
 
             var args = expr.Arguments;
 
-            if (f is AssociativeCommutativeOperation)
+            if (f is IAssociativeCommutativeOperation)
             {
                 if (args.Count < 2)
                 {

--- a/Expressions/ExpressionChecker.cs
+++ b/Expressions/ExpressionChecker.cs
@@ -377,6 +377,10 @@ namespace MetaphysicsIndustries.Solus.Expressions
                             $"but got {argResultTypes[i].DisplayName}");
                     }
             }
+            else if (ft is MultiplicationOperation.MultiplicationFunctionType mft)
+            {
+                MultiplicationOperation.CheckArguments(env, argResultTypes);
+            }
             // TODO: AllVectorFunctions ?
             // TODO: AllRealFunctions ?
             // TODO: AllFunctions ?

--- a/Expressions/MatrixExpression.cs
+++ b/Expressions/MatrixExpression.cs
@@ -701,17 +701,20 @@ namespace MetaphysicsIndustries.Solus.Expressions
                 values[r, c] = value;
             }
 
+            if (allLiteral)
+            {
+                var values2 = new IMathObject[RowCount, ColumnCount];
+                for (r = 0; r < RowCount; r++)
+                for (c = 0; c < ColumnCount; c++)
+                    values2[r, c] = ((Literal)values[r, c]).Value;
+                var matrix = new Matrix(values2);
+                return new Literal(matrix);
+            }
+
             if (allSame)
                 return this;
-            if (!allLiteral)
-                return new MatrixExpression(values);
 
-            var values2 = new IMathObject[RowCount, ColumnCount];
-            for (r = 0; r < RowCount; r++)
-            for (c = 0; c < ColumnCount; c++)
-                values2[r, c] = ((Literal) values[r, c]).Value;
-            var matrix = new Matrix(values2);
-            return new Literal(matrix);
+            return new MatrixExpression(values);
         }
 
         public override void ApplyToAll(Modulator mod)

--- a/Expressions/VectorExpression.cs
+++ b/Expressions/VectorExpression.cs
@@ -161,10 +161,14 @@ namespace MetaphysicsIndustries.Solus.Expressions
 
         //methods and overloaded operators
 
-        public VectorExpression Convolution(VectorExpression convolvee)
-        {
-            return AdvancedConvolution(convolvee, MultiplicationOperation.Value, AdditionOperation.Value);
-        }
+        // TODO: refactor this into a Function
+        //
+        // public VectorExpression Convolution(VectorExpression convolvee)
+        // {
+        //     return AdvancedConvolution(convolvee,
+        //         MultiplicationOperation.Value,
+        //         AdditionOperation.Value);
+        // }
 
         public VectorExpression AdvancedConvolution(VectorExpression convolvee,
             Operation firstOp, AssociativeCommutativeOperation secondOp)

--- a/Expressions/VectorExpression.cs
+++ b/Expressions/VectorExpression.cs
@@ -171,7 +171,7 @@ namespace MetaphysicsIndustries.Solus.Expressions
         // }
 
         public VectorExpression AdvancedConvolution(VectorExpression convolvee,
-            Operation firstOp, AssociativeCommutativeOperation secondOp)
+            IOperation firstOp, IAssociativeCommutativeOperation secondOp)
         {
             int r = Length + convolvee.Length - 1;
 
@@ -192,13 +192,13 @@ namespace MetaphysicsIndustries.Solus.Expressions
 
                     group.Add(
                         new FunctionCall(
-                        firstOp,
+                        (Function)firstOp,
                         this[k],
                         convolvee[n - k]));
                 }
 
                 CleanUpTransformer cleanup = new CleanUpTransformer();
-                ret[n] = cleanup.CleanUp(new FunctionCall(secondOp, group.ToArray()));
+                ret[n] = cleanup.CleanUp(new FunctionCall((Function)secondOp, group.ToArray()));
             }
 
             return ret;

--- a/Functions/AbsoluteValueFunction.cs
+++ b/Functions/AbsoluteValueFunction.cs
@@ -54,5 +54,6 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public override ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes) => Reals.Value;
+        public override IFunctionType FunctionType => Sets.Functions.RealsToReals;
     }
 }

--- a/Functions/AdditionOperation.cs
+++ b/Functions/AdditionOperation.cs
@@ -44,7 +44,69 @@ namespace MetaphysicsIndustries.Solus.Functions
         }
 
         public override IFunctionType FunctionType =>
-            VariadicFunctions.Get(Reals.Value, Reals.Value, 2);
+            AdditionFunctionType.Value;
+
+        public class AdditionFunctionType : IFunctionType
+        {
+            public static readonly AdditionFunctionType Value =
+                new AdditionFunctionType();
+
+            public bool Contains(IMathObject mo)
+            {
+                // TODO: some other functions could theoretically be in this
+                // set
+                return ReferenceEquals(mo, AdditionOperation.Value);
+            }
+
+            public bool IsSupersetOf(ISet other) =>
+                other == this ||
+                (other is VariadicFunctions vf &&
+                 ((vf.ReturnType == Reals.Value &&
+                   vf.ParameterType == Reals.Value &&
+                   vf.MinimumNumberOfArguments == 2) ||
+                  (vf.ReturnType is Vectors &&
+                   vf.ParameterType is Vectors &&
+                   vf.ParameterType == vf.ReturnType &&
+                   vf.MinimumNumberOfArguments == 2) ||
+                  (vf.ReturnType is Matrices &&
+                   vf.ParameterType is Matrices &&
+                   vf.ParameterType == vf.ReturnType &&
+                   vf.MinimumNumberOfArguments == 2))) ||
+                other.IsSubsetOf(this);
+
+            public bool IsSubsetOf(ISet other) =>
+                other == this ||
+                other is AllFunctions ||
+                other is MathObjects;
+
+            public bool? IsScalar(SolusEnvironment env) => false;
+            public bool? IsBoolean(SolusEnvironment env) => false;
+            public bool? IsVector(SolusEnvironment env) => false;
+            public bool? IsMatrix(SolusEnvironment env) => false;
+            public int? GetTensorRank(SolusEnvironment env) => null;
+            public bool? IsString(SolusEnvironment env) => false;
+            public int? GetDimension(SolusEnvironment env, int index) => null;
+            public int[] GetDimensions(SolusEnvironment env) => null;
+            public int? GetVectorLength(SolusEnvironment env) => null;
+            public bool? IsInterval(SolusEnvironment env) => false;
+            public bool? IsFunction(SolusEnvironment env) => false;
+            public bool? IsExpression(SolusEnvironment env) => false;
+            public bool? IsSet(SolusEnvironment env) => true;
+            public bool IsConcrete => true;
+
+            private string _docString = null;
+
+            public string DocString =>
+                "The union of the set of all variadic functions of " +
+                "minimum two real arguments and returning reals, with the " +
+                "set of all variadic functions of minimum two vector " +
+                "arguments of any dimension and returning a vector of that " +
+                "same dimension, with the set of all variadic function of " +
+                "minimum two matrix arguments of any dimensions and " +
+                "returning a matrix of that same dimension";
+
+            public string DisplayName => "Addition Function";
+        }
 
         public override bool IsCommutative => true;
         public override bool IsAssociative => true;

--- a/Functions/AdditionOperation.cs
+++ b/Functions/AdditionOperation.cs
@@ -25,26 +25,14 @@ using MetaphysicsIndustries.Solus.Sets;
 
 namespace MetaphysicsIndustries.Solus.Functions
 {
-    public class AdditionOperation : AssociativeCommutativeOperation
+    public class AdditionOperation : Function
     {
-        public static readonly AdditionOperation Value = new AdditionOperation();
+        public static readonly AdditionOperation
+            Value = new AdditionOperation();
 
         protected AdditionOperation()
+            : base(new Parameter("x", Reals.Value), "+")
         {
-            Name = "+";
-        }
-
-        public override OperationPrecedence Precedence
-        {
-            get { return OperationPrecedence.Addition; }
-        }
-
-        public override float IdentityValue
-        {
-            get
-            {
-                return 0;
-            }
         }
 
         public override ISet GetResultType(SolusEnvironment env,

--- a/Functions/AdditionOperation.cs
+++ b/Functions/AdditionOperation.cs
@@ -21,6 +21,7 @@
  */
 
 using System.Collections.Generic;
+using MetaphysicsIndustries.Solus.Expressions;
 using MetaphysicsIndustries.Solus.Sets;
 
 namespace MetaphysicsIndustries.Solus.Functions
@@ -119,5 +120,8 @@ namespace MetaphysicsIndustries.Solus.Functions
         public virtual float CollapseValue => 0;
         public virtual bool Culls => true;
         public virtual float CullValue => IdentityValue;
+
+        public override string ToString(List<Expression> arguments) =>
+            Operation.ToString(this, arguments);
     }
 }

--- a/Functions/AdditionOperation.cs
+++ b/Functions/AdditionOperation.cs
@@ -38,8 +38,8 @@ namespace MetaphysicsIndustries.Solus.Functions
         public override ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes)
         {
-            // TODO: tensor arithmetic
-            // TODO: string concatenation
+            foreach (var argType in argTypes)
+                return argType;
             return Reals.Value;
         }
 

--- a/Functions/AdditionOperation.cs
+++ b/Functions/AdditionOperation.cs
@@ -25,7 +25,7 @@ using MetaphysicsIndustries.Solus.Sets;
 
 namespace MetaphysicsIndustries.Solus.Functions
 {
-    public class AdditionOperation : Function
+    public class AdditionOperation : Function, IAssociativeCommutativeOperation
     {
         public static readonly AdditionOperation
             Value = new AdditionOperation();
@@ -34,6 +34,10 @@ namespace MetaphysicsIndustries.Solus.Functions
             : base(new Parameter("x", Reals.Value), "+")
         {
         }
+
+        public OperationPrecedence Precedence => OperationPrecedence.Addition;
+        public bool HasIdentityValue => true;
+        public float IdentityValue => 0;
 
         public override ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes)
@@ -110,5 +114,10 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public override bool IsCommutative => true;
         public override bool IsAssociative => true;
+
+        public virtual bool Collapses => false;
+        public virtual float CollapseValue => 0;
+        public virtual bool Culls => true;
+        public virtual float CullValue => IdentityValue;
     }
 }

--- a/Functions/AdditionOperation.cs
+++ b/Functions/AdditionOperation.cs
@@ -54,5 +54,11 @@ namespace MetaphysicsIndustries.Solus.Functions
             // TODO: string concatenation
             return Reals.Value;
         }
+
+        public override IFunctionType FunctionType =>
+            VariadicFunctions.Get(Reals.Value, Reals.Value, 2);
+
+        public override bool IsCommutative => true;
+        public override bool IsAssociative => true;
     }
 }

--- a/Functions/ArccosecantFunction.cs
+++ b/Functions/ArccosecantFunction.cs
@@ -62,5 +62,6 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public override ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes) => Reals.Value;
+        public override IFunctionType FunctionType => Sets.Functions.RealsToReals;
     }
 }

--- a/Functions/ArccosineFunction.cs
+++ b/Functions/ArccosineFunction.cs
@@ -63,5 +63,6 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public override ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes) => Reals.Value;
+        public override IFunctionType FunctionType => Sets.Functions.RealsToReals;
     }
 }

--- a/Functions/ArccotangentFunction.cs
+++ b/Functions/ArccotangentFunction.cs
@@ -62,5 +62,6 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public override ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes) => Reals.Value;
+        public override IFunctionType FunctionType => Sets.Functions.RealsToReals;
     }
 }

--- a/Functions/ArcsecantFunction.cs
+++ b/Functions/ArcsecantFunction.cs
@@ -62,5 +62,6 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public override ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes) => Reals.Value;
+        public override IFunctionType FunctionType => Sets.Functions.RealsToReals;
     }
 }

--- a/Functions/ArcsineFunction.cs
+++ b/Functions/ArcsineFunction.cs
@@ -63,5 +63,6 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public override ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes) => Reals.Value;
+        public override IFunctionType FunctionType => Sets.Functions.RealsToReals;
     }
 }

--- a/Functions/Arctangent2Function.cs
+++ b/Functions/Arctangent2Function.cs
@@ -53,5 +53,7 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public override ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes) => Reals.Value;
+        public override IFunctionType FunctionType =>
+            Sets.Functions.Get(Reals.Value, Reals.Value, Reals.Value);
     }
 }

--- a/Functions/ArctangentFunction.cs
+++ b/Functions/ArctangentFunction.cs
@@ -62,5 +62,6 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public override ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes) => Reals.Value;
+        public override IFunctionType FunctionType => Sets.Functions.RealsToReals;
     }
 }

--- a/Functions/AssociativeCommutativeOperation.cs
+++ b/Functions/AssociativeCommutativeOperation.cs
@@ -28,7 +28,23 @@ using MetaphysicsIndustries.Solus.Values;
 
 namespace MetaphysicsIndustries.Solus.Functions
 {
-    public abstract class AssociativeCommutativeOperation : Operation
+    public interface IAssociativeCommutativeOperation : IOperation
+    {
+        // if the operation collapses, then any argument that evaluates to the
+        // collapse value will cause the result of the entire operation to be
+        // that value.
+        // e.g. a * 0 = 0
+        bool Collapses { get; }
+        float CollapseValue { get; }
+
+        // if the operation culls, then any argument that evaluates to the
+        // cull value should be removed.
+        // e.g. a + 0 = a
+        bool Culls { get; }
+        float CullValue { get; }
+    }
+
+    public abstract class AssociativeCommutativeOperation : Operation, IAssociativeCommutativeOperation
     {
         protected AssociativeCommutativeOperation()
             : base(Array.Empty<Parameter>())

--- a/Functions/BinaryOperation.cs
+++ b/Functions/BinaryOperation.cs
@@ -34,7 +34,11 @@ using MetaphysicsIndustries.Solus.Values;
 
 namespace MetaphysicsIndustries.Solus.Functions
 {
-    public abstract class BinaryOperation : Operation
+    public interface IBinaryOperation : IOperation
+    {
+    }
+
+    public abstract class BinaryOperation : Operation, IBinaryOperation
     {
         protected BinaryOperation()
             : base(new[]

--- a/Functions/BitwiseAndOperation.cs
+++ b/Functions/BitwiseAndOperation.cs
@@ -25,7 +25,7 @@ using MetaphysicsIndustries.Solus.Sets;
 
 namespace MetaphysicsIndustries.Solus.Functions
 {
-    public class BitwiseAndOperation : BinaryOperation
+    public class BitwiseAndOperation : BinaryOperation, IBinaryOperation
     {
         public static readonly BitwiseAndOperation Value = new BitwiseAndOperation();
 

--- a/Functions/BitwiseAndOperation.cs
+++ b/Functions/BitwiseAndOperation.cs
@@ -51,5 +51,7 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public override ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes) => Reals.Value;
+        public override IFunctionType FunctionType =>
+            Sets.Functions.Get(Reals.Value, Reals.Value, Reals.Value);
     }
 }

--- a/Functions/BitwiseOrOperation.cs
+++ b/Functions/BitwiseOrOperation.cs
@@ -57,5 +57,7 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public override ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes) => Reals.Value;
+        public override IFunctionType FunctionType =>
+            Sets.Functions.Get(Reals.Value, Reals.Value, Reals.Value);
     }
 }

--- a/Functions/CatmullRomSpline.cs
+++ b/Functions/CatmullRomSpline.cs
@@ -130,6 +130,7 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public override ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes) => Reals.Value;
+        public override IFunctionType FunctionType => Sets.Functions.RealsToReals;
     }
 }
 

--- a/Functions/CeilingFunction.cs
+++ b/Functions/CeilingFunction.cs
@@ -62,5 +62,6 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public override ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes) => Reals.Value;
+        public override IFunctionType FunctionType => Sets.Functions.RealsToReals;
     }
 }

--- a/Functions/ComparisonOperation.cs
+++ b/Functions/ComparisonOperation.cs
@@ -1,4 +1,3 @@
-
 /*
  *  MetaphysicsIndustries.Solus
  *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
@@ -22,14 +21,19 @@
 
 namespace MetaphysicsIndustries.Solus.Functions
 {
-    public abstract class ComparisonOperation : BinaryOperation
+    public interface IComparisonOperation : IBinaryOperation
+    {
+        bool Compare(float x, float y);
+    }
+
+    public abstract class ComparisonOperation : BinaryOperation, IComparisonOperation
     {
         protected ComparisonOperation(string name)
         {
             Name = name;
         }
 
-        protected abstract bool Compare(float x, float y);
+        public abstract bool Compare(float x, float y);
 
         public override OperationPrecedence Precedence
         {

--- a/Functions/CosecantFunction.cs
+++ b/Functions/CosecantFunction.cs
@@ -62,5 +62,6 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public override ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes) => Reals.Value;
+        public override IFunctionType FunctionType=>Sets.Functions.RealsToReals;
     }
 }

--- a/Functions/CosineFunction.cs
+++ b/Functions/CosineFunction.cs
@@ -62,5 +62,6 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public override ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes) => Reals.Value;
+        public override IFunctionType FunctionType => Sets.Functions.RealsToReals;
     }
 }

--- a/Functions/CotangentFunction.cs
+++ b/Functions/CotangentFunction.cs
@@ -62,5 +62,6 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public override ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes) => Reals.Value;
+        public override IFunctionType FunctionType => Sets.Functions.RealsToReals;
     }
 }

--- a/Functions/DistFunction.cs
+++ b/Functions/DistFunction.cs
@@ -42,5 +42,7 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public override ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes) => Reals.Value;
+        public override IFunctionType FunctionType =>
+            Sets.Functions.Get(Reals.Value, Reals.Value, Reals.Value);
     }
 }

--- a/Functions/DistSqFunction.cs
+++ b/Functions/DistSqFunction.cs
@@ -41,5 +41,7 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public override ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes) => Reals.Value;
+        public override IFunctionType FunctionType =>
+            Sets.Functions.Get(Reals.Value, Reals.Value, Reals.Value);
     }
 }

--- a/Functions/DivisionOperation.cs
+++ b/Functions/DivisionOperation.cs
@@ -26,7 +26,7 @@ using MetaphysicsIndustries.Solus.Sets;
 
 namespace MetaphysicsIndustries.Solus.Functions
 {
-    public class DivisionOperation : BinaryOperation
+    public class DivisionOperation : BinaryOperation, IBinaryOperation
     {
         public static readonly DivisionOperation Value = new DivisionOperation();
 

--- a/Functions/DivisionOperation.cs
+++ b/Functions/DivisionOperation.cs
@@ -54,5 +54,7 @@ namespace MetaphysicsIndustries.Solus.Functions
             // TODO: matrix divided by scalar
             return Reals.Value;
         }
+        public override IFunctionType FunctionType =>
+            Sets.Functions.Get(Reals.Value, Reals.Value, Reals.Value);
     }
 }

--- a/Functions/EqualComparisonOperation.cs
+++ b/Functions/EqualComparisonOperation.cs
@@ -48,6 +48,11 @@ namespace MetaphysicsIndustries.Solus.Functions
         {
             return Booleans.Value;
         }
+        public override IFunctionType FunctionType =>
+            Sets.Functions.Get(
+                Reals.Value,
+                MathObjects.Value,
+                MathObjects.Value);
 
         public override bool IsAssociative => true;
         public override bool IsCommutative => true;

--- a/Functions/EqualComparisonOperation.cs
+++ b/Functions/EqualComparisonOperation.cs
@@ -50,7 +50,7 @@ namespace MetaphysicsIndustries.Solus.Functions
         }
         public override IFunctionType FunctionType =>
             Sets.Functions.Get(
-                Reals.Value,
+                Booleans.Value,
                 MathObjects.Value,
                 MathObjects.Value);
 

--- a/Functions/ExponentOperation.cs
+++ b/Functions/ExponentOperation.cs
@@ -26,7 +26,7 @@ using MetaphysicsIndustries.Solus.Sets;
 
 namespace MetaphysicsIndustries.Solus.Functions
 {
-    public class ExponentOperation : BinaryOperation
+    public class ExponentOperation : BinaryOperation, IBinaryOperation
     {
         public static readonly ExponentOperation Value = new ExponentOperation();
 

--- a/Functions/ExponentOperation.cs
+++ b/Functions/ExponentOperation.cs
@@ -46,5 +46,7 @@ namespace MetaphysicsIndustries.Solus.Functions
             // TODO: square matrix
             return Reals.Value;
         }
+        public override IFunctionType FunctionType =>
+            Sets.Functions.Get(Reals.Value, Reals.Value, Reals.Value);
     }
 }

--- a/Functions/FactorialFunction.cs
+++ b/Functions/FactorialFunction.cs
@@ -52,5 +52,6 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public override ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes) => Reals.Value;
+        public override IFunctionType FunctionType => Sets.Functions.RealsToReals;
     }
 }

--- a/Functions/FloorFunction.cs
+++ b/Functions/FloorFunction.cs
@@ -62,5 +62,6 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public override ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes) => Reals.Value;
+        public override IFunctionType FunctionType => Sets.Functions.RealsToReals;
     }
 }

--- a/Functions/Function.cs
+++ b/Functions/Function.cs
@@ -50,6 +50,13 @@ namespace MetaphysicsIndustries.Solus.Functions
             _name = name;
             Parameters = Array.AsReadOnly(parameters);
         }
+        protected Function(Parameter parameter, string name)
+        {
+            IsVariadic = true;
+            Parameters = new ReadOnlyCollection<Parameter>(
+                new List<Parameter>(new[] { parameter }));
+            _name = name;
+        }
 
         public virtual IMathObject CustomCall(IMathObject[] args,
             SolusEnvironment env) => null;
@@ -97,6 +104,7 @@ namespace MetaphysicsIndustries.Solus.Functions
 		}
 
         public ReadOnlyCollection<Parameter> Parameters { get; }
+        public bool IsVariadic { get; } = false;
         private string _name;
 
         public virtual string ToString(List<Expression> arguments)

--- a/Functions/Function.cs
+++ b/Functions/Function.cs
@@ -42,6 +42,12 @@ using MetaphysicsIndustries.Solus.Sets;
 
 namespace MetaphysicsIndustries.Solus.Functions
 {
+    /// <summary>
+    /// We consider functions as sets of ordered pairs, such that the first
+    /// item of each pair is unique among all of the pairs. We define the
+    /// domain of the function as the set of first items of all pairs. We
+    /// define the codomain as the set of second items from all pairs.
+    /// </summary>
     public abstract class Function : IMathObject
     {
         protected Function(Parameter[] parameters, string name = "")

--- a/Functions/Function.cs
+++ b/Functions/Function.cs
@@ -38,6 +38,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using MetaphysicsIndustries.Solus.Exceptions;
 using MetaphysicsIndustries.Solus.Expressions;
+using MetaphysicsIndustries.Solus.Sets;
 
 namespace MetaphysicsIndustries.Solus.Functions
 {
@@ -52,7 +53,6 @@ namespace MetaphysicsIndustries.Solus.Functions
         }
         protected Function(Parameter parameter, string name)
         {
-            IsVariadic = true;
             Parameters = new ReadOnlyCollection<Parameter>(
                 new List<Parameter>(new[] { parameter }));
             _name = name;
@@ -104,7 +104,7 @@ namespace MetaphysicsIndustries.Solus.Functions
 		}
 
         public ReadOnlyCollection<Parameter> Parameters { get; }
-        public bool IsVariadic { get; } = false;
+        public bool IsVariadic => FunctionType is VariadicFunctions;
         private string _name;
 
         public virtual string ToString(List<Expression> arguments)
@@ -129,6 +129,8 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public abstract ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes);
+
+        public abstract IFunctionType FunctionType { get; }
 
         public bool? IsScalar(SolusEnvironment env) => false;
         public bool? IsBoolean(SolusEnvironment env) => false;

--- a/Functions/Function.cs
+++ b/Functions/Function.cs
@@ -136,6 +136,10 @@ namespace MetaphysicsIndustries.Solus.Functions
         public abstract ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes);
 
+        // TODO: this should return an exact type. The function type should
+        //       indicate the exact sets that comprise the domain and codomain
+        //       of this function, as the domain and codomain are defined in
+        //       the class docstring above.
         public abstract IFunctionType FunctionType { get; }
 
         public bool? IsScalar(SolusEnvironment env) => false;

--- a/Functions/GreaterThanComparisonOperation.cs
+++ b/Functions/GreaterThanComparisonOperation.cs
@@ -44,5 +44,7 @@ namespace MetaphysicsIndustries.Solus.Functions
         {
             return Booleans.Value;
         }
+        public override IFunctionType FunctionType =>
+            Sets.Functions.Get(Booleans.Value, Reals.Value, Reals.Value);
     }
 }

--- a/Functions/GreaterThanComparisonOperation.cs
+++ b/Functions/GreaterThanComparisonOperation.cs
@@ -25,7 +25,7 @@ using MetaphysicsIndustries.Solus.Sets;
 
 namespace MetaphysicsIndustries.Solus.Functions
 {
-    public class GreaterThanComparisonOperation : ComparisonOperation
+    public class GreaterThanComparisonOperation : ComparisonOperation, IComparisonOperation
     {
         public static readonly GreaterThanComparisonOperation Value = new GreaterThanComparisonOperation();
 
@@ -34,7 +34,7 @@ namespace MetaphysicsIndustries.Solus.Functions
         {
         }
 
-        protected override bool Compare(float x, float y)
+        public override bool Compare(float x, float y)
         {
             return x > y;
         }

--- a/Functions/GreaterThanOrEqualComparisonOperation.cs
+++ b/Functions/GreaterThanOrEqualComparisonOperation.cs
@@ -25,7 +25,7 @@ using MetaphysicsIndustries.Solus.Sets;
 
 namespace MetaphysicsIndustries.Solus.Functions
 {
-    public class GreaterThanOrEqualComparisonOperation : ComparisonOperation
+    public class GreaterThanOrEqualComparisonOperation : ComparisonOperation, IComparisonOperation
     {
         public static readonly GreaterThanOrEqualComparisonOperation Value = new GreaterThanOrEqualComparisonOperation();
 
@@ -34,7 +34,7 @@ namespace MetaphysicsIndustries.Solus.Functions
         {
         }
 
-        protected override bool Compare(float x, float y)
+        public override bool Compare(float x, float y)
         {
             return x >= y;
         }

--- a/Functions/GreaterThanOrEqualComparisonOperation.cs
+++ b/Functions/GreaterThanOrEqualComparisonOperation.cs
@@ -44,5 +44,7 @@ namespace MetaphysicsIndustries.Solus.Functions
         {
             return Booleans.Value;
         }
+        public override IFunctionType FunctionType =>
+            Sets.Functions.Get(Booleans.Value, Reals.Value, Reals.Value);
     }
 }

--- a/Functions/LessThanComparisonOperation.cs
+++ b/Functions/LessThanComparisonOperation.cs
@@ -44,5 +44,7 @@ namespace MetaphysicsIndustries.Solus.Functions
         {
             return Booleans.Value;
         }
+        public override IFunctionType FunctionType =>
+            Sets.Functions.Get(Booleans.Value, Reals.Value, Reals.Value);
     }
 }

--- a/Functions/LessThanComparisonOperation.cs
+++ b/Functions/LessThanComparisonOperation.cs
@@ -25,7 +25,7 @@ using MetaphysicsIndustries.Solus.Sets;
 
 namespace MetaphysicsIndustries.Solus.Functions
 {
-    public class LessThanComparisonOperation : ComparisonOperation
+    public class LessThanComparisonOperation : ComparisonOperation, IComparisonOperation
     {
         public static readonly LessThanComparisonOperation Value = new LessThanComparisonOperation();
 
@@ -34,7 +34,7 @@ namespace MetaphysicsIndustries.Solus.Functions
         {
         }
 
-        protected override bool Compare(float x, float y)
+        public override bool Compare(float x, float y)
         {
             return x < y;
         }

--- a/Functions/LessThanOrEqualComparisonOperation.cs
+++ b/Functions/LessThanOrEqualComparisonOperation.cs
@@ -25,7 +25,7 @@ using MetaphysicsIndustries.Solus.Sets;
 
 namespace MetaphysicsIndustries.Solus.Functions
 {
-    public class LessThanOrEqualComparisonOperation : ComparisonOperation
+    public class LessThanOrEqualComparisonOperation : ComparisonOperation, IComparisonOperation
     {
         public static readonly LessThanOrEqualComparisonOperation Value = new LessThanOrEqualComparisonOperation();
 
@@ -34,7 +34,7 @@ namespace MetaphysicsIndustries.Solus.Functions
         {
         }
 
-        protected override bool Compare(float x, float y)
+        public override bool Compare(float x, float y)
         {
             return x <= y;
         }

--- a/Functions/LessThanOrEqualComparisonOperation.cs
+++ b/Functions/LessThanOrEqualComparisonOperation.cs
@@ -44,5 +44,7 @@ namespace MetaphysicsIndustries.Solus.Functions
         {
             return Booleans.Value;
         }
+        public override IFunctionType FunctionType =>
+            Sets.Functions.Get(Booleans.Value, Reals.Value, Reals.Value);
     }
 }

--- a/Functions/LoadImageFunction.cs
+++ b/Functions/LoadImageFunction.cs
@@ -187,5 +187,8 @@ namespace MetaphysicsIndustries.Solus.Functions
         {
             return AllMatrices.Value;
         }
+
+        public override IFunctionType FunctionType =>
+            Sets.Functions.Get(AllMatrices.Value, Strings.Value);
     }
 }

--- a/Functions/Log10Function.cs
+++ b/Functions/Log10Function.cs
@@ -47,5 +47,6 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public override ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes) => Reals.Value;
+        public override IFunctionType FunctionType => Sets.Functions.RealsToReals;
     }
 }

--- a/Functions/Log2Function.cs
+++ b/Functions/Log2Function.cs
@@ -47,5 +47,6 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public override ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes) => Reals.Value;
+        public override IFunctionType FunctionType => Sets.Functions.RealsToReals;
     }
 }

--- a/Functions/LogarithmFunction.cs
+++ b/Functions/LogarithmFunction.cs
@@ -46,5 +46,7 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public override ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes) => Reals.Value;
+        public override IFunctionType FunctionType =>
+            Sets.Functions.Get(Reals.Value, Reals.Value, Reals.Value);
     }
 }

--- a/Functions/LogicalAndOperation.cs
+++ b/Functions/LogicalAndOperation.cs
@@ -47,5 +47,9 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public override ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes) => Booleans.Value;
+        public override IFunctionType FunctionType =>
+            Sets.Functions.Get(
+                Booleans.Value,
+                Booleans.Value, Booleans.Value);
     }
 }

--- a/Functions/LogicalOrOperation.cs
+++ b/Functions/LogicalOrOperation.cs
@@ -47,5 +47,9 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public override ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes) => Booleans.Value;
+        public override IFunctionType FunctionType =>
+            Sets.Functions.Get(
+                Booleans.Value,
+                Booleans.Value, Booleans.Value);
     }
 }

--- a/Functions/MaximumFiniteFunction.cs
+++ b/Functions/MaximumFiniteFunction.cs
@@ -45,5 +45,7 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public override ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes) => Reals.Value;
+        public override IFunctionType FunctionType =>
+            throw new NotImplementedException();
     }
 }

--- a/Functions/MaximumFunction.cs
+++ b/Functions/MaximumFunction.cs
@@ -42,5 +42,7 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public override ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes) => Reals.Value;
+        public override IFunctionType FunctionType =>
+            throw new NotImplementedException();
     }
 }

--- a/Functions/MinimumFiniteFunction.cs
+++ b/Functions/MinimumFiniteFunction.cs
@@ -45,5 +45,7 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public override ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes) => Reals.Value;
+        public override IFunctionType FunctionType =>
+            throw new NotImplementedException();
     }
 }

--- a/Functions/MinimumFunction.cs
+++ b/Functions/MinimumFunction.cs
@@ -42,5 +42,7 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public override ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes) => Reals.Value;
+        public override IFunctionType FunctionType =>
+            throw new NotImplementedException();
     }
 }

--- a/Functions/ModularDivision.cs
+++ b/Functions/ModularDivision.cs
@@ -42,5 +42,7 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public override ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes) => Reals.Value;
+        public override IFunctionType FunctionType =>
+            Sets.Functions.Get(Reals.Value, Reals.Value, Reals.Value);
     }
 }

--- a/Functions/ModularDivision.cs
+++ b/Functions/ModularDivision.cs
@@ -26,7 +26,7 @@ using MetaphysicsIndustries.Solus.Sets;
 
 namespace MetaphysicsIndustries.Solus.Functions
 {
-    public class ModularDivision : BinaryOperation
+    public class ModularDivision : BinaryOperation, IBinaryOperation
     {
         public static readonly ModularDivision Value = new ModularDivision();
 

--- a/Functions/MultiplicationOperation.cs
+++ b/Functions/MultiplicationOperation.cs
@@ -144,7 +144,7 @@ namespace MetaphysicsIndustries.Solus.Functions
                     // m+
                     // first matrix is LxK
                     // last matrix is MxN
-                    // result is LxN vector
+                    // result is LxN matrix
                     int i;
                     var mt0 = (Matrices)nonScalars[0];
                     var last = mt0;
@@ -165,10 +165,21 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public static void CheckArguments(SolusEnvironment env, IEnumerable<ISet> argTypes)
         {
+            var argTypes1 = new List<ISet>(argTypes);
+            if (argTypes1.Count < 2)
+            {
+                var name = MultiplicationOperation.Value.DisplayName;
+                throw new TypeException(
+                    null,
+                    $"Wrong number of arguments given to " +
+                    $"{name} (expected at least " +
+                    "2 but " +
+                    $"got {argTypes1.Count})");
+            }
+
             bool hasMatrix = false;
             bool hasVector = false;
             bool hasScalar = false;
-            var argTypes1 = new List<ISet>(argTypes);
             var nonScalars = new List<ISet>();
             foreach (var argType in argTypes1)
             {
@@ -283,7 +294,7 @@ namespace MetaphysicsIndustries.Solus.Functions
                     // m+
                     // first matrix is LxK
                     // last matrix is MxN
-                    // result is LxN vector
+                    // result is LxN matrix
                     int i;
                     var mt0 = (Matrices)nonScalars[0];
                     var last = mt0;

--- a/Functions/MultiplicationOperation.cs
+++ b/Functions/MultiplicationOperation.cs
@@ -1,4 +1,3 @@
-
 /*
  *  MetaphysicsIndustries.Solus
  *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
@@ -20,59 +19,32 @@
  *
  */
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
+using MetaphysicsIndustries.Solus.Expressions;
 using MetaphysicsIndustries.Solus.Sets;
-using MetaphysicsIndustries.Solus.Values;
 
 namespace MetaphysicsIndustries.Solus.Functions
 {
-    public class MultiplicationOperation : AssociativeCommutativeOperation
+    public class MultiplicationOperation : Function, IAssociativeCommutativeOperation
     {
         public static readonly MultiplicationOperation Value = new MultiplicationOperation();
 
-        protected MultiplicationOperation()
+        private MultiplicationOperation()
+            : base(new Parameter("x", Reals.Value), "*")
         {
-            Name = "*";
         }
 
-        public override OperationPrecedence Precedence
-        {
-            get { return OperationPrecedence.Multiplication; }
-        }
+        public OperationPrecedence Precedence => OperationPrecedence.Multiplication;
+        public override bool IsCommutative => true;
+        public override bool IsAssociative => true;
+        public bool HasIdentityValue => true;
+        public float IdentityValue => 1;
+        public bool Collapses => true;
+        public float CollapseValue => 0;
+        public bool Culls => true;
+        public float CullValue => 1;
 
-        //public override bool IsCommutative
-        //{
-        //    get
-        //    {
-        //        return true;
-        //    }
-        //}
-
-        //public override bool IsAssociative
-        //{
-        //    get
-        //    {
-        //        return true;
-        //    }
-        //}
-
-        public override bool Collapses
-        {
-            get
-            {
-                return true;
-            }
-        }
-
-        public override float CollapseValue
-        {
-            get
-            {
-                return 0;
-            }
-        }
 
         public override ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes)
@@ -83,7 +55,11 @@ namespace MetaphysicsIndustries.Solus.Functions
             // TODO: vector times scalar
             return argTypes.First();
         }
+
         public override IFunctionType FunctionType =>
-            throw new NotImplementedException();
+            VariadicFunctions.Get(Reals.Value, Reals.Value, 2);
+
+        public override string ToString(List<Expression> arguments) =>
+            Operation.ToString(this, arguments);
     }
 }

--- a/Functions/MultiplicationOperation.cs
+++ b/Functions/MultiplicationOperation.cs
@@ -20,8 +20,10 @@
  *
  */
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using MetaphysicsIndustries.Solus.Sets;
 using MetaphysicsIndustries.Solus.Values;
 
 namespace MetaphysicsIndustries.Solus.Functions
@@ -81,5 +83,7 @@ namespace MetaphysicsIndustries.Solus.Functions
             // TODO: vector times scalar
             return argTypes.First();
         }
+        public override IFunctionType FunctionType =>
+            throw new NotImplementedException();
     }
 }

--- a/Functions/MultiplicationOperation.cs
+++ b/Functions/MultiplicationOperation.cs
@@ -19,8 +19,9 @@
  *
  */
 
+using System;
 using System.Collections.Generic;
-using System.Linq;
+using MetaphysicsIndustries.Solus.Exceptions;
 using MetaphysicsIndustries.Solus.Expressions;
 using MetaphysicsIndustries.Solus.Sets;
 
@@ -49,15 +50,329 @@ namespace MetaphysicsIndustries.Solus.Functions
         public override ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes)
         {
-            // TODO: matrix multiplication
-            // TODO: matrix times scalar and vice-versa
-            // TODO: matrix times vector and vice-versa
-            // TODO: vector times scalar
-            return argTypes.First();
+            var argTypes1 = new List<ISet>(argTypes);
+            CheckArguments(env, argTypes1);
+
+            var hasMatrix = false;
+            var hasVector = false;
+            var hasScalar = false;
+            var nonScalars = new List<ISet>();
+            ISet scalarType = null;
+            foreach (var argType in argTypes1)
+            {
+                if (argType.IsSubsetOf(Reals.Value))
+                {
+                    hasScalar = true;
+                    scalarType = argType;
+                }
+                else if (argType.IsSubsetOf(AllVectors.Value))
+                {
+                    hasVector = true;
+                    nonScalars.Add(argType);
+                }
+                else if (argType.IsSubsetOf(AllMatrices.Value))
+                {
+                    hasMatrix = true;
+                    nonScalars.Add(argType);
+                }
+            }
+
+            // ss+ -> scalar
+            // s+m+s -> matrix with scalar
+            // s+vs+ -> vector with scalar
+            // s*vs*vs* -> error, unless row*column
+            // s*vs*v(s*v)+s* -> error
+            // (s*m)+s* -> matmult, possibly w/scalar
+            // (s*m)+s*vs* s*v(s*m)+s* -> matvec, possibly w/scalar
+            //
+            // generally, all scalars can be shifted to the left
+            // if there's more than one vector anywhere, probably an error
+            // if there are more than two vectors, error
+            // vectors and matrices must remain in order
+            if (hasScalar && !hasMatrix && !hasVector)
+                // simple scalar multiplication
+                return scalarType;
+
+            if (hasMatrix)
+            {
+                // check for more than one vector
+                var foundVector = false;
+                int vectorIndex = -1;
+                for (var i = 0; i < nonScalars.Count; i++)
+                {
+                    var argType = nonScalars[i];
+                    if (argType.IsSubsetOf(AllVectors.Value))
+                    {
+                        if (foundVector)
+                            throw new TypeException("More than one vector");
+                        foundVector = true;
+                        vectorIndex = i;
+                    }
+                }
+
+                if (foundVector)
+                {
+                    if (vectorIndex == 0)
+                    {
+                        // vm+
+                        // vector is 1xM row vector
+                        // first matrix is MxN
+                        // last matrix is LxK
+                        // result is 1xK vector
+                        var last = ((Vectors)nonScalars[0]).Dimension;
+                        for (var i = 1; i < nonScalars.Count; i++)
+                            last = ((Matrices)nonScalars[i]).ColumnCount;
+                        return Vectors.Get(last); // Matrices.Get(1, last) ?
+                    }
+
+                    if (vectorIndex == nonScalars.Count - 1)
+                    {
+                        // m+v
+                        // first matrix is LxK
+                        // last matrix is MxN
+                        // vector is Nx1 column vector
+                        // result is Lx1 vector
+                        var mt0 = (Matrices)nonScalars[0];
+                        return Vectors.Get(mt0.RowCount);
+                    }
+
+                    // m+vm+
+                    // last of the first
+                }
+                else
+                {
+                    // m+
+                    // first matrix is LxK
+                    // last matrix is MxN
+                    // result is LxN vector
+                    int i;
+                    var mt0 = (Matrices)nonScalars[0];
+                    var last = mt0;
+                    for (i = 1; i < nonScalars.Count; i++)
+                        last = (Matrices)nonScalars[i];
+
+                    return Matrices.Get(mt0.RowCount, last.ColumnCount);
+                }
+            }
+            else if (hasVector)
+                // one vector with any number of scalars
+                // s+vs*
+                // vs+
+                return nonScalars[0];
+
+            throw new TypeException("???");
+        }
+
+        public static void CheckArguments(SolusEnvironment env, IEnumerable<ISet> argTypes)
+        {
+            bool hasMatrix = false;
+            bool hasVector = false;
+            bool hasScalar = false;
+            var argTypes1 = new List<ISet>(argTypes);
+            var nonScalars = new List<ISet>();
+            foreach (var argType in argTypes1)
+            {
+                if (argType.IsSubsetOf(Reals.Value))
+                {
+                    hasScalar = true;
+                }
+                else if (argType.IsSubsetOf(AllVectors.Value))
+                {
+                    hasVector = true;
+                    nonScalars.Add(argType);
+                }
+                else if (argType.IsSubsetOf(AllMatrices.Value))
+                {
+                    hasMatrix = true;
+                    nonScalars.Add(argType);
+                }
+                else
+                    throw new NotImplementedException(
+                        $"Argument type \"{argType}\"");
+            }
+
+            // ss+ -> scalar
+            // s+m+s -> matrix with scalar
+            // s+vs+ -> vector with scalar
+            // s*vs*vs* -> error, unless row*column
+            // s*vs*v(s*v)+s* -> error
+            // (s*m)+s* -> matmult, possibly w/scalar
+            // (s*m)+s*vs* s*v(s*m)+s* -> matvec, possibly w/scalar
+            //
+            // generally, all scalars can be shifted to the left
+            // if there's more than one vector anywhere, probably an error
+            // if there are more than two vectors, error
+            // vectors and matrices must remain in order
+            if (hasScalar && !hasMatrix && !hasVector)
+                // simple scalar multiplication
+                return;
+
+            if (hasMatrix)
+            {
+                // check for more than one vector
+                var foundVector = false;
+                int vectorIndex = -1;
+                for (var i = 0; i < nonScalars.Count; i++)
+                {
+                    var argType = nonScalars[i];
+                    if (argType.IsSubsetOf(AllVectors.Value))
+                    {
+                        if (foundVector)
+                            throw new TypeException("More than one vector");
+                        foundVector = true;
+                        vectorIndex = i;
+                    }
+                }
+
+                if (foundVector)
+                {
+                    if (vectorIndex == 0)
+                    {
+                        // vm+
+                        // vector is 1xM row vector
+                        // first matrix is MxN
+                        // last matrix is LxK
+                        // result is 1xK vector
+                        int i;
+                        var vdim = ((Vectors)nonScalars[0]).Dimension;
+                        int last = vdim;
+                        for (i = 1; i < nonScalars.Count; i++)
+                        {
+                            var mt = (Matrices)nonScalars[i];
+                            if (mt.RowCount != last)
+                                throw new TypeException(
+                                    $"Matrix dimension does not match, " +
+                                    $"{mt.RowCount} vs {last}");
+                            last = mt.ColumnCount;
+                        }
+
+                        return ;
+                    }
+
+                    if (vectorIndex == nonScalars.Count - 1)
+                    {
+                        // m+v
+                        // first matrix is LxK
+                        // last matrix is MxN
+                        // vector is Nx1 column vector
+                        // result is Lx1 vector
+                        int i;
+                        var vdim = ((Vectors)nonScalars[nonScalars.Count-1]).Dimension;
+                        var mt0 = (Matrices)nonScalars[0];
+                        var last = mt0;
+                        for (i = 1; i < nonScalars.Count - 1; i++)
+                        {
+                            var mt = (Matrices)nonScalars[i];
+                            if (mt.RowCount != last.ColumnCount)
+                                throw new TypeException(
+                                    $"Matrix dimension does not match, " +
+                                    $"{mt.RowCount} vs {last.ColumnCount}");
+                            last = mt;
+                        }
+
+                        if (vdim != last.ColumnCount)
+                            throw new TypeException(
+                                $"Vector dimension does not match, " +
+                                $"{vdim} vs {last.ColumnCount}");
+                    }
+                    // m+vm+
+                    // last of the first
+                }
+                else
+                {
+                    // m+
+                    // first matrix is LxK
+                    // last matrix is MxN
+                    // result is LxN vector
+                    int i;
+                    var mt0 = (Matrices)nonScalars[0];
+                    var last = mt0;
+                    for (i = 1; i < nonScalars.Count; i++)
+                    {
+                        var mt = (Matrices)nonScalars[i];
+                        if (mt.RowCount != last.ColumnCount)
+                            throw new TypeException(
+                                $"Matrix dimension does not match, " +
+                                $"{mt.RowCount} vs {last.ColumnCount}");
+                        last = mt;
+                    }
+                }
+            }
+            else if (hasVector)
+                if (nonScalars.Count > 1)
+                    // more than one vector
+                    // s*v(s*v)+s*
+                    throw new TypeException();
+            // one vector with any number of scalars
+            // s+vs*
+            // vs+
         }
 
         public override IFunctionType FunctionType =>
-            VariadicFunctions.Get(Reals.Value, Reals.Value, 2);
+            MultiplicationFunctionType.Value;
+
+        public class MultiplicationFunctionType : IFunctionType
+        {
+            public static readonly MultiplicationFunctionType Value =
+                new MultiplicationFunctionType();
+
+            public bool Contains(IMathObject mo)
+            {
+                // TODO: some other functions could theoretically be in this
+                // set
+                return ReferenceEquals(mo, MultiplicationOperation.Value);
+            }
+
+            public bool IsSupersetOf(ISet other) =>
+                throw new NotImplementedException();
+            // other == this ||
+            // (other is VariadicFunctions vf &&
+            //  ((vf.ReturnType == Reals.Value &&
+            //    vf.ParameterType == Reals.Value &&
+            //    vf.MinimumNumberOfArguments == 2) ||
+            //   (vf.ReturnType is Vectors &&
+            //    vf.ParameterType is Vectors &&
+            //    vf.ParameterType == vf.ReturnType &&
+            //    vf.MinimumNumberOfArguments == 2) ||
+            //   (vf.ReturnType is Matrices &&
+            //    vf.ParameterType is Matrices &&
+            //    vf.ParameterType == vf.ReturnType &&
+            //    vf.MinimumNumberOfArguments == 2))) ||
+            // other.IsSubsetOf(this);
+
+            public bool IsSubsetOf(ISet other) =>
+                other == this ||
+                other is AllFunctions ||
+                other is MathObjects;
+
+            public bool? IsScalar(SolusEnvironment env) => false;
+            public bool? IsBoolean(SolusEnvironment env) => false;
+            public bool? IsVector(SolusEnvironment env) => false;
+            public bool? IsMatrix(SolusEnvironment env) => false;
+            public int? GetTensorRank(SolusEnvironment env) => null;
+            public bool? IsString(SolusEnvironment env) => false;
+            public int? GetDimension(SolusEnvironment env, int index) => null;
+            public int[] GetDimensions(SolusEnvironment env) => null;
+            public int? GetVectorLength(SolusEnvironment env) => null;
+            public bool? IsInterval(SolusEnvironment env) => false;
+            public bool? IsFunction(SolusEnvironment env) => false;
+            public bool? IsExpression(SolusEnvironment env) => false;
+            public bool? IsSet(SolusEnvironment env) => true;
+            public bool IsConcrete => true;
+
+            private string _docString = null;
+
+            public string DocString => "TODO";
+                // "The union of the set of all variadic functions of " +
+                // "minimum two real arguments and returning reals, with the " +
+                // "set of all variadic functions of minimum two vector " +
+                // "arguments of any dimension and returning a vector of that " +
+                // "same dimension, with the set of all variadic function of " +
+                // "minimum two matrix arguments of any dimensions and " +
+                // "returning a matrix of that same dimension";
+
+            public string DisplayName => "Multiplication Function";
+        }
 
         public override string ToString(List<Expression> arguments) =>
             Operation.ToString(this, arguments);

--- a/Functions/NaturalLogarithmFunction.cs
+++ b/Functions/NaturalLogarithmFunction.cs
@@ -55,5 +55,6 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public override ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes) => Reals.Value;
+        public override IFunctionType FunctionType => Sets.Functions.RealsToReals;
     }
 }

--- a/Functions/NegationOperation.cs
+++ b/Functions/NegationOperation.cs
@@ -20,9 +20,11 @@
  *
  */
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using MetaphysicsIndustries.Solus.Expressions;
+using MetaphysicsIndustries.Solus.Sets;
 using MetaphysicsIndustries.Solus.Values;
 
 namespace MetaphysicsIndustries.Solus.Functions
@@ -67,5 +69,8 @@ namespace MetaphysicsIndustries.Solus.Functions
         {
             return argTypes.First();
         }
+
+        public override IFunctionType FunctionType =>
+            Sets.Functions.RealsToReals;
     }
 }

--- a/Functions/NegationOperation.cs
+++ b/Functions/NegationOperation.cs
@@ -29,7 +29,7 @@ using MetaphysicsIndustries.Solus.Values;
 
 namespace MetaphysicsIndustries.Solus.Functions
 {
-    public class NegationOperation : UnaryOperation
+    public class NegationOperation : UnaryOperation, IUnaryOperation
     {
         public static readonly NegationOperation Value = new NegationOperation();
 

--- a/Functions/NotEqualComparisonOperation.cs
+++ b/Functions/NotEqualComparisonOperation.cs
@@ -49,9 +49,11 @@ namespace MetaphysicsIndustries.Solus.Functions
         {
             return Booleans.Value;
         }
+
         public override IFunctionType FunctionType =>
             Sets.Functions.Get(
-                Reals.Value,
-                MathObjects.Value, MathObjects.Value);
+                Booleans.Value,
+                MathObjects.Value,
+                MathObjects.Value);
     }
 }

--- a/Functions/NotEqualComparisonOperation.cs
+++ b/Functions/NotEqualComparisonOperation.cs
@@ -49,5 +49,9 @@ namespace MetaphysicsIndustries.Solus.Functions
         {
             return Booleans.Value;
         }
+        public override IFunctionType FunctionType =>
+            Sets.Functions.Get(
+                Reals.Value,
+                MathObjects.Value, MathObjects.Value);
     }
 }

--- a/Functions/Operation.cs
+++ b/Functions/Operation.cs
@@ -36,7 +36,14 @@ using MetaphysicsIndustries.Solus.Values;
 
 namespace MetaphysicsIndustries.Solus.Functions
 {
-    public abstract class Operation : Function
+    public interface IOperation
+    {
+        OperationPrecedence Precedence { get; }
+        bool HasIdentityValue { get; }
+        float IdentityValue { get; }
+    }
+
+    public abstract class Operation : Function, IOperation
     {
         protected Operation(Parameter[] parameters)
             : base(parameters)

--- a/Functions/Operation.cs
+++ b/Functions/Operation.cs
@@ -41,6 +41,10 @@ namespace MetaphysicsIndustries.Solus.Functions
         OperationPrecedence Precedence { get; }
         bool HasIdentityValue { get; }
         float IdentityValue { get; }
+
+        // from Function
+        bool IsCommutative { get; }
+        bool IsAssociative { get; }
     }
 
     public abstract class Operation : Function, IOperation

--- a/Functions/Operation.cs
+++ b/Functions/Operation.cs
@@ -107,6 +107,11 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public override string ToString(List<Expression> arguments)
         {
+            return ToString(this, arguments);
+        }
+
+        public static string ToString(Function f, List<Expression> arguments)
+        {
             var strs = Array.ConvertAll(arguments.ToArray(),
                 Expression.ToString);
 
@@ -115,12 +120,13 @@ namespace MetaphysicsIndustries.Solus.Functions
             {
                 if (arguments[i] is FunctionCall call &&
                     call.Function is Literal literal &&
-                    literal.Value is Operation oper &&
-                    oper.Precedence < Precedence)
+                    literal.Value is IOperation oper &&
+                    f is IOperation foper &&
+                    oper.Precedence < foper.Precedence)
                     strs[i] = "(" + strs[i] + ")";
             }
 
-            return string.Join(" " + DisplayName + " ", strs);
+            return string.Join(" " + f.DisplayName + " ", strs);
         }
     }
 }

--- a/Functions/SecantFunction.cs
+++ b/Functions/SecantFunction.cs
@@ -54,5 +54,6 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public override ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes) => Reals.Value;
+        public override IFunctionType FunctionType=>Sets.Functions.RealsToReals;
     }
 }

--- a/Functions/SineFunction.cs
+++ b/Functions/SineFunction.cs
@@ -62,5 +62,6 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public override ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes) => Reals.Value;
+        public override IFunctionType FunctionType => Sets.Functions.RealsToReals;
     }
 }

--- a/Functions/SizeFunction.cs
+++ b/Functions/SizeFunction.cs
@@ -50,5 +50,7 @@ namespace MetaphysicsIndustries.Solus.Functions
                 return Vectors.R2;
             throw new NotImplementedException();
         }
+        public override IFunctionType FunctionType =>
+            throw new NotImplementedException();
     }
 }

--- a/Functions/TangentFunction.cs
+++ b/Functions/TangentFunction.cs
@@ -54,5 +54,6 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public override ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes) => Reals.Value;
+        public override IFunctionType FunctionType=>Sets.Functions.RealsToReals;
     }
 }

--- a/Functions/UnaryOperation.cs
+++ b/Functions/UnaryOperation.cs
@@ -1,4 +1,3 @@
-
 /*
  *  MetaphysicsIndustries.Solus
  *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
@@ -24,7 +23,11 @@ using MetaphysicsIndustries.Solus.Sets;
 
 namespace MetaphysicsIndustries.Solus.Functions
 {
-    public abstract class UnaryOperation : Operation
+    public interface IUnaryOperation : IOperation
+    {
+    }
+
+    public abstract class UnaryOperation : Operation, IUnaryOperation
     {
         protected UnaryOperation()
             : base(new[] { new Parameter("arg", Reals.Value) })

--- a/Functions/UnitStepFunction.cs
+++ b/Functions/UnitStepFunction.cs
@@ -53,5 +53,6 @@ namespace MetaphysicsIndustries.Solus.Functions
 
         public override ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes) => Reals.Value;
+        public override IFunctionType FunctionType=>Sets.Functions.RealsToReals;
     }
 }

--- a/Functions/UserDefinedFunction.cs
+++ b/Functions/UserDefinedFunction.cs
@@ -20,6 +20,7 @@
  *
  */
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using MetaphysicsIndustries.Solus.Expressions;
@@ -37,6 +38,9 @@ namespace MetaphysicsIndustries.Solus.Functions
         {
             Name = name;
             Expression = expr;
+            FunctionType = Sets.Functions.Get(Reals.Value,
+                argnames.Select(_ => (ISet)Reals.Value).ToArray());
+            // Sets.Functions.Get(expr.GetResultType())
         }
         public UserDefinedFunction(string name,
             IEnumerable<Parameter> parameters, Expression expr)
@@ -44,6 +48,8 @@ namespace MetaphysicsIndustries.Solus.Functions
         {
             Name = name;
             Expression = expr;
+            FunctionType = Sets.Functions.Get(Reals.Value,
+                parameters.Select(p => p.Type).ToArray());
         }
 
         public Expression Expression;
@@ -67,5 +73,7 @@ namespace MetaphysicsIndustries.Solus.Functions
 
             return Expression.GetResultType(env2);
         }
+
+        public override IFunctionType FunctionType { get; }
     }
 }

--- a/Functions/UserDefinedFunction.cs
+++ b/Functions/UserDefinedFunction.cs
@@ -52,7 +52,7 @@ namespace MetaphysicsIndustries.Solus.Functions
                 parameters.Select(p => p.Type).ToArray());
         }
 
-        public Expression Expression;
+        public readonly Expression Expression;
 
         public override ISet GetResultType(SolusEnvironment env,
             IEnumerable<ISet> argTypes)

--- a/MathObjectHelper.cs
+++ b/MathObjectHelper.cs
@@ -153,6 +153,25 @@ namespace MetaphysicsIndustries.Solus
 
         public static ISet GetMathType(this IMathObject mo)
         {
+            // TODO: The problem with this function is that it tries to map
+            //       from the set of all math objects to the set of types.
+            //       But if a particular object is a member of more than one
+            //       set, this function should not be able to determine which
+            //       set should be returned. For now, we get by because there
+            //       is a small, fixed number of types. In the future,
+            //       however, we will run into problems. For example, if we
+            //       had a type for integers, then any integer would be a
+            //       member of it as well as the set of reals (and the
+            //       rationals, while we're at it). It is little help that the
+            //       integers are a subset of the reals, or else we could
+            //       simply return the most restrictive set of which the
+            //       object is a member, because sets do not always form a
+            //       clean hierarchy. Another counter-example is user-defined
+            //       sets. A given set X could have as members 2, pi, a 2d
+            //       vector, and a set. That set X could then be given as the
+            //       type of an argument to a function. There is virtually no
+            //       way for this function to know that the caller will need
+            //       X instead of the integers or reals or 2d vectors or sets.
             if (Reals.Value.Contains(mo)) return Reals.Value;
             if (Booleans.Value.Contains(mo)) return Booleans.Value;
             if (Vectors.R2.Contains(mo))

--- a/MathObjectHelper.cs
+++ b/MathObjectHelper.cs
@@ -187,15 +187,16 @@ namespace MetaphysicsIndustries.Solus
             if (mo.IsIsFunction(null))
             {
                 var f = mo.ToFunction();
-                if (Sets.Functions.FunctionHasFixedTypes(f))
-                {
-                    // TODO: reduce allocations
-                    var paramTypes =
-                        f.Parameters.Select(p => p.Type).ToArray();
-                    return Sets.Functions.Get(
-                        f.GetResultType(null, null),
-                        paramTypes);
-                }
+                return f.FunctionType;
+                // if (Sets.Functions.FunctionHasFixedTypes(f))
+                // {
+                //     // TODO: reduce allocations
+                //     var paramTypes =
+                //         f.Parameters.Select(p => p.Type).ToArray();
+                //     return Sets.Functions.Get(
+                //         f.GetResultType(null, null),
+                //         paramTypes);
+                // }
             }
 
             if (AllFunctions.Value.Contains(mo))

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/ExpressionsT/MatrixExpressionT/EvalMatrixExpressionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/ExpressionsT/MatrixExpressionT/EvalMatrixExpressionTest.cs
@@ -147,8 +147,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
                 () => eval.Eval(expr, null));
             // and
             Assert.That(ex.Message,
-                Is.EqualTo(
-                    "The type was incorrect: All components must be reals"));
+                Is.EqualTo("All components must be reals"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/ExpressionsT/VectorExpressionT/EvalVectorExpressionTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/ExpressionsT/VectorExpressionT/EvalVectorExpressionTest.cs
@@ -110,8 +110,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
                 () => eval.Eval(expr, null));
             // and
             Assert.That(ex.Message,
-                Is.EqualTo(
-                    "The type was incorrect: All components must be reals"));
+                Is.EqualTo("All components must be reals"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/AdditionOperationT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/AdditionOperationT/CallTest.cs
@@ -160,7 +160,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             Assert.That(ex, Is.Not.Null);
             Assert.That(ex.Message,
                 Is.EqualTo(
-                    "Operand types do not match: Vectors(3) and Vectors(2)"));
+                    "Wrong argument type at index 1: expected Vector(3) " +
+                    "but got Vector(2)"));
         }
 
         [Test]
@@ -260,8 +261,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             Assert.That(ex, Is.Not.Null);
             Assert.That(ex.Message,
                 Is.EqualTo(
-                    "Operand types do not match: Matrices(2, 2) and " +
-                    "Matrices(3, 2)"));
+                    "Wrong argument type at index 1: expected " +
+                    "Matrix(2, 2) but got Matrix(3, 2)"));
         }
 
         [Test]
@@ -283,7 +284,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             Assert.That(ex, Is.Not.Null);
             Assert.That(ex.Message,
                 Is.EqualTo(
-                    "Operand types do not match: Scalar and Vectors(2)"));
+                    "Wrong argument type at index 1: expected Scalar but " +
+                    "got Vector(3)"));
         }
 
         [Test]
@@ -305,7 +307,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             Assert.That(ex, Is.Not.Null);
             Assert.That(ex.Message,
                 Is.EqualTo(
-                    "Operand types do not match: Vectors(2) and Scalar"));
+                    "Wrong argument type at index 1: expected Vector(3) " +
+                    "but got Scalar"));
         }
 
         [Test]
@@ -331,7 +334,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             Assert.That(ex, Is.Not.Null);
             Assert.That(ex.Message,
                 Is.EqualTo(
-                    "Operand types do not match: Scalar and Matrices(2, 2)"));
+                    "Wrong argument type at index 1: expected Scalar but " +
+                    "got Matrix(2, 2)"));
         }
 
         [Test]
@@ -357,7 +361,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             Assert.That(ex, Is.Not.Null);
             Assert.That(ex.Message,
                 Is.EqualTo(
-                    "Operand types do not match: Matrices(2, 2) and Scalar"));
+                    "Wrong argument type at index 1: expected " +
+                    "Matrix(2, 2) but got Scalar"));
         }
 
         [Test]
@@ -383,8 +388,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             Assert.That(ex, Is.Not.Null);
             Assert.That(ex.Message,
                 Is.EqualTo(
-                    "Operand types do not match: Vectors(3) and " +
-                    "Matrices(2, 2)"));
+                    "Wrong argument type at index 1: expected Vector(3) " +
+                    "but got Matrix(2, 2)"));
         }
 
         [Test]
@@ -410,8 +415,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             Assert.That(ex, Is.Not.Null);
             Assert.That(ex.Message,
                 Is.EqualTo(
-                    "Operand types do not match: Matrices(2, 2) and " +
-                    "Vector(3)"));
+                    "Wrong argument type at index 1: expected " +
+                    "Matrix(2, 2) but got Vector(3)"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/AdditionOperationT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/AdditionOperationT/CallTest.cs
@@ -113,8 +113,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var v = result.ToVector();
             Assert.That(v.Length, Is.EqualTo(3));
             Assert.That(v[0].ToNumber().Value, Is.EqualTo(5f));
-            Assert.That(v[0].ToNumber().Value, Is.EqualTo(7f));
-            Assert.That(v[0].ToNumber().Value, Is.EqualTo(9f));
+            Assert.That(v[1].ToNumber().Value, Is.EqualTo(7f));
+            Assert.That(v[2].ToNumber().Value, Is.EqualTo(9f));
         }
 
         [Test]
@@ -137,8 +137,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var v = result.ToVector();
             Assert.That(v.Length, Is.EqualTo(3));
             Assert.That(v[0].ToNumber().Value, Is.EqualTo(12f));
-            Assert.That(v[0].ToNumber().Value, Is.EqualTo(15f));
-            Assert.That(v[0].ToNumber().Value, Is.EqualTo(18f));
+            Assert.That(v[1].ToNumber().Value, Is.EqualTo(15f));
+            Assert.That(v[2].ToNumber().Value, Is.EqualTo(18f));
         }
 
         [Test]

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/AdditionOperationT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/AdditionOperationT/CallTest.cs
@@ -20,7 +20,6 @@
  *
  */
 
-using System;
 using MetaphysicsIndustries.Solus.Evaluators;
 using MetaphysicsIndustries.Solus.Exceptions;
 using MetaphysicsIndustries.Solus.Expressions;

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/AdditionOperationT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/AdditionOperationT/CallTest.cs
@@ -45,7 +45,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var eval = Util.CreateEvaluator<T>();
             var expr = new FunctionCall(f, args);
             // expect
-            Assert.Throws<ArgumentException>(
+            Assert.Throws<TypeException>(
                 () => eval.Eval(expr, null));
         }
 
@@ -58,7 +58,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var eval = Util.CreateEvaluator<T>();
             var expr = new FunctionCall(f, args);
             // expect
-            Assert.Throws<ArgumentException>(
+            Assert.Throws<TypeException>(
                 () => eval.Eval(expr, null));
         }
 

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/AdditionOperationT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/AdditionOperationT/CallTest.cs
@@ -22,8 +22,10 @@
 
 using System;
 using MetaphysicsIndustries.Solus.Evaluators;
+using MetaphysicsIndustries.Solus.Exceptions;
 using MetaphysicsIndustries.Solus.Expressions;
 using MetaphysicsIndustries.Solus.Functions;
+using MetaphysicsIndustries.Solus.Values;
 using NUnit.Framework;
 
 namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
@@ -91,6 +93,326 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Eval(expr, null);
             // then
             Assert.That(result.ToNumber().Value, Is.EqualTo(7));
+        }
+
+        [Test]
+        public void AddTwoVectorsYieldsVector()
+        {
+            // given
+            var f = AdditionOperation.Value;
+            var args = new Expression[]
+            {
+                new Literal(new Vector3(1, 2, 3)),
+                new Literal(new Vector3(4, 5, 6))
+            };
+            var eval = Util.CreateEvaluator<T>();
+            var expr = new FunctionCall(f, args);
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.That(result.IsIsVector(null));
+            var v = result.ToVector();
+            Assert.That(v.Length, Is.EqualTo(3));
+            Assert.That(v[0].ToNumber().Value, Is.EqualTo(5f));
+            Assert.That(v[0].ToNumber().Value, Is.EqualTo(7f));
+            Assert.That(v[0].ToNumber().Value, Is.EqualTo(9f));
+        }
+
+        [Test]
+        public void AddThreeVectorsYieldsVector()
+        {
+            // given
+            var f = AdditionOperation.Value;
+            var args = new Expression[]
+            {
+                new Literal(new Vector3(1, 2, 3)),
+                new Literal(new Vector3(4, 5, 6)),
+                new Literal(new Vector3(7, 8, 9))
+            };
+            var eval = Util.CreateEvaluator<T>();
+            var expr = new FunctionCall(f, args);
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.That(result.IsIsVector(null));
+            var v = result.ToVector();
+            Assert.That(v.Length, Is.EqualTo(3));
+            Assert.That(v[0].ToNumber().Value, Is.EqualTo(12f));
+            Assert.That(v[0].ToNumber().Value, Is.EqualTo(15f));
+            Assert.That(v[0].ToNumber().Value, Is.EqualTo(18f));
+        }
+
+        [Test]
+        public void VectorsOfDifferentDimensionThrows()
+        {
+            // given
+            var f = AdditionOperation.Value;
+            var args = new Expression[]
+            {
+                new Literal(new Vector3(1, 2, 3)),
+                new Literal(new Vector2(4, 5))
+            };
+            var eval = Util.CreateEvaluator<T>();
+            var expr = new FunctionCall(f, args);
+            // expect
+            var ex = Assert.Throws<TypeException>(
+                () => eval.Eval(expr, null));
+            // and
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex.Message,
+                Is.EqualTo(
+                    "Operand types do not match: Vectors(3) and Vectors(2)"));
+        }
+
+        [Test]
+        public void AddTwoMatricesYieldsMatrix()
+        {
+            // given
+            var f = AdditionOperation.Value;
+            var args = new Expression[]
+            {
+                new Literal(new Matrix(new float[,]
+                {
+                    { 1, 2 },
+                    { 3, 4 }
+                })),
+                new Literal(new Matrix(new float[,]
+                {
+                    { 5, 6 },
+                    { 7, 8 }
+                }))
+            };
+            var eval = Util.CreateEvaluator<T>();
+            var expr = new FunctionCall(f, args);
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.That(result.IsIsMatrix(null));
+            var m = result.ToMatrix();
+            Assert.That(m,
+                Is.EqualTo(
+                    new Matrix(new float[,] { { 6, 8 }, { 10, 12 } })));
+        }
+
+        [Test]
+        public void AddThreeMatricesYieldsMatrix()
+        {
+            // given
+            var f = AdditionOperation.Value;
+            var args = new Expression[]
+            {
+                new Literal(new Matrix(new float[,]
+                {
+                    { 1, 2 },
+                    { 3, 4 }
+                })),
+                new Literal(new Matrix(new float[,]
+                {
+                    { 5, 6 },
+                    { 7, 8 }
+                })),
+                new Literal(new Matrix(new float[,]
+                {
+                    { 9, 10 },
+                    { 11, 12 }
+                }))
+            };
+            var eval = Util.CreateEvaluator<T>();
+            var expr = new FunctionCall(f, args);
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.That(result.IsIsMatrix(null));
+            var m = result.ToMatrix();
+            Assert.That(m,
+                Is.EqualTo(
+                    new Matrix(new float[,]
+                    {
+                        { 15, 18 },
+                        { 21, 24 }
+                    })));
+        }
+
+        [Test]
+        public void MatricesOfDifferentSizeThrows()
+        {
+            // given
+            var f = AdditionOperation.Value;
+            var args = new Expression[]
+            {
+                new Literal(new Matrix(new float[,]
+                {
+                    { 1, 2 },
+                    { 3, 4 }
+                })),
+                new Literal(new Matrix(new float[,]
+                {
+                    { 5, 6 },
+                    { 7, 8 },
+                    { 9, 10 }
+                }))
+            };
+            var eval = Util.CreateEvaluator<T>();
+            var expr = new FunctionCall(f, args);
+            // expect
+            var ex = Assert.Throws<TypeException>(
+                () => eval.Eval(expr, null));
+            // and
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex.Message,
+                Is.EqualTo(
+                    "Operand types do not match: Matrices(2, 2) and " +
+                    "Matrices(3, 2)"));
+        }
+
+        [Test]
+        public void ScalarPlusVectorThrows()
+        {
+            // given
+            var f = AdditionOperation.Value;
+            var args = new Expression[]
+            {
+                new Literal(123f),
+                new Literal(new Vector3(1, 2, 3))
+            };
+            var eval = Util.CreateEvaluator<T>();
+            var expr = new FunctionCall(f, args);
+            // expect
+            var ex = Assert.Throws<TypeException>(
+                () => eval.Eval(expr, null));
+            // and
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex.Message,
+                Is.EqualTo(
+                    "Operand types do not match: Scalar and Vectors(2)"));
+        }
+
+        [Test]
+        public void VectorPlusScalarThrows()
+        {
+            // given
+            var f = AdditionOperation.Value;
+            var args = new Expression[]
+            {
+                new Literal(new Vector3(1, 2, 3)),
+                new Literal(123f),
+            };
+            var eval = Util.CreateEvaluator<T>();
+            var expr = new FunctionCall(f, args);
+            // expect
+            var ex = Assert.Throws<TypeException>(
+                () => eval.Eval(expr, null));
+            // and
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex.Message,
+                Is.EqualTo(
+                    "Operand types do not match: Vectors(2) and Scalar"));
+        }
+
+        [Test]
+        public void ScalarPlusMatrixThrows()
+        {
+            // given
+            var f = AdditionOperation.Value;
+            var args = new Expression[]
+            {
+                new Literal(123f),
+                new Literal(new Matrix(new float[,]
+                {
+                    { 1, 2 },
+                    { 3, 4 }
+                }))
+            };
+            var eval = Util.CreateEvaluator<T>();
+            var expr = new FunctionCall(f, args);
+            // expect
+            var ex = Assert.Throws<TypeException>(
+                () => eval.Eval(expr, null));
+            // and
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex.Message,
+                Is.EqualTo(
+                    "Operand types do not match: Scalar and Matrices(2, 2)"));
+        }
+
+        [Test]
+        public void MatrixPlusScalarThrows()
+        {
+            // given
+            var f = AdditionOperation.Value;
+            var args = new Expression[]
+            {
+                new Literal(new Matrix(new float[,]
+                {
+                    { 1, 2 },
+                    { 3, 4 }
+                })),
+                new Literal(123f),
+            };
+            var eval = Util.CreateEvaluator<T>();
+            var expr = new FunctionCall(f, args);
+            // expect
+            var ex = Assert.Throws<TypeException>(
+                () => eval.Eval(expr, null));
+            // and
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex.Message,
+                Is.EqualTo(
+                    "Operand types do not match: Matrices(2, 2) and Scalar"));
+        }
+
+        [Test]
+        public void VectorPlusMatrixThrows()
+        {
+            // given
+            var f = AdditionOperation.Value;
+            var args = new Expression[]
+            {
+                new Literal(new Vector3(1, 2, 3)),
+                new Literal(new Matrix(new float[,]
+                {
+                    { 1, 2 },
+                    { 3, 4 }
+                }))
+            };
+            var eval = Util.CreateEvaluator<T>();
+            var expr = new FunctionCall(f, args);
+            // expect
+            var ex = Assert.Throws<TypeException>(
+                () => eval.Eval(expr, null));
+            // and
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex.Message,
+                Is.EqualTo(
+                    "Operand types do not match: Vectors(3) and " +
+                    "Matrices(2, 2)"));
+        }
+
+        [Test]
+        public void MatrixPlusVectorThrows()
+        {
+            // given
+            var f = AdditionOperation.Value;
+            var args = new Expression[]
+            {
+                new Literal(new Matrix(new float[,]
+                {
+                    { 1, 2 },
+                    { 3, 4 }
+                })),
+                new Literal(new Vector3(1, 2, 3))
+            };
+            var eval = Util.CreateEvaluator<T>();
+            var expr = new FunctionCall(f, args);
+            // expect
+            var ex = Assert.Throws<TypeException>(
+                () => eval.Eval(expr, null));
+            // and
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex.Message,
+                Is.EqualTo(
+                    "Operand types do not match: Matrices(2, 2) and " +
+                    "Vector(3)"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/FactorialFunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/FactorialFunctionT/CallTest.cs
@@ -22,6 +22,7 @@
 
 using System;
 using MetaphysicsIndustries.Solus.Evaluators;
+using MetaphysicsIndustries.Solus.Exceptions;
 using MetaphysicsIndustries.Solus.Expressions;
 using MetaphysicsIndustries.Solus.Functions;
 using NUnit.Framework;
@@ -43,7 +44,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var eval = Util.CreateEvaluator<T>();
             var expr = new FunctionCall(f, args);
             // expect
-            Assert.Throws<ArgumentException>(() =>
+            Assert.Throws<TypeException>(() =>
                 eval.Eval(expr, null));
         }
 
@@ -56,7 +57,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var eval = Util.CreateEvaluator<T>();
             var expr = new FunctionCall(f, args);
             // expect
-            Assert.Throws<ArgumentException>(() =>
+            Assert.Throws<TypeException>(() =>
                 eval.Eval(expr, null));
         }
 
@@ -74,7 +75,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var eval = Util.CreateEvaluator<T>();
             var expr = new FunctionCall(f, args);
             // expect
-            Assert.Throws<ArgumentException>(() =>
+            Assert.Throws<TypeException>(() =>
                 eval.Eval(expr, null));
         }
 

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/MultiplicationOperationT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/MultiplicationOperationT/CallTest.cs
@@ -25,6 +25,7 @@ using MetaphysicsIndustries.Solus.Evaluators;
 using MetaphysicsIndustries.Solus.Exceptions;
 using MetaphysicsIndustries.Solus.Expressions;
 using MetaphysicsIndustries.Solus.Functions;
+using MetaphysicsIndustries.Solus.Values;
 using NUnit.Framework;
 
 namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
@@ -81,7 +82,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<TypeException>(() =>
                 eval.Eval(expr, null));
             // and
-            Assert.IsTrue(ex.Message.StartsWith("Wrong number of arguments"));
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex.Message, Does.StartWith("Wrong number of arguments"));
         }
 
         [Test]
@@ -96,7 +98,8 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var ex = Assert.Throws<TypeException>(() =>
                 eval.Eval(expr, null));
             // and
-            Assert.IsTrue(ex.Message.StartsWith("Wrong number of arguments"));
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex.Message, Does.StartWith("Wrong number of arguments"));
         }
 
         [Test]
@@ -130,6 +133,214 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var result = eval.Eval(expr, null);
             // then
             Assert.That(result.ToNumber().Value, Is.EqualTo(30));
+        }
+
+        [Test]
+        public void ScalarAndVectorYieldsVector()
+        {
+            // given
+            var f = MultiplicationOperation.Value;
+            var args = new Expression[]
+            {
+                new Literal(2),
+                new Literal(Vector2.One),
+            };
+            var eval = Util.CreateEvaluator<T>();
+            var expr = new FunctionCall(f, args);
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.That(result, Is.EqualTo(new Vector2(2, 2)));
+        }
+
+        [Test]
+        public void VectorAndScalarYieldsVector()
+        {
+            // given
+            var f = MultiplicationOperation.Value;
+            var args = new Expression[]
+            {
+                new Literal(Vector2.One),
+                new Literal(2),
+            };
+            var eval = Util.CreateEvaluator<T>();
+            var expr = new FunctionCall(f, args);
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.That(result, Is.EqualTo(new Vector(new float[] { 2, 2 })));
+        }
+
+        [Test]
+        public void MatrixAndScalarYieldsMatrix()
+        {
+            // given
+            var f = MultiplicationOperation.Value;
+            var args = new Expression[]
+            {
+                new Literal(Matrix.Identity3),
+                new Literal(2),
+            };
+            var eval = Util.CreateEvaluator<T>();
+            var expr = new FunctionCall(f, args);
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.That(result,
+                Is.EqualTo(new Matrix(
+                    new float[,] { { 2, 0, 0 }, { 0, 2, 0 }, { 0, 0, 2 } })));
+        }
+
+        [Test]
+        public void ScalarAndMatrixYieldsMatrix()
+        {
+            // given
+            var f = MultiplicationOperation.Value;
+            var args = new Expression[]
+            {
+                new Literal(2),
+                new Literal(Matrix.Identity3),
+            };
+            var eval = Util.CreateEvaluator<T>();
+            var expr = new FunctionCall(f, args);
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.That(result,
+                Is.EqualTo(
+                    Matrix.M33(
+                        2, 0, 0,
+                        0, 2, 0,
+                        0, 0, 2)));
+        }
+
+        [Test]
+        public void MatrixAndVectorYieldsVector()
+        {
+            // given
+            var f = MultiplicationOperation.Value;
+            var args = new Expression[]
+            {
+                new Literal(
+                    Matrix.M33(
+                        2, 0, 0,
+                        0, 3, 0,
+                        0, 0, 5)),
+                new Literal(new Vector3(7, 11, 13))
+            };
+            var eval = Util.CreateEvaluator<T>();
+            var expr = new FunctionCall(f, args);
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.That(result, Is.EqualTo(new Vector3(14, 33, 65)));
+        }
+
+        [Test]
+        public void MatrixAndMatrixYieldsMatrix()
+        {
+            // given
+            var f = MultiplicationOperation.Value;
+            var args = new Expression[]
+            {
+                new Literal(
+                    Matrix.M22(
+                        2, 3,
+                        5, 7)),
+                new Literal(
+                    Matrix.M22(
+                        11, 13,
+                        17, 19)),
+            };
+            var eval = Util.CreateEvaluator<T>();
+            var expr = new FunctionCall(f, args);
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.That(result,
+                Is.EqualTo(
+                    Matrix.M22(
+                        73, 83,
+                        174, 198)));
+        }
+
+        // VectorAndMatrix ?
+        // VectorAndVector ?
+
+        [Test]
+        public void ScalarAndVectorAndScalarYieldsVector()
+        {
+            // given
+            var f = MultiplicationOperation.Value;
+            var args = new Expression[]
+            {
+                new Literal(2),
+                new Literal(new Vector3(3, 5, 7)),
+                new Literal(11),
+            };
+
+            var eval = Util.CreateEvaluator<T>();
+            var expr = new FunctionCall(f, args);
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.That(result, Is.EqualTo(new Vector3(66, 110, 154)));
+        }
+
+        [Test]
+        public void ScalarAndMatrixAndScalarYieldsMatrix()
+        {
+            // given
+            var f = MultiplicationOperation.Value;
+            var args = new Expression[]
+            {
+                new Literal(2),
+                new Literal(
+                    Matrix.M22(
+                        3, 5,
+                        7, 11)),
+                new Literal(13),
+            };
+
+            var eval = Util.CreateEvaluator<T>();
+            var expr = new FunctionCall(f, args);
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.That(result,
+                Is.EqualTo(
+                    Matrix.M22(
+                        78, 130,
+                        182, 286)));
+        }
+
+        [Test]
+        public void MatrixAndScalarAndMatrixYieldsMatrix()
+        {
+            // given
+            var f = MultiplicationOperation.Value;
+            var args = new Expression[]
+            {
+                new Literal(
+                    Matrix.M22(
+                        2, 3,
+                        5, 7)),
+                new Literal(23),
+                new Literal(
+                    Matrix.M22(
+                        11, 13,
+                        17, 19)),
+            };
+            var eval = Util.CreateEvaluator<T>();
+            var expr = new FunctionCall(f, args);
+            // when
+            var result = eval.Eval(expr, null);
+            // then
+            Assert.That(result,
+                Is.EqualTo(
+                    Matrix.M22(
+                        1679, 1909,
+                        4002, 4554)));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/MultiplicationOperationT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/EvaluatorsT/CommonT/FunctionsT/MultiplicationOperationT/CallTest.cs
@@ -22,6 +22,7 @@
 
 using System;
 using MetaphysicsIndustries.Solus.Evaluators;
+using MetaphysicsIndustries.Solus.Exceptions;
 using MetaphysicsIndustries.Solus.Expressions;
 using MetaphysicsIndustries.Solus.Functions;
 using NUnit.Framework;
@@ -77,7 +78,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var eval = Util.CreateEvaluator<T>();
             var expr = new FunctionCall(f, args);
             // expect
-            var ex = Assert.Throws<ArgumentException>(() =>
+            var ex = Assert.Throws<TypeException>(() =>
                 eval.Eval(expr, null));
             // and
             Assert.IsTrue(ex.Message.StartsWith("Wrong number of arguments"));
@@ -92,7 +93,7 @@ namespace MetaphysicsIndustries.Solus.Test.EvaluatorsT.CommonT.
             var eval = Util.CreateEvaluator<T>();
             var expr = new FunctionCall(f, args);
             // expect
-            var ex = Assert.Throws<ArgumentException>(() =>
+            var ex = Assert.Throws<TypeException>(() =>
                 eval.Eval(expr, null));
             // and
             Assert.IsTrue(ex.Message.StartsWith("Wrong number of arguments"));

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/ExpressionsT/FunctionCallT/CheckTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/ExpressionsT/FunctionCallT/CheckTest.cs
@@ -41,7 +41,8 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
                 new[] { new Parameter("", Reals.Value) },
                 "f")
             {
-                CallF = args => args.First()
+                CallF = args => args.First(),
+                FunctionTypeV = Sets.Functions.RealsToReals
             };
             var expr = new FunctionCall(mf, new Literal(5));
             var ec = new ExpressionChecker();
@@ -57,7 +58,8 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
                 new[] { new Parameter("", Reals.Value) },
                 "f")
             {
-                CallF = args => args.First()
+                CallF = args => args.First(),
+                FunctionTypeV = Sets.Functions.RealsToReals
             };
             var expr = new FunctionCall(new VariableAccess("f"),
                 new Expression[] { new Literal(5) });

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/ExpressionsT/MatrixExpressionT/CheckTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/ExpressionsT/MatrixExpressionT/CheckTest.cs
@@ -116,8 +116,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
                 () => ec.Check(expr, null));
             // and
             Assert.That(ex.Message,
-                Is.EqualTo(
-                    "The type was incorrect: All components must be reals"));
+                Is.EqualTo("All components must be reals"));
         }
 
         [Test]
@@ -135,8 +134,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
                 () => ec.Check(expr, null));
             // and
             Assert.That(ex.Message,
-                Is.EqualTo(
-                    "The type was incorrect: All components must be reals"));
+                Is.EqualTo("All components must be reals"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/ExpressionsT/VectorExpressionT/CheckTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/ExpressionsT/VectorExpressionT/CheckTest.cs
@@ -96,8 +96,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
                 () => ec.Check(expr, null));
             // and
             Assert.That(ex.Message,
-                Is.EqualTo(
-                    "The type was incorrect: All components must be reals"));
+                Is.EqualTo("All components must be reals"));
         }
 
         [Test]
@@ -114,8 +113,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
                 () => ec.Check(expr, null));
             // and
             Assert.That(ex.Message,
-                Is.EqualTo(
-                    "The type was incorrect: All components must be reals"));
+                Is.EqualTo("All components must be reals"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/AdditionOperationT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/AdditionOperationT/CallTest.cs
@@ -96,9 +96,9 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var f = AdditionOperation.Value;
             var args = new Expression[]
             {
-                new Literal(new Vector(new float[] { 1, 2, 3 })),
                 new Literal(1),
-                new Literal(2)
+                new Literal(new Vector(new float[] { 1, 2, 3 })),
+                new Literal(3),
             };
             var expr = new FunctionCall(f, args);
             var ec = new ExpressionChecker();
@@ -108,8 +108,8 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             Assert.That(
                 ex.Message,
                 Is.EqualTo(
-                    "Argument 0 wrong type: " +
-                    "expected Scalar but got Vector"));
+                    "Wrong argument type at index 1: " +
+                    "expected Scalar but got Vector(3)"));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/AdditionOperationT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/AdditionOperationT/CallTest.cs
@@ -39,7 +39,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
         {
             // given
             var f = AdditionOperation.Value;
-            var args = new Expression[] { new Literal(1) };
+            var args = Array.Empty<Expression>();
             var expr = new FunctionCall(f, args);
             var ec = new ExpressionChecker();
             // expect

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/AdditionOperationT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/AdditionOperationT/CallTest.cs
@@ -43,7 +43,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var expr = new FunctionCall(f, args);
             var ec = new ExpressionChecker();
             // expect
-            Assert.Throws<ArgumentException>(
+            Assert.Throws<TypeException>(
                 () => ec.Check(expr, null));
         }
 
@@ -56,7 +56,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var expr = new FunctionCall(f, args);
             var ec = new ExpressionChecker();
             // expect
-            Assert.Throws<ArgumentException>(
+            Assert.Throws<TypeException>(
                 () => ec.Check(expr, null));
         }
 

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/AdditionOperationT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/AdditionOperationT/CallTest.cs
@@ -108,7 +108,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             Assert.That(
                 ex.Message,
                 Is.EqualTo(
-                    "The type was incorrect: Argument 0 wrong type: " +
+                    "Argument 0 wrong type: " +
                     "expected Scalar but got Vector"));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/FactorialFunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/FactorialFunctionT/CallTest.cs
@@ -22,6 +22,7 @@
 
 using System;
 using MetaphysicsIndustries.Solus.Evaluators;
+using MetaphysicsIndustries.Solus.Exceptions;
 using MetaphysicsIndustries.Solus.Expressions;
 using MetaphysicsIndustries.Solus.Functions;
 using NUnit.Framework;
@@ -41,7 +42,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var expr = new FunctionCall(f, args);
             var ec = new ExpressionChecker();
             // expect
-            Assert.Throws<ArgumentException>(() =>
+            Assert.Throws<TypeException>(() =>
                 ec.Check(expr, null));
         }
 
@@ -54,7 +55,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var expr = new FunctionCall(f, args);
             var ec = new ExpressionChecker();
             // expect
-            Assert.Throws<ArgumentException>(() =>
+            Assert.Throws<TypeException>(() =>
                 ec.Check(expr, null));
         }
 
@@ -72,7 +73,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var expr = new FunctionCall(f, args);
             var ec = new ExpressionChecker();
             // expect
-            Assert.Throws<ArgumentException>(() =>
+            Assert.Throws<TypeException>(() =>
                 ec.Check(expr, null));
         }
 

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/MultiplicationOperationT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/MultiplicationOperationT/CallTest.cs
@@ -22,6 +22,7 @@
 
 using System;
 using MetaphysicsIndustries.Solus.Evaluators;
+using MetaphysicsIndustries.Solus.Exceptions;
 using MetaphysicsIndustries.Solus.Expressions;
 using MetaphysicsIndustries.Solus.Functions;
 using NUnit.Framework;
@@ -71,7 +72,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var expr = new FunctionCall(f, args);
             var ec = new ExpressionChecker();
             // expect
-            var ex = Assert.Throws<ArgumentException>(() =>
+            var ex = Assert.Throws<TypeException>(() =>
                 ec.Check(expr, null));
             // and
             Assert.IsTrue(ex.Message.StartsWith("Wrong number of arguments"));
@@ -86,7 +87,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var expr = new FunctionCall(f, args);
             var ec = new ExpressionChecker();
             // expect
-            var ex = Assert.Throws<ArgumentException>(() =>
+            var ex = Assert.Throws<TypeException>(() =>
                 ec.Check(expr, null));
             // and
             Assert.IsTrue(ex.Message.StartsWith("Wrong number of arguments"));

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/MultiplicationOperationT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/MultiplicationOperationT/CallTest.cs
@@ -172,7 +172,7 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
         }
 
         [Test]
-        public void MismatchedMatrixAndVectorThrows()
+        public void MismatchedMatrixAndVectorThrows1()
         {
             // given
             var f = MultiplicationOperation.Value;
@@ -180,6 +180,22 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             {
                 new Literal(Matrix.Identity3),
                 new Literal(Vector2.UnitX),
+            };
+            var expr = new FunctionCall(f, args);
+            var ec = new ExpressionChecker();
+            // expect
+            Assert.Throws<TypeException>(() => ec.Check(expr, null));
+        }
+
+        [Test]
+        public void MismatchedMatrixAndVectorThrows2()
+        {
+            // given
+            var f = MultiplicationOperation.Value;
+            var args = new Expression[]
+            {
+                new Literal(Matrix.Identity2),
+                new Literal(Vector3.UnitX),
             };
             var expr = new FunctionCall(f, args);
             var ec = new ExpressionChecker();

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/MultiplicationOperationT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/MultiplicationOperationT/CallTest.cs
@@ -25,13 +25,14 @@ using MetaphysicsIndustries.Solus.Evaluators;
 using MetaphysicsIndustries.Solus.Exceptions;
 using MetaphysicsIndustries.Solus.Expressions;
 using MetaphysicsIndustries.Solus.Functions;
+using MetaphysicsIndustries.Solus.Values;
 using NUnit.Framework;
 
 namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
     FunctionsT.MultiplicationOperationT
 {
     [TestFixture]
-    public class EvalMultiplicationOperationTest
+    public class CheckMultiplicationOperationTest
     {
         [Test]
         [TestCase(0, 1, 0)]
@@ -120,6 +121,118 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             var ec = new ExpressionChecker();
             // expect
             Assert.DoesNotThrow(() => ec.Check(expr, null));
+        }
+
+        [Test]
+        public void ScalarAndVectorDoesNotThrow()
+        {
+            // given
+            var f = MultiplicationOperation.Value;
+            var args = new Expression[]
+            {
+                new Literal(2),
+                new Literal(Vector3.UnitX),
+            };
+            var expr = new FunctionCall(f, args);
+            var ec = new ExpressionChecker();
+            // expect
+            Assert.DoesNotThrow(() => ec.Check(expr, null));
+        }
+
+        [Test]
+        public void ScalarAndMatrixDoesNotThrow()
+        {
+            // given
+            var f = MultiplicationOperation.Value;
+            var args = new Expression[]
+            {
+                new Literal(2),
+                new Literal(Matrix.Identity3),
+            };
+            var expr = new FunctionCall(f, args);
+            var ec = new ExpressionChecker();
+            // expect
+            Assert.DoesNotThrow(() => ec.Check(expr, null));
+        }
+
+        [Test]
+        public void MatrixAndVectorDoesNotThrow()
+        {
+            // given
+            var f = MultiplicationOperation.Value;
+            var args = new Expression[]
+            {
+                new Literal(Matrix.Identity3),
+                new Literal(Vector3.UnitX),
+            };
+            var expr = new FunctionCall(f, args);
+            var ec = new ExpressionChecker();
+            // expect
+            Assert.DoesNotThrow(() => ec.Check(expr, null));
+        }
+
+        [Test]
+        public void MismatchedMatrixAndVectorThrows()
+        {
+            // given
+            var f = MultiplicationOperation.Value;
+            var args = new Expression[]
+            {
+                new Literal(Matrix.Identity3),
+                new Literal(Vector2.UnitX),
+            };
+            var expr = new FunctionCall(f, args);
+            var ec = new ExpressionChecker();
+            // expect
+            Assert.Throws<TypeException>(() => ec.Check(expr, null));
+        }
+
+        [Test]
+        public void MatrixAndMatrixDoesNotThrow()
+        {
+            // given
+            var f = MultiplicationOperation.Value;
+            var args = new Expression[]
+            {
+                new Literal(Matrix.Identity3),
+                new Literal(Matrix.Identity3),
+            };
+            var expr = new FunctionCall(f, args);
+            var ec = new ExpressionChecker();
+            // expect
+            Assert.DoesNotThrow(() => ec.Check(expr, null));
+        }
+
+        [Test]
+        public void MismatchedMatrixAndMatrixThrows()
+        {
+            // given
+            var f = MultiplicationOperation.Value;
+            var args = new Expression[]
+            {
+                new Literal(Matrix.Identity3),
+                new Literal(Matrix.Identity2),
+            };
+            var expr = new FunctionCall(f, args);
+            var ec = new ExpressionChecker();
+            // expect
+            Assert.Throws<TypeException>(() => ec.Check(expr, null));
+        }
+
+        [Test]
+        public void VectorAndVectorThrows()
+        {
+            // given
+            var f = MultiplicationOperation.Value;
+            var args = new Expression[]
+            {
+                new Literal(Vector3.UnitX),
+                new Literal(Vector3.One),
+            };
+            var expr = new FunctionCall(f, args);
+            var ec = new ExpressionChecker();
+            // expect
+            Assert.Throws<TypeException>(() => ec.Check(expr, null));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/UserDefinedFunctionT/CallTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ExpressionsT/ExpressionCheckerT/FunctionsT/UserDefinedFunctionT/CallTest.cs
@@ -78,8 +78,8 @@ namespace MetaphysicsIndustries.Solus.Test.ExpressionsT.ExpressionCheckerT.
             // and
             Assert.That(ex.Message,
                 Is.EqualTo(
-                    "The type was incorrect: Argument 0 wrong type: " +
-                    "expected Scalar but got String"));
+                    "Argument 0 wrong type: " +
+                    "expected Scalar but got String: x"));
         }
 
         [Test]

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/AbsoluteValueFunctionT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/AbsoluteValueFunctionT/FunctionTypeTest.cs
@@ -1,0 +1,41 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.AbsoluteValueFunctionT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsRealsToReals()
+        {
+            // when
+            var value = AbsoluteValueFunction.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result, Is.SameAs(Sets.Functions.RealsToReals));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/AdditionOperationT/AdditionOperationTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/AdditionOperationT/AdditionOperationTest.cs
@@ -20,9 +20,7 @@
  *
  */
 
-using System;
 using MetaphysicsIndustries.Solus.Functions;
-using MetaphysicsIndustries.Solus.Values;
 using NUnit.Framework;
 
 namespace MetaphysicsIndustries.Solus.Test.FunctionsT.AdditionOperationT
@@ -42,21 +40,6 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.AdditionOperationT
         {
             // expect
             Assert.That(AdditionOperation.Value.Name, Is.EqualTo("+"));
-        }
-
-        [Test]
-        public void PrecedenceIsSet()
-        {
-            // expect
-            Assert.That(AdditionOperation.Value.Precedence,
-                Is.EqualTo(OperationPrecedence.Addition));
-        }
-
-        [Test]
-        public void IdentityValueIsSet()
-        {
-            // expect
-            Assert.That(AdditionOperation.Value.IdentityValue, Is.EqualTo(0));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/AdditionOperationT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/AdditionOperationT/FunctionTypeTest.cs
@@ -1,0 +1,46 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using MetaphysicsIndustries.Solus.Sets;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.AdditionOperationT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsVariadicRealsToReals()
+        {
+            // when
+            var value = AdditionOperation.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result,
+                Is.SameAs(VariadicFunctions.Get(
+                    Reals.Value,
+                    Reals.Value,
+                    2)));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/AdditionOperationT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/AdditionOperationT/FunctionTypeTest.cs
@@ -37,10 +37,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.AdditionOperationT
             var result = value.FunctionType;
             // then
             Assert.That(result,
-                Is.SameAs(VariadicFunctions.Get(
-                    Reals.Value,
-                    Reals.Value,
-                    2)));
+                Is.SameAs(AdditionOperation.AdditionFunctionType.Value));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/AdditionOperationT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/AdditionOperationT/GetResultTest.cs
@@ -31,7 +31,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.AdditionOperationT
     public class GetResultTest
     {
         [Test]
-        public void ResultIsScalar1()
+        public void ResultIsReal()
         {
             // given
             var args = new ISet[] { Reals.Value, Reals.Value };
@@ -43,7 +43,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.AdditionOperationT
         }
 
         [Test]
-        public void ResultIsScalar2()
+        public void ResultIsString()
         {
             // given
             var args = new ISet[] { Strings.Value, Strings.Value };
@@ -51,7 +51,55 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.AdditionOperationT
             var value = AdditionOperation.Value;
             var result = value.GetResultType(null, args);
             // then
-            Assert.That(result, Is.SameAs(Reals.Value));
+            Assert.That(result, Is.SameAs(Strings.Value));
+        }
+
+        [Test]
+        public void ResultIsVector1()
+        {
+            // given
+            var args = new ISet[] { Vectors.R2, Vectors.R2 };
+            // when
+            var value = AdditionOperation.Value;
+            var result = value.GetResultType(null, args);
+            // then
+            Assert.That(result, Is.SameAs(Vectors.R2));
+        }
+
+        [Test]
+        public void ResultIsVector2()
+        {
+            // given
+            var args = new ISet[] { Vectors.R3, Vectors.R3 };
+            // when
+            var value = AdditionOperation.Value;
+            var result = value.GetResultType(null, args);
+            // then
+            Assert.That(result, Is.SameAs(Vectors.R3));
+        }
+
+        [Test]
+        public void ResultIsMatrix1()
+        {
+            // given
+            var args = new ISet[] { Matrices.M2x2, Matrices.M2x2 };
+            // when
+            var value = AdditionOperation.Value;
+            var result = value.GetResultType(null, args);
+            // then
+            Assert.That(result, Is.SameAs(Matrices.M2x2));
+        }
+
+        [Test]
+        public void ResultIsMatrix2()
+        {
+            // given
+            var args = new ISet[] { Matrices.M3x3, Matrices.M3x3 };
+            // when
+            var value = AdditionOperation.Value;
+            var result = value.GetResultType(null, args);
+            // then
+            Assert.That(result, Is.SameAs(Matrices.M3x3));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/ArccosecantFunctionT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/ArccosecantFunctionT/FunctionTypeTest.cs
@@ -1,0 +1,41 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.ArccosecantFunctionT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsRealsToReals()
+        {
+            // when
+            var value = ArccosecantFunction.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result, Is.SameAs(Sets.Functions.RealsToReals));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/ArccosineFunctionT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/ArccosineFunctionT/FunctionTypeTest.cs
@@ -1,0 +1,41 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.ArccosineFunctionT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsRealsToReals()
+        {
+            // when
+            var value = ArccosineFunction.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result, Is.SameAs(Sets.Functions.RealsToReals));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/ArccotangentFunctionT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/ArccotangentFunctionT/FunctionTypeTest.cs
@@ -1,0 +1,41 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.ArccotangentFunctionT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsRealsToReals()
+        {
+            // when
+            var value = ArccotangentFunction.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result, Is.SameAs(Sets.Functions.RealsToReals));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/ArcsecantFunctionT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/ArcsecantFunctionT/FunctionTypeTest.cs
@@ -1,0 +1,41 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.ArcsecantFunctionT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsRealsToReals()
+        {
+            // when
+            var value = ArcsecantFunction.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result, Is.SameAs(Sets.Functions.RealsToReals));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/ArcsineFunctionT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/ArcsineFunctionT/FunctionTypeTest.cs
@@ -1,0 +1,41 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.ArcsineFunctionT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsRealsToReals()
+        {
+            // when
+            var value = ArcsineFunction.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result, Is.SameAs(Sets.Functions.RealsToReals));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/Arctangent2FunctionT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/Arctangent2FunctionT/FunctionTypeTest.cs
@@ -1,0 +1,47 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using MetaphysicsIndustries.Solus.Sets;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.Arctangent2FunctionT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsRealsRealsToReals()
+        {
+            // when
+            var value = Arctangent2Function.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result,
+                Is.SameAs(
+                    Sets.Functions.Get(
+                        Reals.Value,
+                        Reals.Value,
+                        Reals.Value)));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/ArctangentFunctionT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/ArctangentFunctionT/FunctionTypeTest.cs
@@ -1,0 +1,41 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.ArctangentFunctionT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsRealsToReals()
+        {
+            // when
+            var value = ArctangentFunction.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result, Is.SameAs(Sets.Functions.RealsToReals));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/BitwiseAndOperationT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/BitwiseAndOperationT/FunctionTypeTest.cs
@@ -1,0 +1,47 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using MetaphysicsIndustries.Solus.Sets;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.BitwiseAndOperationT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsRealsRealsToReals()
+        {
+            // when
+            var value = BitwiseAndOperation.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result,
+                Is.SameAs(
+                    Sets.Functions.Get(
+                        Reals.Value,
+                        Reals.Value,
+                        Reals.Value)));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/BitwiseOrOperationT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/BitwiseOrOperationT/FunctionTypeTest.cs
@@ -1,0 +1,47 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using MetaphysicsIndustries.Solus.Sets;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.BitwiseOrOperationT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsRealsToReals()
+        {
+            // when
+            var value = BitwiseOrOperation.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result,
+                Is.SameAs(
+                    Sets.Functions.Get(
+                        Reals.Value,
+                        Reals.Value,
+                        Reals.Value)));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/CeilingFunctionT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/CeilingFunctionT/FunctionTypeTest.cs
@@ -1,0 +1,41 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.CeilingFunctionT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsRealsToReals()
+        {
+            // when
+            var value = CeilingFunction.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result, Is.SameAs(Sets.Functions.RealsToReals));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/CosecantFunctionT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/CosecantFunctionT/FunctionTypeTest.cs
@@ -1,0 +1,41 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.CosecantFunctionT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsRealsToReals()
+        {
+            // when
+            var value = CosecantFunction.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result, Is.SameAs(Sets.Functions.RealsToReals));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/CosineFunctionT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/CosineFunctionT/FunctionTypeTest.cs
@@ -1,0 +1,41 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.CosineFunctionT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsRealsToReals()
+        {
+            // when
+            var value = CosineFunction.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result, Is.SameAs(Sets.Functions.RealsToReals));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/CotangentFunctionT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/CotangentFunctionT/FunctionTypeTest.cs
@@ -1,0 +1,41 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.CotangentFunctionT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsRealsToReals()
+        {
+            // when
+            var value = CotangentFunction.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result, Is.SameAs(Sets.Functions.RealsToReals));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/DistFunctionT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/DistFunctionT/FunctionTypeTest.cs
@@ -1,0 +1,47 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using MetaphysicsIndustries.Solus.Sets;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.DistFunctionT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsRealsRealsToReals()
+        {
+            // when
+            var value = DistFunction.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result,
+                Is.SameAs(
+                    Sets.Functions.Get(
+                        Reals.Value,
+                        Reals.Value,
+                        Reals.Value)));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/DistSqFunctionT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/DistSqFunctionT/FunctionTypeTest.cs
@@ -1,0 +1,47 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using MetaphysicsIndustries.Solus.Sets;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.DistSqFunctionT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsRealsRealsToReals()
+        {
+            // when
+            var value = DistSqFunction.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result,
+                Is.SameAs(
+                    Sets.Functions.Get(
+                        Reals.Value,
+                        Reals.Value,
+                        Reals.Value)));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/DivisionOperationT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/DivisionOperationT/FunctionTypeTest.cs
@@ -1,0 +1,47 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using MetaphysicsIndustries.Solus.Sets;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.DivisionOperationT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsRealsRealsToReals()
+        {
+            // when
+            var value = DivisionOperation.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result,
+                Is.SameAs(
+                    Sets.Functions.Get(
+                        Reals.Value,
+                        Reals.Value,
+                        Reals.Value)));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/EqualComparisonOperationT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/EqualComparisonOperationT/FunctionTypeTest.cs
@@ -1,0 +1,47 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using MetaphysicsIndustries.Solus.Sets;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.EqualComparisonOperationT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsMathObjectsMathObjectsToBooleans()
+        {
+            // when
+            var value = EqualComparisonOperation.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result,
+                Is.SameAs(
+                    Sets.Functions.Get(
+                        Booleans.Value,
+                        MathObjects.Value,
+                        MathObjects.Value)));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/ExponentOperationT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/ExponentOperationT/FunctionTypeTest.cs
@@ -1,0 +1,47 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using MetaphysicsIndustries.Solus.Sets;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.ExponentOperationT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsRealsRealsToReals()
+        {
+            // when
+            var value = ExponentOperation.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result,
+                Is.SameAs(
+                    Sets.Functions.Get(
+                        Reals.Value,
+                        Reals.Value,
+                        Reals.Value)));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/FactorialFunctionT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/FactorialFunctionT/FunctionTypeTest.cs
@@ -1,0 +1,41 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.FactorialFunctionT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsRealsToReals()
+        {
+            // when
+            var value = FactorialFunction.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result, Is.SameAs(Sets.Functions.RealsToReals));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/FloorFunctionT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/FloorFunctionT/FunctionTypeTest.cs
@@ -1,0 +1,41 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.FloorFunctionT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsRealsToReals()
+        {
+            // when
+            var value = FloorFunction.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result, Is.SameAs(Sets.Functions.RealsToReals));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/GreaterThanComparisonOperationT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/GreaterThanComparisonOperationT/FunctionTypeTest.cs
@@ -1,0 +1,48 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using MetaphysicsIndustries.Solus.Sets;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.
+    GreaterThanComparisonOperationT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsRealsRealsToBooleans()
+        {
+            // when
+            var value = GreaterThanComparisonOperation.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result,
+                Is.SameAs(
+                    Sets.Functions.Get(
+                        Booleans.Value,
+                        Reals.Value,
+                        Reals.Value)));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/GreaterThanOrEqualComparisonOperationT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/GreaterThanOrEqualComparisonOperationT/FunctionTypeTest.cs
@@ -1,0 +1,48 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using MetaphysicsIndustries.Solus.Sets;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.
+    GreaterThanOrEqualComparisonOperationT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsRealsRealsToBooleans()
+        {
+            // when
+            var value = GreaterThanOrEqualComparisonOperation.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result,
+                Is.SameAs(
+                    Sets.Functions.Get(
+                        Booleans.Value,
+                        Reals.Value,
+                        Reals.Value)));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/LessThanComparisonOperationT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/LessThanComparisonOperationT/FunctionTypeTest.cs
@@ -1,0 +1,48 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using MetaphysicsIndustries.Solus.Sets;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.
+    LessThanComparisonOperationT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsRealsRealsToBooleans()
+        {
+            // when
+            var value = LessThanComparisonOperation.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result,
+                Is.SameAs(
+                    Sets.Functions.Get(
+                        Booleans.Value,
+                        Reals.Value,
+                        Reals.Value)));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/LessThanOrEqualComparisonOperationT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/LessThanOrEqualComparisonOperationT/FunctionTypeTest.cs
@@ -1,0 +1,48 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using MetaphysicsIndustries.Solus.Sets;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.
+    LessThanOrEqualComparisonOperationT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsRealsRealsToBooleans()
+        {
+            // when
+            var value = LessThanOrEqualComparisonOperation.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result,
+                Is.SameAs(
+                    Sets.Functions.Get(
+                        Booleans.Value,
+                        Reals.Value,
+                        Reals.Value)));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/LoadImageFunctionT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/LoadImageFunctionT/FunctionTypeTest.cs
@@ -1,0 +1,45 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using MetaphysicsIndustries.Solus.Sets;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.LoadImageFunctionT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsStringsToAllMatrices()
+        {
+            // when
+            var value = LoadImageFunction.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result,
+                Is.SameAs(Sets.Functions.Get(
+                    AllMatrices.Value,
+                    Strings.Value)));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/Log10FunctionT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/Log10FunctionT/FunctionTypeTest.cs
@@ -1,0 +1,41 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.Log10FunctionT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsRealsToReals()
+        {
+            // when
+            var value = Log10Function.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result, Is.SameAs(Sets.Functions.RealsToReals));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/Log2FunctionT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/Log2FunctionT/FunctionTypeTest.cs
@@ -1,0 +1,41 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.Log2FunctionT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsRealsToReals()
+        {
+            // when
+            var value = Log2Function.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result, Is.SameAs(Sets.Functions.RealsToReals));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/LogarithmFunctionT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/LogarithmFunctionT/FunctionTypeTest.cs
@@ -1,0 +1,47 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using MetaphysicsIndustries.Solus.Sets;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.LogarithmFunctionT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsRealsRealsToReals()
+        {
+            // when
+            var value = LogarithmFunction.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result,
+                Is.SameAs(
+                    Sets.Functions.Get(
+                        Reals.Value,
+                        Reals.Value,
+                        Reals.Value)));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/LogicalAndOperationT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/LogicalAndOperationT/FunctionTypeTest.cs
@@ -1,0 +1,47 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using MetaphysicsIndustries.Solus.Sets;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.LogicalAndOperationT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsBoolsBoolslsToBooleans()
+        {
+            // when
+            var value = LogicalAndOperation.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result,
+                Is.SameAs(
+                    Sets.Functions.Get(
+                        Booleans.Value,
+                        Booleans.Value,
+                        Booleans.Value)));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/LogicalOrOperationT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/LogicalOrOperationT/FunctionTypeTest.cs
@@ -1,0 +1,47 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using MetaphysicsIndustries.Solus.Sets;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.LogicalOrOperationT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsBoolsBoolslsToBooleans()
+        {
+            // when
+            var value = LogicalOrOperation.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result,
+                Is.SameAs(
+                    Sets.Functions.Get(
+                        Booleans.Value,
+                        Booleans.Value,
+                        Booleans.Value)));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/MaximumFiniteFunctionT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/MaximumFiniteFunctionT/FunctionTypeTest.cs
@@ -1,0 +1,44 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using System;
+using MetaphysicsIndustries.Solus.Functions;
+using MetaphysicsIndustries.Solus.Sets;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.MaximumFiniteFunctionT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsNotImplemented()
+        {
+            // when
+            var value = MaximumFiniteFunction.Value;
+            // expect
+            IFunctionType result;
+            Assert.Throws<NotImplementedException>(
+                () => result = value.FunctionType);
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/MaximumFunctionT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/MaximumFunctionT/FunctionTypeTest.cs
@@ -1,0 +1,44 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using System;
+using MetaphysicsIndustries.Solus.Functions;
+using MetaphysicsIndustries.Solus.Sets;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.MaximumFunctionT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsNotImplemented()
+        {
+            // when
+            var value = MaximumFunction.Value;
+            // expect
+            IFunctionType result;
+            Assert.Throws<NotImplementedException>(
+                () => result = value.FunctionType);
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/MinimumFiniteFunctionT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/MinimumFiniteFunctionT/FunctionTypeTest.cs
@@ -1,0 +1,44 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using System;
+using MetaphysicsIndustries.Solus.Functions;
+using MetaphysicsIndustries.Solus.Sets;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.MinimumFiniteFunctionT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsNotImplemented()
+        {
+            // when
+            var value = MinimumFiniteFunction.Value;
+            // expect
+            IFunctionType result;
+            Assert.Throws<NotImplementedException>(
+                () => result = value.FunctionType);
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/MinimumFunctionT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/MinimumFunctionT/FunctionTypeTest.cs
@@ -1,0 +1,44 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using System;
+using MetaphysicsIndustries.Solus.Functions;
+using MetaphysicsIndustries.Solus.Sets;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.MinimumFunctionT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsNotImplemented()
+        {
+            // when
+            var value = MinimumFunction.Value;
+            // expect
+            IFunctionType result;
+            Assert.Throws<NotImplementedException>(
+                () => result = value.FunctionType);
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/ModularDivisionT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/ModularDivisionT/FunctionTypeTest.cs
@@ -1,0 +1,47 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using MetaphysicsIndustries.Solus.Sets;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.ModularDivisionT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsRealsRealsToReals()
+        {
+            // when
+            var value = ModularDivision.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result,
+                Is.SameAs(
+                    Sets.Functions.Get(
+                        Reals.Value,
+                        Reals.Value,
+                        Reals.Value)));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/MultiplicationOperationT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/MultiplicationOperationT/FunctionTypeTest.cs
@@ -1,0 +1,44 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using System;
+using MetaphysicsIndustries.Solus.Functions;
+using MetaphysicsIndustries.Solus.Sets;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.MultiplicationOperationT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsNotImplemented()
+        {
+            // when
+            var value = MultiplicationOperation.Value;
+            // expect
+            IFunctionType result;
+            Assert.Throws<NotImplementedException>(
+                () => result = value.FunctionType);
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/MultiplicationOperationT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/MultiplicationOperationT/FunctionTypeTest.cs
@@ -1,4 +1,3 @@
-
 /*
  *  MetaphysicsIndustries.Solus
  *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
@@ -35,10 +34,13 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.MultiplicationOperationT
         {
             // when
             var value = MultiplicationOperation.Value;
-            // expect
-            IFunctionType result;
-            Assert.Throws<NotImplementedException>(
-                () => result = value.FunctionType);
+            var result = value.FunctionType;
+            // then
+            Assert.That(result,
+                Is.SameAs(VariadicFunctions.Get(
+                    Reals.Value,
+                    Reals.Value,
+                    2)));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/MultiplicationOperationT/GetResultTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/MultiplicationOperationT/GetResultTest.cs
@@ -1,4 +1,3 @@
-
 /*
  *  MetaphysicsIndustries.Solus
  *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
@@ -20,9 +19,9 @@
  *
  */
 
+using MetaphysicsIndustries.Solus.Exceptions;
 using MetaphysicsIndustries.Solus.Functions;
 using MetaphysicsIndustries.Solus.Sets;
-using MetaphysicsIndustries.Solus.Values;
 using NUnit.Framework;
 
 namespace MetaphysicsIndustries.Solus.Test.FunctionsT.MultiplicationOperationT
@@ -31,7 +30,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.MultiplicationOperationT
     public class GetResultTest
     {
         [Test]
-        public void ResultMatchesFirstArg1()
+        public void ScalarsYieldScalar()
         {
             // given
             var args = new ISet[] { Reals.Value, Reals.Value };
@@ -43,7 +42,7 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.MultiplicationOperationT
         }
 
         [Test]
-        public void ResultMatchesFirstArg2()
+        public void ScalarsAndVectorYieldVector1()
         {
             // given
             var args = new ISet[] { Vectors.R3, Reals.Value };
@@ -52,6 +51,207 @@ namespace MetaphysicsIndustries.Solus.Test.FunctionsT.MultiplicationOperationT
             var result = value.GetResultType(null, args);
             // then
             Assert.That(result, Is.SameAs(Vectors.R3));
+        }
+
+        [Test]
+        public void ScalarsAndVectorYieldVector2()
+        {
+            // given
+            var args = new ISet[] { Vectors.R3, Reals.Value, Reals.Value };
+            // when
+            var value = MultiplicationOperation.Value;
+            var result = value.GetResultType(null, args);
+            // then
+            Assert.That(result, Is.SameAs(Vectors.R3));
+        }
+
+        [Test]
+        public void ScalarsAndVectorYieldVector3()
+        {
+            // given
+            var args = new ISet[] { Reals.Value, Vectors.R3 };
+            // when
+            var value = MultiplicationOperation.Value;
+            var result = value.GetResultType(null, args);
+            // then
+            Assert.That(result, Is.SameAs(Vectors.R3));
+        }
+
+        [Test]
+        public void ScalarsAndVectorYieldVector4()
+        {
+            // given
+            var args = new ISet[] { Reals.Value, Reals.Value, Vectors.R3 };
+            // when
+            var value = MultiplicationOperation.Value;
+            var result = value.GetResultType(null, args);
+            // then
+            Assert.That(result, Is.SameAs(Vectors.R3));
+        }
+
+        [Test]
+        public void ScalarsAndVectorYieldVector5()
+        {
+            // given
+            var args = new ISet[] { Reals.Value, Vectors.R3, Reals.Value };
+            // when
+            var value = MultiplicationOperation.Value;
+            var result = value.GetResultType(null, args);
+            // then
+            Assert.That(result, Is.SameAs(Vectors.R3));
+        }
+
+        [Test]
+        public void MultipleVectorsRaises()
+        {
+            // given
+            var args = new ISet[] { Vectors.R3, Vectors.R3, };
+            // expect
+            var value = MultiplicationOperation.Value;
+            Assert.Throws<TypeException>(
+                () => value.GetResultType(null, args));
+        }
+
+
+        [Test]
+        public void ScalarsAndMatrixYieldMatrix1()
+        {
+            // given
+            var args = new ISet[] { Matrices.M3x3, Reals.Value };
+            // when
+            var value = MultiplicationOperation.Value;
+            var result = value.GetResultType(null, args);
+            // then
+            Assert.That(result, Is.SameAs(Matrices.M3x3));
+        }
+
+        [Test]
+        public void ScalarsAndMatrixYieldMatrix2()
+        {
+            // given
+            var args = new ISet[] { Matrices.M3x3, Reals.Value, Reals.Value };
+            // when
+            var value = MultiplicationOperation.Value;
+            var result = value.GetResultType(null, args);
+            // then
+            Assert.That(result, Is.SameAs(Matrices.M3x3));
+        }
+
+        [Test]
+        public void ScalarsAndMatrixYieldMatrix3()
+        {
+            // given
+            var args = new ISet[] { Reals.Value, Matrices.M3x3 };
+            // when
+            var value = MultiplicationOperation.Value;
+            var result = value.GetResultType(null, args);
+            // then
+            Assert.That(result, Is.SameAs(Matrices.M3x3));
+        }
+
+        [Test]
+        public void ScalarsAndMatrixYieldMatrix4()
+        {
+            // given
+            var args = new ISet[] { Reals.Value, Reals.Value, Matrices.M3x3 };
+            // when
+            var value = MultiplicationOperation.Value;
+            var result = value.GetResultType(null, args);
+            // then
+            Assert.That(result, Is.SameAs(Matrices.M3x3));
+        }
+
+        [Test]
+        public void ScalarsAndMatrixYieldMatrix5()
+        {
+            // given
+            var args = new ISet[] { Reals.Value, Matrices.M3x3, Reals.Value };
+            // when
+            var value = MultiplicationOperation.Value;
+            var result = value.GetResultType(null, args);
+            // then
+            Assert.That(result, Is.SameAs(Matrices.M3x3));
+        }
+
+        [Test]
+        public void MatrixAndMatrixYieldsMatrix1()
+        {
+            // given
+            var args = new ISet[] { Matrices.M3x3, Matrices.M3x3 };
+            // when
+            var value = MultiplicationOperation.Value;
+            var result = value.GetResultType(null, args);
+            // then
+            Assert.That(result, Is.SameAs(Matrices.M3x3));
+        }
+
+        [Test]
+        public void MatrixAndMatrixYieldsMatrix2()
+        {
+            // given
+            var args = new ISet[] { Matrices.M2x4, Matrices.M4x3 };
+            // when
+            var value = MultiplicationOperation.Value;
+            var result = value.GetResultType(null, args);
+            // then
+            Assert.That(result, Is.SameAs(Matrices.M2x3));
+        }
+
+        [Test]
+        public void IncompatibleMatrixAndMatrixThrows()
+        {
+            // given
+            var args = new ISet[] { Matrices.M2x4, Matrices.M2x4 };
+            // expect
+            var value = MultiplicationOperation.Value;
+            Assert.Throws<TypeException>(
+                () => value.GetResultType(null, args));
+        }
+
+        [Test]
+        public void MatrixAndVectorYieldsVector1()
+        {
+            // given
+            var args = new ISet[] { Matrices.M3x3, Vectors.R3 };
+            // when
+            var value = MultiplicationOperation.Value;
+            var result = value.GetResultType(null, args);
+            // then
+            Assert.That(result, Is.SameAs(Vectors.R3));
+        }
+
+        [Test]
+        public void MatrixAndVectorYieldsVector2()
+        {
+            // given
+            var args = new ISet[] { Vectors.R3, Matrices.M3x3 };
+            // when
+            var value = MultiplicationOperation.Value;
+            var result = value.GetResultType(null, args);
+            // then
+            Assert.That(result, Is.SameAs(Vectors.R3));
+        }
+
+        [Test]
+        public void IncompatibleMatrixAndVectorThrows1()
+        {
+            // given
+            var args = new ISet[] { Matrices.M3x3, Vectors.R2 };
+            // expect
+            var value = MultiplicationOperation.Value;
+            Assert.Throws<TypeException>(
+                () => value.GetResultType(null, args));
+        }
+
+        [Test]
+        public void IncompatibleMatrixAndVectorThrows2()
+        {
+            // given
+            var args = new ISet[] { Vectors.R2, Matrices.M3x3 };
+            // expect
+            var value = MultiplicationOperation.Value;
+            Assert.Throws<TypeException>(
+                () => value.GetResultType(null, args));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/NaturalLogarithmFunctionT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/NaturalLogarithmFunctionT/FunctionTypeTest.cs
@@ -1,0 +1,41 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.NaturalLogarithmFunctionT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsRealsToReals()
+        {
+            // when
+            var value = NaturalLogarithmFunction.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result, Is.SameAs(Sets.Functions.RealsToReals));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/NegationOperationT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/NegationOperationT/FunctionTypeTest.cs
@@ -1,0 +1,41 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.NegationOperationT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsRealsToReals()
+        {
+            // when
+            var value = NegationOperation.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result, Is.SameAs(Sets.Functions.RealsToReals));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/NotEqualComparisonOperationT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/NotEqualComparisonOperationT/FunctionTypeTest.cs
@@ -1,0 +1,48 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using MetaphysicsIndustries.Solus.Sets;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.
+    NotEqualComparisonOperationT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsMathObjectsMathObjectsToBooleans()
+        {
+            // when
+            var value = NotEqualComparisonOperation.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result,
+                Is.SameAs(
+                    Sets.Functions.Get(
+                        Booleans.Value,
+                        MathObjects.Value,
+                        MathObjects.Value)));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/SecantFunctionT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/SecantFunctionT/FunctionTypeTest.cs
@@ -1,0 +1,41 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.SecantFunctionT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsRealsToReals()
+        {
+            // when
+            var value = SecantFunction.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result, Is.SameAs(Sets.Functions.RealsToReals));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/SineFunctionT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/SineFunctionT/FunctionTypeTest.cs
@@ -1,0 +1,41 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.SineFunctionT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsRealsToReals()
+        {
+            // when
+            var value = SineFunction.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result, Is.SameAs(Sets.Functions.RealsToReals));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/SizeFunctionT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/SizeFunctionT/FunctionTypeTest.cs
@@ -1,0 +1,44 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using System;
+using MetaphysicsIndustries.Solus.Functions;
+using MetaphysicsIndustries.Solus.Sets;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.SizeFunctionT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsNotImplemented()
+        {
+            // when
+            var value = SizeFunction.Value;
+            // expect
+            IFunctionType result;
+            Assert.Throws<NotImplementedException>(
+                () => result = value.FunctionType);
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/TangentFunctionT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/TangentFunctionT/FunctionTypeTest.cs
@@ -1,0 +1,41 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.TangentFunctionT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsRealsToReals()
+        {
+            // when
+            var value = TangentFunction.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result, Is.SameAs(Sets.Functions.RealsToReals));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/UnitStepFunctionT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/UnitStepFunctionT/FunctionTypeTest.cs
@@ -1,0 +1,41 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Functions;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.UnitStepFunctionT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void TypeIsRealsToReals()
+        {
+            // when
+            var value = UnitStepFunction.Value;
+            var result = value.FunctionType;
+            // then
+            Assert.That(result, Is.SameAs(Sets.Functions.RealsToReals));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/FunctionsT/UserDefinedFunctionT/FunctionTypeTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/FunctionsT/UserDefinedFunctionT/FunctionTypeTest.cs
@@ -1,0 +1,82 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using System;
+using MetaphysicsIndustries.Solus.Expressions;
+using MetaphysicsIndustries.Solus.Functions;
+using MetaphysicsIndustries.Solus.Sets;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.FunctionsT.UserDefinedFunctionT
+{
+    [TestFixture]
+    public class FunctionTypeTest
+    {
+        [Test]
+        public void NullaryFunctionType1()
+        {
+            // given
+            var expr = new Literal(1.ToNumber());
+            var f = new UserDefinedFunction("f", Array.Empty<string>(), expr);
+            // when
+            var result = f.FunctionType;
+            // then
+            Assert.That(result, Is.SameAs(Sets.Functions.Get(Reals.Value)));
+        }
+
+        [Test]
+        public void NullaryStringStillSaysReals()
+        {
+            // given
+            var expr = new Literal("abc");
+            var f = new UserDefinedFunction("f", Array.Empty<string>(), expr);
+            // when
+            var result = f.FunctionType;
+            // then
+            Assert.That(result, Is.SameAs(Sets.Functions.Get(Reals.Value)));
+        }
+
+        [Test]
+        public void NullaryBooleanStillSaysReals()
+        {
+            // given
+            var expr = new Literal(true);
+            var f = new UserDefinedFunction("f", Array.Empty<string>(), expr);
+            // when
+            var result = f.FunctionType;
+            // then
+            Assert.That(result, Is.SameAs(Sets.Functions.Get(Reals.Value)));
+        }
+
+        [Test]
+        public void UnaryFunctionType3()
+        {
+            // given
+            var expr = new VariableAccess("a");
+            var f = new UserDefinedFunction("f", new[] { "a" }, expr);
+            // when
+            var result = f.FunctionType;
+            // then
+            Assert.That(result, Is.SameAs(Sets.Functions.RealsToReals));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/MockFunction.cs
+++ b/MetaphysicsIndustries.Solus.Test/MockFunction.cs
@@ -22,8 +22,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using MetaphysicsIndustries.Solus.Functions;
-using MetaphysicsIndustries.Solus.Values;
+using MetaphysicsIndustries.Solus.Sets;
 
 namespace MetaphysicsIndustries.Solus.Test
 {
@@ -52,6 +53,19 @@ namespace MetaphysicsIndustries.Solus.Test
             if (GetResultF != null)
                 return GetResultF(argTypes);
             throw new NotImplementedException();
+        }
+
+        public IFunctionType FunctionTypeV;
+        public override IFunctionType FunctionType
+        {
+            get
+            {
+                if (FunctionTypeV != null)
+                    return FunctionTypeV;
+                return Sets.Functions.Get(
+                    GetResultType(null, null),
+                    Parameters.Select(p => p.Type).ToArray());
+            }
         }
 
         public string DocStringV = "";

--- a/MetaphysicsIndustries.Solus.Test/MockSet.cs
+++ b/MetaphysicsIndustries.Solus.Test/MockSet.cs
@@ -53,7 +53,8 @@ namespace MetaphysicsIndustries.Solus.Test
         }
 
         public bool IsSupersetOf(ISet other) =>
-            throw new NotImplementedException();
+            other == this ||
+            other.IsSubsetOf(this);
         public bool IsSubsetOf(ISet other) =>
             throw new NotImplementedException();
     }

--- a/MetaphysicsIndustries.Solus.Test/SetsT/AllFunctionsT/SupersetAndSubsetTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/SetsT/AllFunctionsT/SupersetAndSubsetTest.cs
@@ -32,49 +32,49 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.AllFunctionsT
         public void TestAllFunctionsIsNotSupersetOfMathObjects()
         {
             // expect
-            Assert.That(!AllFunctions.Value.IsSupersetOf(MathObjects.Value));
+            Assert.False(AllFunctions.Value.IsSupersetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestAllFunctionsIsSubsetOfMathObjects()
         {
             // expect
-            Assert.That(AllFunctions.Value.IsSubsetOf(MathObjects.Value));
+            Assert.True(AllFunctions.Value.IsSubsetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestAllFunctionsIsNotSupersetOfSets()
         {
             // expect
-            Assert.That(!AllFunctions.Value.IsSupersetOf(Sets.Sets.Value));
+            Assert.False(AllFunctions.Value.IsSupersetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestAllFunctionsIsNotSubsetOfSets()
         {
             // expect
-            Assert.That(!AllFunctions.Value.IsSubsetOf(Sets.Sets.Value));
+            Assert.False(AllFunctions.Value.IsSubsetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestAllFunctionsIsSupersetOfSelf()
         {
             // expect
-            Assert.That(AllFunctions.Value.IsSupersetOf(AllFunctions.Value));
+            Assert.True(AllFunctions.Value.IsSupersetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestAllFunctionsIsSubsetOfSelf()
         {
             // expect
-            Assert.That(AllFunctions.Value.IsSubsetOf(AllFunctions.Value));
+            Assert.True(AllFunctions.Value.IsSubsetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestAllFunctionsIsSupersetOfFunctions()
         {
             // expect
-            Assert.That(
+            Assert.True(
                 AllFunctions.Value.IsSupersetOf(Sets.Functions.RealsToReals));
         }
 
@@ -82,278 +82,297 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.AllFunctionsT
         public void TestAllFunctionsIsNotSubsetOfFunctions()
         {
             // expect
-            Assert.That(
-                !AllFunctions.Value.IsSubsetOf(Sets.Functions.RealsToReals));
+            Assert.False(
+                AllFunctions.Value.IsSubsetOf(Sets.Functions.RealsToReals));
+        }
+
+        [Test]
+        public void TestAllFunctionsIsSupersetOfVariadicFunctions()
+        {
+            // expect
+            Assert.True(
+                AllFunctions.Value.IsSupersetOf(
+                    VariadicFunctions.RealsToReals));
+        }
+
+        [Test]
+        public void TestAllFunctionsIsNotSubsetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                AllFunctions.Value.IsSubsetOf(
+                    VariadicFunctions.RealsToReals));
         }
 
         [Test]
         public void TestAllFunctionsIsNotSupersetOfTensors()
         {
             // expect
-            Assert.That(!AllFunctions.Value.IsSupersetOf(Tensors.Value));
+            Assert.False(AllFunctions.Value.IsSupersetOf(Tensors.Value));
         }
 
         [Test]
         public void TestAllFunctionsIsNotSubsetOfTensors()
         {
             // expect
-            Assert.That(!AllFunctions.Value.IsSubsetOf(Tensors.Value));
+            Assert.False(AllFunctions.Value.IsSubsetOf(Tensors.Value));
         }
 
         [Test]
         public void TestAllFunctionsIsNotSupersetOfAllVectors()
         {
             // expect
-            Assert.That(!AllFunctions.Value.IsSupersetOf(AllVectors.Value));
+            Assert.False(AllFunctions.Value.IsSupersetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestAllFunctionsIsNotSubsetOfAllVectors()
         {
             // expect
-            Assert.That(!AllFunctions.Value.IsSubsetOf(AllVectors.Value));
+            Assert.False(AllFunctions.Value.IsSubsetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestAllFunctionsIsNotSupersetOfVectors()
         {
             // expect
-            Assert.That(!AllFunctions.Value.IsSupersetOf(Vectors.R2));
-            Assert.That(!AllFunctions.Value.IsSupersetOf(Vectors.R3));
+            Assert.False(AllFunctions.Value.IsSupersetOf(Vectors.R2));
+            Assert.False(AllFunctions.Value.IsSupersetOf(Vectors.R3));
         }
 
         [Test]
         public void TestAllFunctionsIsNotSubsetOfVectors()
         {
             // expect
-            Assert.That(!AllFunctions.Value.IsSubsetOf(Vectors.R2));
-            Assert.That(!AllFunctions.Value.IsSubsetOf(Vectors.R3));
+            Assert.False(AllFunctions.Value.IsSubsetOf(Vectors.R2));
+            Assert.False(AllFunctions.Value.IsSubsetOf(Vectors.R3));
         }
 
         [Test]
         public void TestAllFunctionsIsNotSupersetOfAllMatrices()
         {
             // expect
-            Assert.That(!AllFunctions.Value.IsSupersetOf(AllMatrices.Value));
+            Assert.False(AllFunctions.Value.IsSupersetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestAllFunctionsIsNotSubsetOfAllMatrices()
         {
             // expect
-            Assert.That(!AllFunctions.Value.IsSubsetOf(AllMatrices.Value));
+            Assert.False(AllFunctions.Value.IsSubsetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestAllFunctionsIsNotSupersetOfMatrices()
         {
             // expect
-            Assert.That(!AllFunctions.Value.IsSupersetOf(Matrices.M2x2));
-            Assert.That(!AllFunctions.Value.IsSupersetOf(Matrices.M3x3));
+            Assert.False(AllFunctions.Value.IsSupersetOf(Matrices.M2x2));
+            Assert.False(AllFunctions.Value.IsSupersetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestAllFunctionsIsNotSubsetOfMatrices()
         {
             // expect
-            Assert.That(!AllFunctions.Value.IsSubsetOf(Matrices.M2x2));
-            Assert.That(!AllFunctions.Value.IsSubsetOf(Matrices.M3x3));
+            Assert.False(AllFunctions.Value.IsSubsetOf(Matrices.M2x2));
+            Assert.False(AllFunctions.Value.IsSubsetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestAllFunctionsIsNotSupersetOfReals()
         {
             // expect
-            Assert.That(!AllFunctions.Value.IsSupersetOf(Reals.Value));
+            Assert.False(AllFunctions.Value.IsSupersetOf(Reals.Value));
         }
 
         [Test]
         public void TestAllFunctionsIsNotSubsetOfReals()
         {
             // expect
-            Assert.That(!AllFunctions.Value.IsSubsetOf(Reals.Value));
+            Assert.False(AllFunctions.Value.IsSubsetOf(Reals.Value));
         }
 
         [Test]
         public void TestAllFunctionsIsNotSupersetOfStrings()
         {
             // expect
-            Assert.That(!AllFunctions.Value.IsSupersetOf(Strings.Value));
+            Assert.False(AllFunctions.Value.IsSupersetOf(Strings.Value));
         }
 
         [Test]
         public void TestAllFunctionsIsNotSubsetOfStrings()
         {
             // expect
-            Assert.That(!AllFunctions.Value.IsSubsetOf(Strings.Value));
+            Assert.False(AllFunctions.Value.IsSubsetOf(Strings.Value));
         }
 
         [Test]
         public void TestAllFunctionsIsNotSupersetOfIntervals()
         {
             // expect
-            Assert.That(!AllFunctions.Value.IsSupersetOf(Intervals.Value));
+            Assert.False(AllFunctions.Value.IsSupersetOf(Intervals.Value));
         }
 
         [Test]
         public void TestAllFunctionsIsNotSubsetOfIntervals()
         {
             // expect
-            Assert.That(!AllFunctions.Value.IsSubsetOf(Intervals.Value));
+            Assert.False(AllFunctions.Value.IsSubsetOf(Intervals.Value));
         }
 
         [Test]
         public void TestAllFunctionsIsNotSupersetOfBooleans()
         {
             // expect
-            Assert.That(!AllFunctions.Value.IsSupersetOf(Booleans.Value));
+            Assert.False(AllFunctions.Value.IsSupersetOf(Booleans.Value));
         }
 
         [Test]
         public void TestAllFunctionsIsNotSubsetOfBooleans()
         {
             // expect
-            Assert.That(!AllFunctions.Value.IsSubsetOf(Booleans.Value));
+            Assert.False(AllFunctions.Value.IsSubsetOf(Booleans.Value));
         }
 
         [Test]
         public void TestAllFunctionsIsNotSupersetOfExpressions()
         {
             // expect
-            Assert.That(
-                !AllFunctions.Value.IsSupersetOf(Sets.Expressions.Value));
+            Assert.False(
+                AllFunctions.Value.IsSupersetOf(Sets.Expressions.Value));
         }
 
         [Test]
         public void TestAllFunctionsIsNotSubsetOfExpressions()
         {
             // expect
-            Assert.That(!AllFunctions.Value.IsSubsetOf(
-                Sets.Expressions.Value));
+            Assert.False(
+                AllFunctions.Value.IsSubsetOf(Sets.Expressions.Value));
         }
 
         [Test]
         public void TestAllFunctionsIsNotSupersetOfLiterals()
         {
             // expect
-            Assert.That(!AllFunctions.Value.IsSupersetOf(Literals.Value));
+            Assert.False(AllFunctions.Value.IsSupersetOf(Literals.Value));
         }
 
         [Test]
         public void TestAllFunctionsIsNotSubsetOfLiterals()
         {
             // expect
-            Assert.That(!AllFunctions.Value.IsSubsetOf(Literals.Value));
+            Assert.False(AllFunctions.Value.IsSubsetOf(Literals.Value));
         }
 
         [Test]
         public void TestAllFunctionsIsNotSupersetOfComponentAccesses()
         {
             // expect
-            Assert.That(
-                !AllFunctions.Value.IsSupersetOf(ComponentAccesses.Value));
+            Assert.False(
+                AllFunctions.Value.IsSupersetOf(ComponentAccesses.Value));
         }
 
         [Test]
         public void TestAllFunctionsIsNotSubsetOfComponentAccesses()
         {
             // expect
-            Assert.That(
-                !AllFunctions.Value.IsSubsetOf(ComponentAccesses.Value));
+            Assert.False(
+                AllFunctions.Value.IsSubsetOf(ComponentAccesses.Value));
         }
 
         [Test]
         public void TestAllFunctionsIsNotSupersetOfFunctionCalls()
         {
             // expect
-            Assert.That(!AllFunctions.Value.IsSupersetOf(FunctionCalls.Value));
+            Assert.False(
+                AllFunctions.Value.IsSupersetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestAllFunctionsIsNotSubsetOfFunctionCalls()
         {
             // expect
-            Assert.That(!AllFunctions.Value.IsSubsetOf(FunctionCalls.Value));
+            Assert.False(AllFunctions.Value.IsSubsetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestAllFunctionsIsNotSupersetOfIntervalExpressions()
         {
             // expect
-            Assert.That(
-                !AllFunctions.Value.IsSupersetOf(IntervalExpressions.Value));
+            Assert.False(
+                AllFunctions.Value.IsSupersetOf(IntervalExpressions.Value));
         }
 
         [Test]
         public void TestAllFunctionsIsNotSubsetOfIntervalExpressions()
         {
             // expect
-            Assert.That(
-                !AllFunctions.Value.IsSubsetOf(IntervalExpressions.Value));
+            Assert.False(
+                AllFunctions.Value.IsSubsetOf(IntervalExpressions.Value));
         }
 
         [Test]
         public void TestAllFunctionsIsNotSupersetOfTensorExpressions()
         {
             // expect
-            Assert.That(
-                !AllFunctions.Value.IsSupersetOf(TensorExpressions.Value));
+            Assert.False(
+                AllFunctions.Value.IsSupersetOf(TensorExpressions.Value));
         }
 
         [Test]
         public void TestAllFunctionsIsNotSubsetOfTensorExpressions()
         {
             // expect
-            Assert.That(
-                !AllFunctions.Value.IsSubsetOf(TensorExpressions.Value));
+            Assert.False(
+                AllFunctions.Value.IsSubsetOf(TensorExpressions.Value));
         }
 
         [Test]
         public void TestAllFunctionsIsNotSupersetOfMatrixExpressions()
         {
             // expect
-            Assert.That(
-                !AllFunctions.Value.IsSupersetOf(MatrixExpressions.Value));
+            Assert.False(
+                AllFunctions.Value.IsSupersetOf(MatrixExpressions.Value));
         }
 
         [Test]
         public void TestAllFunctionsIsNotSubsetOfMatrixExpressions()
         {
             // expect
-            Assert.That(
-                !AllFunctions.Value.IsSubsetOf(MatrixExpressions.Value));
+            Assert.False(
+                AllFunctions.Value.IsSubsetOf(MatrixExpressions.Value));
         }
 
         [Test]
         public void TestAllFunctionsIsNotSupersetOfVectorExpressions()
         {
             // expect
-            Assert.That(
-                !AllFunctions.Value.IsSupersetOf(VectorExpressions.Value));
+            Assert.False(
+                AllFunctions.Value.IsSupersetOf(VectorExpressions.Value));
         }
 
         [Test]
         public void TestAllFunctionsIsNotSubsetOfVectorExpressions()
         {
             // expect
-            Assert.That(
-                !AllFunctions.Value.IsSubsetOf(VectorExpressions.Value));
+            Assert.False(
+                AllFunctions.Value.IsSubsetOf(VectorExpressions.Value));
         }
 
         [Test]
         public void TestAllFunctionsIsNotSupersetOfVariableAccesses()
         {
             // expect
-            Assert.That(
-                !AllFunctions.Value.IsSupersetOf(VariableAccesses.Value));
+            Assert.False(
+                AllFunctions.Value.IsSupersetOf(VariableAccesses.Value));
         }
 
         [Test]
         public void TestAllFunctionsIsNotSubsetOfVariableAccesses()
         {
             // expect
-            Assert.That(!AllFunctions.Value.IsSubsetOf(
-                VariableAccesses.Value));
+            Assert.False(
+                AllFunctions.Value.IsSubsetOf(VariableAccesses.Value));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/SetsT/AllMatricesT/SupersetAndSubsetTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/SetsT/AllMatricesT/SupersetAndSubsetTest.cs
@@ -32,326 +32,345 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.AllMatricesT
         public void TestAllMatricesIsNotSupersetOfMathObjects()
         {
             // expect
-            Assert.That(!AllMatrices.Value.IsSupersetOf(MathObjects.Value));
+            Assert.False(AllMatrices.Value.IsSupersetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestAllMatricesIsSubsetOfMathObjects()
         {
             // expect
-            Assert.That(AllMatrices.Value.IsSubsetOf(MathObjects.Value));
+            Assert.True(AllMatrices.Value.IsSubsetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestAllMatricesIsNotSupersetOfSets()
         {
             // expect
-            Assert.That(!AllMatrices.Value.IsSupersetOf(Sets.Sets.Value));
+            Assert.False(AllMatrices.Value.IsSupersetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestAllMatricesIsNotSubsetOfSets()
         {
             // expect
-            Assert.That(!AllMatrices.Value.IsSubsetOf(Sets.Sets.Value));
+            Assert.False(AllMatrices.Value.IsSubsetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestAllMatricesIsNotSupersetOfAllFunctions()
         {
             // expect
-            Assert.That(!AllMatrices.Value.IsSupersetOf(AllFunctions.Value));
+            Assert.False(AllMatrices.Value.IsSupersetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestAllMatricesIsNotSubsetOfAllFunctions()
         {
             // expect
-            Assert.That(!AllMatrices.Value.IsSubsetOf(AllFunctions.Value));
+            Assert.False(AllMatrices.Value.IsSubsetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestAllMatricesIsNotSupersetOfFunctions()
         {
             // expect
-            Assert.That(
-                !AllMatrices.Value.IsSupersetOf(Sets.Functions.RealsToReals));
+            Assert.False(
+                AllMatrices.Value.IsSupersetOf(Sets.Functions.RealsToReals));
         }
 
         [Test]
         public void TestAllMatricesIsNotSubsetOfFunctions()
         {
             // expect
-            Assert.That(
-                !AllMatrices.Value.IsSubsetOf(Sets.Functions.RealsToReals));
+            Assert.False(
+                AllMatrices.Value.IsSubsetOf(Sets.Functions.RealsToReals));
+        }
+
+        [Test]
+        public void TestAllMatricesIsNotSupersetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                AllMatrices.Value.IsSupersetOf(
+                    VariadicFunctions.RealsToReals));
+        }
+
+        [Test]
+        public void TestAllMatricesIsNotSubsetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                AllMatrices.Value.IsSubsetOf(VariadicFunctions.RealsToReals));
         }
 
         [Test]
         public void TestAllMatricesIsNotSupersetOfTensors()
         {
             // expect
-            Assert.That(!AllMatrices.Value.IsSupersetOf(Tensors.Value));
+            Assert.False(AllMatrices.Value.IsSupersetOf(Tensors.Value));
         }
 
         [Test]
         public void TestAllMatricesIsSubsetOfTensors()
         {
             // expect
-            Assert.That(AllMatrices.Value.IsSubsetOf(Tensors.Value));
+            Assert.True(AllMatrices.Value.IsSubsetOf(Tensors.Value));
         }
 
         [Test]
         public void TestAllMatricesIsNotSupersetOfAllVectors()
         {
             // expect
-            Assert.That(!AllMatrices.Value.IsSupersetOf(AllVectors.Value));
+            Assert.False(AllMatrices.Value.IsSupersetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestAllMatricesIsNotSubsetOfAllVectors()
         {
             // expect
-            Assert.That(!AllMatrices.Value.IsSubsetOf(AllVectors.Value));
+            Assert.False(AllMatrices.Value.IsSubsetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestAllMatricesIsNotSupersetOfVectors()
         {
             // expect
-            Assert.That(!AllMatrices.Value.IsSupersetOf(Vectors.R2));
-            Assert.That(!AllMatrices.Value.IsSupersetOf(Vectors.R3));
+            Assert.False(AllMatrices.Value.IsSupersetOf(Vectors.R2));
+            Assert.False(AllMatrices.Value.IsSupersetOf(Vectors.R3));
         }
 
         [Test]
         public void TestAllMatricesIsNotSubsetOfVectors()
         {
             // expect
-            Assert.That(!AllMatrices.Value.IsSubsetOf(Vectors.R2));
-            Assert.That(!AllMatrices.Value.IsSubsetOf(Vectors.R3));
+            Assert.False(AllMatrices.Value.IsSubsetOf(Vectors.R2));
+            Assert.False(AllMatrices.Value.IsSubsetOf(Vectors.R3));
         }
 
         [Test]
         public void TestAllMatricesIsSupersetOfSelf()
         {
             // expect
-            Assert.That(AllMatrices.Value.IsSupersetOf(AllMatrices.Value));
+            Assert.True(AllMatrices.Value.IsSupersetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestAllMatricesIsSubsetOfSelf()
         {
             // expect
-            Assert.That(AllMatrices.Value.IsSubsetOf(AllMatrices.Value));
+            Assert.True(AllMatrices.Value.IsSubsetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestAllMatricesIsSupersetOfMatrices()
         {
             // expect
-            Assert.That(AllMatrices.Value.IsSupersetOf(Matrices.M2x2));
-            Assert.That(AllMatrices.Value.IsSupersetOf(Matrices.M3x3));
+            Assert.True(AllMatrices.Value.IsSupersetOf(Matrices.M2x2));
+            Assert.True(AllMatrices.Value.IsSupersetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestAllMatricesIsNotSubsetOfMatrices()
         {
             // expect
-            Assert.That(!AllMatrices.Value.IsSubsetOf(Matrices.M2x2));
-            Assert.That(!AllMatrices.Value.IsSubsetOf(Matrices.M3x3));
+            Assert.False(AllMatrices.Value.IsSubsetOf(Matrices.M2x2));
+            Assert.False(AllMatrices.Value.IsSubsetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestAllMatricesIsNotSupersetOfReals()
         {
             // expect
-            Assert.That(!AllMatrices.Value.IsSupersetOf(Reals.Value));
+            Assert.False(AllMatrices.Value.IsSupersetOf(Reals.Value));
         }
 
         [Test]
         public void TestAllMatricesIsNotSubsetOfReals()
         {
             // expect
-            Assert.That(!AllMatrices.Value.IsSubsetOf(Reals.Value));
+            Assert.False(AllMatrices.Value.IsSubsetOf(Reals.Value));
         }
 
         [Test]
         public void TestAllMatricesIsNotSupersetOfStrings()
         {
             // expect
-            Assert.That(!AllMatrices.Value.IsSupersetOf(Strings.Value));
+            Assert.False(AllMatrices.Value.IsSupersetOf(Strings.Value));
         }
 
         [Test]
         public void TestAllMatricesIsNotSubsetOfStrings()
         {
             // expect
-            Assert.That(!AllMatrices.Value.IsSubsetOf(Strings.Value));
+            Assert.False(AllMatrices.Value.IsSubsetOf(Strings.Value));
         }
 
         [Test]
         public void TestAllMatricesIsNotSupersetOfIntervals()
         {
             // expect
-            Assert.That(!AllMatrices.Value.IsSupersetOf(Intervals.Value));
+            Assert.False(AllMatrices.Value.IsSupersetOf(Intervals.Value));
         }
 
         [Test]
         public void TestAllMatricesIsNotSubsetOfIntervals()
         {
             // expect
-            Assert.That(!AllMatrices.Value.IsSubsetOf(Intervals.Value));
+            Assert.False(AllMatrices.Value.IsSubsetOf(Intervals.Value));
         }
 
         [Test]
         public void TestAllMatricesIsNotSupersetOfBooleans()
         {
             // expect
-            Assert.That(!AllMatrices.Value.IsSupersetOf(Booleans.Value));
+            Assert.False(AllMatrices.Value.IsSupersetOf(Booleans.Value));
         }
 
         [Test]
         public void TestAllMatricesIsNotSubsetOfBooleans()
         {
             // expect
-            Assert.That(!AllMatrices.Value.IsSubsetOf(Booleans.Value));
+            Assert.False(AllMatrices.Value.IsSubsetOf(Booleans.Value));
         }
 
         [Test]
         public void TestAllMatricesIsNotSupersetOfExpressions()
         {
             // expect
-            Assert.That(
-                !AllMatrices.Value.IsSupersetOf(Sets.Expressions.Value));
+            Assert.False(
+                AllMatrices.Value.IsSupersetOf(Sets.Expressions.Value));
         }
 
         [Test]
         public void TestAllMatricesIsNotSubsetOfExpressions()
         {
             // expect
-            Assert.That(!AllMatrices.Value.IsSubsetOf(Sets.Expressions.Value));
+            Assert.False(
+                AllMatrices.Value.IsSubsetOf(Sets.Expressions.Value));
         }
 
         [Test]
         public void TestAllMatricesIsNotSupersetOfLiterals()
         {
             // expect
-            Assert.That(!AllMatrices.Value.IsSupersetOf(Literals.Value));
+            Assert.False(AllMatrices.Value.IsSupersetOf(Literals.Value));
         }
 
         [Test]
         public void TestAllMatricesIsNotSubsetOfLiterals()
         {
             // expect
-            Assert.That(!AllMatrices.Value.IsSubsetOf(Literals.Value));
+            Assert.False(AllMatrices.Value.IsSubsetOf(Literals.Value));
         }
 
         [Test]
         public void TestAllMatricesIsNotSupersetOfComponentAccesses()
         {
             // expect
-            Assert.That(
-                !AllMatrices.Value.IsSupersetOf(ComponentAccesses.Value));
+            Assert.False(
+                AllMatrices.Value.IsSupersetOf(ComponentAccesses.Value));
         }
 
         [Test]
         public void TestAllMatricesIsNotSubsetOfComponentAccesses()
         {
             // expect
-            Assert.That(!AllMatrices.Value.IsSubsetOf(
-                ComponentAccesses.Value));
+            Assert.False(
+                AllMatrices.Value.IsSubsetOf(ComponentAccesses.Value));
         }
 
         [Test]
         public void TestAllMatricesIsNotSupersetOfFunctionCalls()
         {
             // expect
-            Assert.That(!AllMatrices.Value.IsSupersetOf(FunctionCalls.Value));
+            Assert.False(AllMatrices.Value.IsSupersetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestAllMatricesIsNotSubsetOfFunctionCalls()
         {
             // expect
-            Assert.That(!AllMatrices.Value.IsSubsetOf(FunctionCalls.Value));
+            Assert.False(AllMatrices.Value.IsSubsetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestAllMatricesIsNotSupersetOfIntervalExpressions()
         {
             // expect
-            Assert.That(
-                !AllMatrices.Value.IsSupersetOf(IntervalExpressions.Value));
+            Assert.False(
+                AllMatrices.Value.IsSupersetOf(IntervalExpressions.Value));
         }
 
         [Test]
         public void TestAllMatricesIsNotSubsetOfIntervalExpressions()
         {
             // expect
-            Assert.That(
-                !AllMatrices.Value.IsSubsetOf(IntervalExpressions.Value));
+            Assert.False(
+                AllMatrices.Value.IsSubsetOf(IntervalExpressions.Value));
         }
 
         [Test]
         public void TestAllMatricesIsNotSupersetOfTensorExpressions()
         {
             // expect
-            Assert.That(
-                !AllMatrices.Value.IsSupersetOf(TensorExpressions.Value));
+            Assert.False(
+                AllMatrices.Value.IsSupersetOf(TensorExpressions.Value));
         }
 
         [Test]
         public void TestAllMatricesIsNotSubsetOfTensorExpressions()
         {
             // expect
-            Assert.That(!AllMatrices.Value.IsSubsetOf(
-                TensorExpressions.Value));
+            Assert.False(
+                AllMatrices.Value.IsSubsetOf(TensorExpressions.Value));
         }
 
         [Test]
         public void TestAllMatricesIsNotSupersetOfMatrixExpressions()
         {
             // expect
-            Assert.That(
-                !AllMatrices.Value.IsSupersetOf(MatrixExpressions.Value));
+            Assert.False(
+                AllMatrices.Value.IsSupersetOf(MatrixExpressions.Value));
         }
 
         [Test]
         public void TestAllMatricesIsNotSubsetOfMatrixExpressions()
         {
             // expect
-            Assert.That(!AllMatrices.Value.IsSubsetOf(
-                MatrixExpressions.Value));
+            Assert.False(
+                AllMatrices.Value.IsSubsetOf(MatrixExpressions.Value));
         }
 
         [Test]
         public void TestAllMatricesIsNotSupersetOfVectorExpressions()
         {
             // expect
-            Assert.That(
-                !AllMatrices.Value.IsSupersetOf(VectorExpressions.Value));
+            Assert.False(
+                AllMatrices.Value.IsSupersetOf(VectorExpressions.Value));
         }
 
         [Test]
         public void TestAllMatricesIsNotSubsetOfVectorExpressions()
         {
             // expect
-            Assert.That(!AllMatrices.Value.IsSubsetOf(
-                VectorExpressions.Value));
+            Assert.False(
+                AllMatrices.Value.IsSubsetOf(VectorExpressions.Value));
         }
 
         [Test]
         public void TestAllMatricesIsNotSupersetOfVariableAccesses()
         {
             // expect
-            Assert.That(
-                !AllMatrices.Value.IsSupersetOf(VariableAccesses.Value));
+            Assert.False(
+                AllMatrices.Value.IsSupersetOf(VariableAccesses.Value));
         }
 
         [Test]
         public void TestAllMatricesIsNotSubsetOfVariableAccesses()
         {
             // expect
-            Assert.That(!AllMatrices.Value.IsSubsetOf(VariableAccesses.Value));
+            Assert.False(
+                AllMatrices.Value.IsSubsetOf(VariableAccesses.Value));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/SetsT/AllVectorsT/SupersetAndSubsetTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/SetsT/AllVectorsT/SupersetAndSubsetTest.cs
@@ -32,322 +32,343 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.AllVectorsT
         public void TestAllVectorsIsNotSupersetOfMathObjects()
         {
             // expect
-            Assert.That(!AllVectors.Value.IsSupersetOf(MathObjects.Value));
+            Assert.False(AllVectors.Value.IsSupersetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestAllVectorsIsSubsetOfMathObjects()
         {
             // expect
-            Assert.That(AllVectors.Value.IsSubsetOf(MathObjects.Value));
+            Assert.True(AllVectors.Value.IsSubsetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestAllVectorsIsNotSupersetOfSets()
         {
             // expect
-            Assert.That(!AllVectors.Value.IsSupersetOf(Sets.Sets.Value));
+            Assert.False(AllVectors.Value.IsSupersetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestAllVectorsIsNotSubsetOfSets()
         {
             // expect
-            Assert.That(!AllVectors.Value.IsSubsetOf(Sets.Sets.Value));
+            Assert.False(AllVectors.Value.IsSubsetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestAllVectorsIsNotSupersetOfAllFunctions()
         {
             // expect
-            Assert.That(!AllVectors.Value.IsSupersetOf(AllFunctions.Value));
+            Assert.False(AllVectors.Value.IsSupersetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestAllVectorsIsNotSubsetOfAllFunctions()
         {
             // expect
-            Assert.That(!AllVectors.Value.IsSubsetOf(AllFunctions.Value));
+            Assert.False(AllVectors.Value.IsSubsetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestAllVectorsIsNotSupersetOfFunctions()
         {
             // expect
-            Assert.That(
-                !AllVectors.Value.IsSupersetOf(Sets.Functions.RealsToReals));
+            Assert.False(
+                AllVectors.Value.IsSupersetOf(Sets.Functions.RealsToReals));
         }
 
         [Test]
         public void TestAllVectorsIsNotSubsetOfFunctions()
         {
             // expect
-            Assert.That(
-                !AllVectors.Value.IsSubsetOf(Sets.Functions.RealsToReals));
+            Assert.False(
+                AllVectors.Value.IsSubsetOf(Sets.Functions.RealsToReals));
+        }
+
+        [Test]
+        public void TestAllVectorsIsNotSupersetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                AllVectors.Value.IsSupersetOf(
+                    VariadicFunctions.RealsToReals));
+        }
+
+        [Test]
+        public void TestAllVectorsIsNotSubsetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                AllVectors.Value.IsSubsetOf(VariadicFunctions.RealsToReals));
         }
 
         [Test]
         public void TestAllVectorsIsNotSupersetOfTensors()
         {
             // expect
-            Assert.That(!AllVectors.Value.IsSupersetOf(Tensors.Value));
+            Assert.False(AllVectors.Value.IsSupersetOf(Tensors.Value));
         }
 
         [Test]
         public void TestAllVectorsIsSubsetOfTensors()
         {
             // expect
-            Assert.That(AllVectors.Value.IsSubsetOf(Tensors.Value));
+            Assert.True(AllVectors.Value.IsSubsetOf(Tensors.Value));
         }
 
         [Test]
         public void TestAllVectorsIsSupersetOfSelf()
         {
             // expect
-            Assert.That(AllVectors.Value.IsSupersetOf(AllVectors.Value));
+            Assert.True(AllVectors.Value.IsSupersetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestAllVectorsIsSubsetOfSelf()
         {
             // expect
-            Assert.That(AllVectors.Value.IsSubsetOf(AllVectors.Value));
+            Assert.True(AllVectors.Value.IsSubsetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestAllVectorsIsSupersetOfVectors()
         {
             // expect
-            Assert.That(AllVectors.Value.IsSupersetOf(Vectors.R2));
-            Assert.That(AllVectors.Value.IsSupersetOf(Vectors.R3));
+            Assert.True(AllVectors.Value.IsSupersetOf(Vectors.R2));
+            Assert.True(AllVectors.Value.IsSupersetOf(Vectors.R3));
         }
 
         [Test]
         public void TestAllVectorsIsNotSubsetOfVectors()
         {
             // expect
-            Assert.That(!AllVectors.Value.IsSubsetOf(Vectors.R2));
-            Assert.That(!AllVectors.Value.IsSubsetOf(Vectors.R3));
+            Assert.False(AllVectors.Value.IsSubsetOf(Vectors.R2));
+            Assert.False(AllVectors.Value.IsSubsetOf(Vectors.R3));
         }
 
         [Test]
         public void TestAllVectorsIsNotSupersetOfAllMatrices()
         {
             // expect
-            Assert.That(!AllVectors.Value.IsSupersetOf(AllMatrices.Value));
+            Assert.False(AllVectors.Value.IsSupersetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestAllVectorsIsNotSubsetOfAllMatrices()
         {
             // expect
-            Assert.That(!AllVectors.Value.IsSubsetOf(AllMatrices.Value));
+            Assert.False(AllVectors.Value.IsSubsetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestAllVectorsIsNotSupersetOfMatrices()
         {
             // expect
-            Assert.That(!AllVectors.Value.IsSupersetOf(Matrices.M2x2));
-            Assert.That(!AllVectors.Value.IsSupersetOf(Matrices.M3x3));
+            Assert.False(AllVectors.Value.IsSupersetOf(Matrices.M2x2));
+            Assert.False(AllVectors.Value.IsSupersetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestAllVectorsIsNotSubsetOfMatrices()
         {
             // expect
-            Assert.That(!AllVectors.Value.IsSubsetOf(Matrices.M2x2));
-            Assert.That(!AllVectors.Value.IsSubsetOf(Matrices.M3x3));
+            Assert.False(AllVectors.Value.IsSubsetOf(Matrices.M2x2));
+            Assert.False(AllVectors.Value.IsSubsetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestAllVectorsIsNotSupersetOfReals()
         {
             // expect
-            Assert.That(!AllVectors.Value.IsSupersetOf(Reals.Value));
+            Assert.False(AllVectors.Value.IsSupersetOf(Reals.Value));
         }
 
         [Test]
         public void TestAllVectorsIsNotSubsetOfReals()
         {
             // expect
-            Assert.That(!AllVectors.Value.IsSubsetOf(Reals.Value));
+            Assert.False(AllVectors.Value.IsSubsetOf(Reals.Value));
         }
 
         [Test]
         public void TestAllVectorsIsNotSupersetOfStrings()
         {
             // expect
-            Assert.That(!AllVectors.Value.IsSupersetOf(Strings.Value));
+            Assert.False(AllVectors.Value.IsSupersetOf(Strings.Value));
         }
 
         [Test]
         public void TestAllVectorsIsNotSubsetOfStrings()
         {
             // expect
-            Assert.That(!AllVectors.Value.IsSubsetOf(Strings.Value));
+            Assert.False(AllVectors.Value.IsSubsetOf(Strings.Value));
         }
 
         [Test]
         public void TestAllVectorsIsNotSupersetOfIntervals()
         {
             // expect
-            Assert.That(!AllVectors.Value.IsSupersetOf(Intervals.Value));
+            Assert.False(AllVectors.Value.IsSupersetOf(Intervals.Value));
         }
 
         [Test]
         public void TestAllVectorsIsNotSubsetOfIntervals()
         {
             // expect
-            Assert.That(!AllVectors.Value.IsSubsetOf(Intervals.Value));
+            Assert.False(AllVectors.Value.IsSubsetOf(Intervals.Value));
         }
 
         [Test]
         public void TestAllVectorsIsNotSupersetOfBooleans()
         {
             // expect
-            Assert.That(!AllVectors.Value.IsSupersetOf(Booleans.Value));
+            Assert.False(AllVectors.Value.IsSupersetOf(Booleans.Value));
         }
 
         [Test]
         public void TestAllVectorsIsNotSubsetOfBooleans()
         {
             // expect
-            Assert.That(!AllVectors.Value.IsSubsetOf(Booleans.Value));
+            Assert.False(AllVectors.Value.IsSubsetOf(Booleans.Value));
         }
 
         [Test]
         public void TestAllVectorsIsNotSupersetOfExpressions()
         {
             // expect
-            Assert.That(!AllVectors.Value.IsSupersetOf(
-                Sets.Expressions.Value));
+            Assert.False(
+                AllVectors.Value.IsSupersetOf(Sets.Expressions.Value));
         }
 
         [Test]
         public void TestAllVectorsIsNotSubsetOfExpressions()
         {
             // expect
-            Assert.That(!AllVectors.Value.IsSubsetOf(Sets.Expressions.Value));
+            Assert.False(AllVectors.Value.IsSubsetOf(Sets.Expressions.Value));
         }
 
         [Test]
         public void TestAllVectorsIsNotSupersetOfLiterals()
         {
             // expect
-            Assert.That(!AllVectors.Value.IsSupersetOf(Literals.Value));
+            Assert.False(AllVectors.Value.IsSupersetOf(Literals.Value));
         }
 
         [Test]
         public void TestAllVectorsIsNotSubsetOfLiterals()
         {
             // expect
-            Assert.That(!AllVectors.Value.IsSubsetOf(Literals.Value));
+            Assert.False(AllVectors.Value.IsSubsetOf(Literals.Value));
         }
 
         [Test]
         public void TestAllVectorsIsNotSupersetOfComponentAccesses()
         {
             // expect
-            Assert.That(
-                !AllVectors.Value.IsSupersetOf(ComponentAccesses.Value));
+            Assert.False(
+                AllVectors.Value.IsSupersetOf(ComponentAccesses.Value));
         }
 
         [Test]
         public void TestAllVectorsIsNotSubsetOfComponentAccesses()
         {
             // expect
-            Assert.That(!AllVectors.Value.IsSubsetOf(ComponentAccesses.Value));
+            Assert.False(
+                AllVectors.Value.IsSubsetOf(ComponentAccesses.Value));
         }
 
         [Test]
         public void TestAllVectorsIsNotSupersetOfFunctionCalls()
         {
             // expect
-            Assert.That(!AllVectors.Value.IsSupersetOf(FunctionCalls.Value));
+            Assert.False(AllVectors.Value.IsSupersetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestAllVectorsIsNotSubsetOfFunctionCalls()
         {
             // expect
-            Assert.That(!AllVectors.Value.IsSubsetOf(FunctionCalls.Value));
+            Assert.False(AllVectors.Value.IsSubsetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestAllVectorsIsNotSupersetOfIntervalExpressions()
         {
             // expect
-            Assert.That(
-                !AllVectors.Value.IsSupersetOf(IntervalExpressions.Value));
+            Assert.False(
+                AllVectors.Value.IsSupersetOf(IntervalExpressions.Value));
         }
 
         [Test]
         public void TestAllVectorsIsNotSubsetOfIntervalExpressions()
         {
             // expect
-            Assert.That(
-                !AllVectors.Value.IsSubsetOf(IntervalExpressions.Value));
+            Assert.False(
+                AllVectors.Value.IsSubsetOf(IntervalExpressions.Value));
         }
 
         [Test]
         public void TestAllVectorsIsNotSupersetOfTensorExpressions()
         {
             // expect
-            Assert.That(
-                !AllVectors.Value.IsSupersetOf(TensorExpressions.Value));
+            Assert.False(
+                AllVectors.Value.IsSupersetOf(TensorExpressions.Value));
         }
 
         [Test]
         public void TestAllVectorsIsNotSubsetOfTensorExpressions()
         {
             // expect
-            Assert.That(!AllVectors.Value.IsSubsetOf(TensorExpressions.Value));
+            Assert.False(
+                AllVectors.Value.IsSubsetOf(TensorExpressions.Value));
         }
 
         [Test]
         public void TestAllVectorsIsNotSupersetOfMatrixExpressions()
         {
             // expect
-            Assert.That(
-                !AllVectors.Value.IsSupersetOf(MatrixExpressions.Value));
+            Assert.False(
+                AllVectors.Value.IsSupersetOf(MatrixExpressions.Value));
         }
 
         [Test]
         public void TestAllVectorsIsNotSubsetOfMatrixExpressions()
         {
             // expect
-            Assert.That(!AllVectors.Value.IsSubsetOf(MatrixExpressions.Value));
+            Assert.False(
+                AllVectors.Value.IsSubsetOf(MatrixExpressions.Value));
         }
 
         [Test]
         public void TestAllVectorsIsNotSupersetOfVectorExpressions()
         {
             // expect
-            Assert.That(
-                !AllVectors.Value.IsSupersetOf(VectorExpressions.Value));
+            Assert.False(
+                AllVectors.Value.IsSupersetOf(VectorExpressions.Value));
         }
 
         [Test]
         public void TestAllVectorsIsNotSubsetOfVectorExpressions()
         {
             // expect
-            Assert.That(!AllVectors.Value.IsSubsetOf(VectorExpressions.Value));
+            Assert.False(
+                AllVectors.Value.IsSubsetOf(VectorExpressions.Value));
         }
 
         [Test]
         public void TestAllVectorsIsNotSupersetOfVariableAccesses()
         {
             // expect
-            Assert.That(!AllVectors.Value.IsSupersetOf(
-                VariableAccesses.Value));
+            Assert.False(
+                AllVectors.Value.IsSupersetOf(VariableAccesses.Value));
         }
 
         [Test]
         public void TestAllVectorsIsNotSubsetOfVariableAccesses()
         {
             // expect
-            Assert.That(!AllVectors.Value.IsSubsetOf(VariableAccesses.Value));
+            Assert.False(AllVectors.Value.IsSubsetOf(VariableAccesses.Value));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/SetsT/BooleansT/SupersetAndSubsetTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/SetsT/BooleansT/SupersetAndSubsetTest.cs
@@ -32,315 +32,336 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.BooleansT
         public void TestBooleansIsNotSupersetOfMathObjects()
         {
             // expect
-            Assert.That(!Booleans.Value.IsSupersetOf(MathObjects.Value));
+            Assert.False(Booleans.Value.IsSupersetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestBooleansIsSubsetOfMathObjects()
         {
             // expect
-            Assert.That(Booleans.Value.IsSubsetOf(MathObjects.Value));
+            Assert.True(Booleans.Value.IsSubsetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestBooleansIsNotSupersetOfSets()
         {
             // expect
-            Assert.That(!Booleans.Value.IsSupersetOf(Sets.Sets.Value));
+            Assert.False(Booleans.Value.IsSupersetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestBooleansIsNotSubsetOfSets()
         {
             // expect
-            Assert.That(!Booleans.Value.IsSubsetOf(Sets.Sets.Value));
+            Assert.False(Booleans.Value.IsSubsetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestBooleansIsNotSupersetOfAllFunctions()
         {
             // expect
-            Assert.That(!Booleans.Value.IsSupersetOf(AllFunctions.Value));
+            Assert.False(Booleans.Value.IsSupersetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestBooleansIsNotSubsetOfAllFunctions()
         {
             // expect
-            Assert.That(!Booleans.Value.IsSubsetOf(AllFunctions.Value));
+            Assert.False(Booleans.Value.IsSubsetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestBooleansIsNotSupersetOfFunctions()
         {
             // expect
-            Assert.That(
-                !Booleans.Value.IsSupersetOf(Sets.Functions.RealsToReals));
+            Assert.False(
+                Booleans.Value.IsSupersetOf(Sets.Functions.RealsToReals));
         }
 
         [Test]
         public void TestBooleansIsNotSubsetOfFunctions()
         {
             // expect
-            Assert.That(
-                !Booleans.Value.IsSubsetOf(Sets.Functions.RealsToReals));
+            Assert.False(
+                Booleans.Value.IsSubsetOf(Sets.Functions.RealsToReals));
+        }
+
+        [Test]
+        public void TestBooleansIsNotSupersetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                Booleans.Value.IsSupersetOf(VariadicFunctions.RealsToReals));
+        }
+
+        [Test]
+        public void TestBooleansIsNotSubsetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                Booleans.Value.IsSubsetOf(VariadicFunctions.RealsToReals));
         }
 
         [Test]
         public void TestBooleansIsNotSupersetOfTensors()
         {
             // expect
-            Assert.That(!Booleans.Value.IsSupersetOf(Tensors.Value));
+            Assert.False(Booleans.Value.IsSupersetOf(Tensors.Value));
         }
 
         [Test]
         public void TestBooleansIsNotSubsetOfTensors()
         {
             // expect
-            Assert.That(!Booleans.Value.IsSubsetOf(Tensors.Value));
+            Assert.False(Booleans.Value.IsSubsetOf(Tensors.Value));
         }
 
         [Test]
         public void TestBooleansIsNotSupersetOfAllVectors()
         {
             // expect
-            Assert.That(!Booleans.Value.IsSupersetOf(AllVectors.Value));
+            Assert.False(Booleans.Value.IsSupersetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestBooleansIsNotSubsetOfAllVectors()
         {
             // expect
-            Assert.That(!Booleans.Value.IsSubsetOf(AllVectors.Value));
+            Assert.False(Booleans.Value.IsSubsetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestBooleansIsNotSupersetOfVectors()
         {
             // expect
-            Assert.That(!Booleans.Value.IsSupersetOf(Vectors.R2));
-            Assert.That(!Booleans.Value.IsSupersetOf(Vectors.R3));
+            Assert.False(Booleans.Value.IsSupersetOf(Vectors.R2));
+            Assert.False(Booleans.Value.IsSupersetOf(Vectors.R3));
         }
 
         [Test]
         public void TestBooleansIsNotSubsetOfVectors()
         {
             // expect
-            Assert.That(!Booleans.Value.IsSubsetOf(Vectors.R2));
-            Assert.That(!Booleans.Value.IsSubsetOf(Vectors.R3));
+            Assert.False(Booleans.Value.IsSubsetOf(Vectors.R2));
+            Assert.False(Booleans.Value.IsSubsetOf(Vectors.R3));
         }
 
         [Test]
         public void TestBooleansIsNotSupersetOfAllMatrices()
         {
             // expect
-            Assert.That(!Booleans.Value.IsSupersetOf(AllMatrices.Value));
+            Assert.False(Booleans.Value.IsSupersetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestBooleansIsNotSubsetOfAllMatrices()
         {
             // expect
-            Assert.That(!Booleans.Value.IsSubsetOf(AllMatrices.Value));
+            Assert.False(Booleans.Value.IsSubsetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestBooleansIsNotSupersetOfMatrices()
         {
             // expect
-            Assert.That(!Booleans.Value.IsSupersetOf(Matrices.M2x2));
-            Assert.That(!Booleans.Value.IsSupersetOf(Matrices.M3x3));
+            Assert.False(Booleans.Value.IsSupersetOf(Matrices.M2x2));
+            Assert.False(Booleans.Value.IsSupersetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestBooleansIsNotSubsetOfMatrices()
         {
             // expect
-            Assert.That(!Booleans.Value.IsSubsetOf(Matrices.M2x2));
-            Assert.That(!Booleans.Value.IsSubsetOf(Matrices.M3x3));
+            Assert.False(Booleans.Value.IsSubsetOf(Matrices.M2x2));
+            Assert.False(Booleans.Value.IsSubsetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestBooleansIsNotSupersetOfReals()
         {
             // expect
-            Assert.That(!Booleans.Value.IsSupersetOf(Reals.Value));
+            Assert.False(Booleans.Value.IsSupersetOf(Reals.Value));
         }
 
         [Test]
         public void TestBooleansIsNotSubsetOfReals()
         {
             // expect
-            Assert.That(!Booleans.Value.IsSubsetOf(Reals.Value));
+            Assert.False(Booleans.Value.IsSubsetOf(Reals.Value));
         }
 
         [Test]
         public void TestBooleansIsNotSupersetOfStrings()
         {
             // expect
-            Assert.That(!Booleans.Value.IsSupersetOf(Strings.Value));
+            Assert.False(Booleans.Value.IsSupersetOf(Strings.Value));
         }
 
         [Test]
         public void TestBooleansIsNotSubsetOfStrings()
         {
             // expect
-            Assert.That(!Booleans.Value.IsSubsetOf(Strings.Value));
+            Assert.False(Booleans.Value.IsSubsetOf(Strings.Value));
         }
 
         [Test]
         public void TestBooleansIsNotSupersetOfIntervals()
         {
             // expect
-            Assert.That(!Booleans.Value.IsSupersetOf(Intervals.Value));
+            Assert.False(Booleans.Value.IsSupersetOf(Intervals.Value));
         }
 
         [Test]
         public void TestBooleansIsNotSubsetOfIntervals()
         {
             // expect
-            Assert.That(!Booleans.Value.IsSubsetOf(Intervals.Value));
+            Assert.False(Booleans.Value.IsSubsetOf(Intervals.Value));
         }
 
         [Test]
         public void TestBooleansIsSupersetOfSelf()
         {
             // expect
-            Assert.That(Booleans.Value.IsSupersetOf(Booleans.Value));
+            Assert.True(Booleans.Value.IsSupersetOf(Booleans.Value));
         }
 
         [Test]
         public void TestBooleansIsSubsetOfSelf()
         {
             // expect
-            Assert.That(Booleans.Value.IsSubsetOf(Booleans.Value));
+            Assert.True(Booleans.Value.IsSubsetOf(Booleans.Value));
         }
 
         [Test]
         public void TestBooleansIsNotSupersetOfExpressions()
         {
             // expect
-            Assert.That(!Booleans.Value.IsSupersetOf(Sets.Expressions.Value));
+            Assert.False(Booleans.Value.IsSupersetOf(Sets.Expressions.Value));
         }
 
         [Test]
         public void TestBooleansIsNotSubsetOfExpressions()
         {
             // expect
-            Assert.That(!Booleans.Value.IsSubsetOf(Sets.Expressions.Value));
+            Assert.False(Booleans.Value.IsSubsetOf(Sets.Expressions.Value));
         }
 
         [Test]
         public void TestBooleansIsNotSupersetOfLiterals()
         {
             // expect
-            Assert.That(!Booleans.Value.IsSupersetOf(Literals.Value));
+            Assert.False(Booleans.Value.IsSupersetOf(Literals.Value));
         }
 
         [Test]
         public void TestBooleansIsNotSubsetOfLiterals()
         {
             // expect
-            Assert.That(!Booleans.Value.IsSubsetOf(Literals.Value));
+            Assert.False(Booleans.Value.IsSubsetOf(Literals.Value));
         }
 
         [Test]
         public void TestBooleansIsNotSupersetOfComponentAccesses()
         {
             // expect
-            Assert.That(!Booleans.Value.IsSupersetOf(ComponentAccesses.Value));
+            Assert.False(
+                Booleans.Value.IsSupersetOf(ComponentAccesses.Value));
         }
 
         [Test]
         public void TestBooleansIsNotSubsetOfComponentAccesses()
         {
             // expect
-            Assert.That(!Booleans.Value.IsSubsetOf(ComponentAccesses.Value));
+            Assert.False(Booleans.Value.IsSubsetOf(ComponentAccesses.Value));
         }
 
         [Test]
         public void TestBooleansIsNotSupersetOfFunctionCalls()
         {
             // expect
-            Assert.That(!Booleans.Value.IsSupersetOf(FunctionCalls.Value));
+            Assert.False(Booleans.Value.IsSupersetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestBooleansIsNotSubsetOfFunctionCalls()
         {
             // expect
-            Assert.That(!Booleans.Value.IsSubsetOf(FunctionCalls.Value));
+            Assert.False(Booleans.Value.IsSubsetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestBooleansIsNotSupersetOfIntervalExpressions()
         {
             // expect
-            Assert.That(
-                !Booleans.Value.IsSupersetOf(IntervalExpressions.Value));
+            Assert.False(
+                Booleans.Value.IsSupersetOf(IntervalExpressions.Value));
         }
 
         [Test]
         public void TestBooleansIsNotSubsetOfIntervalExpressions()
         {
             // expect
-            Assert.That(!Booleans.Value.IsSubsetOf(IntervalExpressions.Value));
+            Assert.False(
+                Booleans.Value.IsSubsetOf(IntervalExpressions.Value));
         }
 
         [Test]
         public void TestBooleansIsNotSupersetOfTensorExpressions()
         {
             // expect
-            Assert.That(!Booleans.Value.IsSupersetOf(TensorExpressions.Value));
+            Assert.False(
+                Booleans.Value.IsSupersetOf(TensorExpressions.Value));
         }
 
         [Test]
         public void TestBooleansIsNotSubsetOfTensorExpressions()
         {
             // expect
-            Assert.That(!Booleans.Value.IsSubsetOf(TensorExpressions.Value));
+            Assert.False(Booleans.Value.IsSubsetOf(TensorExpressions.Value));
         }
 
         [Test]
         public void TestBooleansIsNotSupersetOfMatrixExpressions()
         {
             // expect
-            Assert.That(!Booleans.Value.IsSupersetOf(MatrixExpressions.Value));
+            Assert.False(
+                Booleans.Value.IsSupersetOf(MatrixExpressions.Value));
         }
 
         [Test]
         public void TestBooleansIsNotSubsetOfMatrixExpressions()
         {
             // expect
-            Assert.That(!Booleans.Value.IsSubsetOf(MatrixExpressions.Value));
+            Assert.False(Booleans.Value.IsSubsetOf(MatrixExpressions.Value));
         }
 
         [Test]
         public void TestBooleansIsNotSupersetOfVectorExpressions()
         {
             // expect
-            Assert.That(!Booleans.Value.IsSupersetOf(VectorExpressions.Value));
+            Assert.False(
+                Booleans.Value.IsSupersetOf(VectorExpressions.Value));
         }
 
         [Test]
         public void TestBooleansIsNotSubsetOfVectorExpressions()
         {
             // expect
-            Assert.That(!Booleans.Value.IsSubsetOf(VectorExpressions.Value));
+            Assert.False(Booleans.Value.IsSubsetOf(VectorExpressions.Value));
         }
 
         [Test]
         public void TestBooleansIsNotSupersetOfVariableAccesses()
         {
             // expect
-            Assert.That(!Booleans.Value.IsSupersetOf(VariableAccesses.Value));
+            Assert.False(Booleans.Value.IsSupersetOf(VariableAccesses.Value));
         }
 
         [Test]
         public void TestBooleansIsNotSubsetOfVariableAccesses()
         {
             // expect
-            Assert.That(!Booleans.Value.IsSubsetOf(VariableAccesses.Value));
+            Assert.False(Booleans.Value.IsSubsetOf(VariableAccesses.Value));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/SetsT/ComponentAccessesT/SupersetAndSubsetTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/SetsT/ComponentAccessesT/SupersetAndSubsetTest.cs
@@ -32,213 +32,234 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.ComponentAccessesT
         public void TestComponentAccessesIsNotSupersetOfMathObjects()
         {
             // expect
-            Assert.That(
-                !ComponentAccesses.Value.IsSupersetOf(MathObjects.Value));
+            Assert.False(
+                ComponentAccesses.Value.IsSupersetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestComponentAccessesIsSubsetOfMathObjects()
         {
             // expect
-            Assert.That(ComponentAccesses.Value.IsSubsetOf(MathObjects.Value));
+            Assert.True(
+                ComponentAccesses.Value.IsSubsetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestComponentAccessesIsNotSupersetOfSets()
         {
             // expect
-            Assert.That(!ComponentAccesses.Value.IsSupersetOf(
-                Sets.Sets.Value));
+            Assert.False(
+                ComponentAccesses.Value.IsSupersetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestComponentAccessesIsNotSubsetOfSets()
         {
             // expect
-            Assert.That(!ComponentAccesses.Value.IsSubsetOf(Sets.Sets.Value));
+            Assert.False(ComponentAccesses.Value.IsSubsetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestComponentAccessesIsNotSupersetOfAllFunctions()
         {
             // expect
-            Assert.That(
-                !ComponentAccesses.Value.IsSupersetOf(AllFunctions.Value));
+            Assert.False(
+                ComponentAccesses.Value.IsSupersetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestComponentAccessesIsNotSubsetOfAllFunctions()
         {
             // expect
-            Assert.That(
-                !ComponentAccesses.Value.IsSubsetOf(AllFunctions.Value));
+            Assert.False(
+                ComponentAccesses.Value.IsSubsetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestComponentAccessesIsNotSupersetOfFunctions()
         {
             // expect
-            Assert.That(
-                !ComponentAccesses.Value.IsSupersetOf(Sets.Functions
-                    .RealsToReals));
+            Assert.False(
+                ComponentAccesses.Value.IsSupersetOf(
+                    Sets.Functions.RealsToReals));
         }
 
         [Test]
         public void TestComponentAccessesIsNotSubsetOfFunctions()
         {
             // expect
-            Assert.That(
-                !ComponentAccesses.Value.IsSubsetOf(Sets.Functions
-                    .RealsToReals));
+            Assert.False(
+                ComponentAccesses.Value.IsSubsetOf(
+                    Sets.Functions.RealsToReals));
+        }
+
+        [Test]
+        public void TestComponentAccessesIsNotSupersetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                ComponentAccesses.Value.IsSupersetOf(
+                    VariadicFunctions.RealsToReals));
+        }
+
+        [Test]
+        public void TestComponentAccessesIsNotSubsetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                ComponentAccesses.Value.IsSubsetOf(
+                    VariadicFunctions.RealsToReals));
         }
 
         [Test]
         public void TestComponentAccessesIsNotSupersetOfTensors()
         {
             // expect
-            Assert.That(!ComponentAccesses.Value.IsSupersetOf(Tensors.Value));
+            Assert.False(ComponentAccesses.Value.IsSupersetOf(Tensors.Value));
         }
 
         [Test]
         public void TestComponentAccessesIsNotSubsetOfTensors()
         {
             // expect
-            Assert.That(!ComponentAccesses.Value.IsSubsetOf(Tensors.Value));
+            Assert.False(ComponentAccesses.Value.IsSubsetOf(Tensors.Value));
         }
 
         [Test]
         public void TestComponentAccessesIsNotSupersetOfAllVectors()
         {
             // expect
-            Assert.That(
-                !ComponentAccesses.Value.IsSupersetOf(AllVectors.Value));
+            Assert.False(
+                ComponentAccesses.Value.IsSupersetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestComponentAccessesIsNotSubsetOfAllVectors()
         {
             // expect
-            Assert.That(!ComponentAccesses.Value.IsSubsetOf(AllVectors.Value));
+            Assert.False(
+                ComponentAccesses.Value.IsSubsetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestComponentAccessesIsNotSupersetOfVectors()
         {
             // expect
-            Assert.That(!ComponentAccesses.Value.IsSupersetOf(Vectors.R2));
-            Assert.That(!ComponentAccesses.Value.IsSupersetOf(Vectors.R3));
+            Assert.False(ComponentAccesses.Value.IsSupersetOf(Vectors.R2));
+            Assert.False(ComponentAccesses.Value.IsSupersetOf(Vectors.R3));
         }
 
         [Test]
         public void TestComponentAccessesIsNotSubsetOfVectors()
         {
             // expect
-            Assert.That(!ComponentAccesses.Value.IsSubsetOf(Vectors.R2));
-            Assert.That(!ComponentAccesses.Value.IsSubsetOf(Vectors.R3));
+            Assert.False(ComponentAccesses.Value.IsSubsetOf(Vectors.R2));
+            Assert.False(ComponentAccesses.Value.IsSubsetOf(Vectors.R3));
         }
 
         [Test]
         public void TestComponentAccessesIsNotSupersetOfAllMatrices()
         {
             // expect
-            Assert.That(
-                !ComponentAccesses.Value.IsSupersetOf(AllMatrices.Value));
+            Assert.False(
+                ComponentAccesses.Value.IsSupersetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestComponentAccessesIsNotSubsetOfAllMatrices()
         {
             // expect
-            Assert.That(!ComponentAccesses.Value.IsSubsetOf(
-                AllMatrices.Value));
+            Assert.False(
+                ComponentAccesses.Value.IsSubsetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestComponentAccessesIsNotSupersetOfMatrices()
         {
             // expect
-            Assert.That(!ComponentAccesses.Value.IsSupersetOf(Matrices.M2x2));
-            Assert.That(!ComponentAccesses.Value.IsSupersetOf(Matrices.M3x3));
+            Assert.False(ComponentAccesses.Value.IsSupersetOf(Matrices.M2x2));
+            Assert.False(ComponentAccesses.Value.IsSupersetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestComponentAccessesIsNotSubsetOfMatrices()
         {
             // expect
-            Assert.That(!ComponentAccesses.Value.IsSubsetOf(Matrices.M2x2));
-            Assert.That(!ComponentAccesses.Value.IsSubsetOf(Matrices.M3x3));
+            Assert.False(ComponentAccesses.Value.IsSubsetOf(Matrices.M2x2));
+            Assert.False(ComponentAccesses.Value.IsSubsetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestComponentAccessesIsNotSupersetOfReals()
         {
             // expect
-            Assert.That(!ComponentAccesses.Value.IsSupersetOf(Reals.Value));
+            Assert.False(ComponentAccesses.Value.IsSupersetOf(Reals.Value));
         }
 
         [Test]
         public void TestComponentAccessesIsNotSubsetOfReals()
         {
             // expect
-            Assert.That(!ComponentAccesses.Value.IsSubsetOf(Reals.Value));
+            Assert.False(ComponentAccesses.Value.IsSubsetOf(Reals.Value));
         }
 
         [Test]
         public void TestComponentAccessesIsNotSupersetOfStrings()
         {
             // expect
-            Assert.That(!ComponentAccesses.Value.IsSupersetOf(Strings.Value));
+            Assert.False(ComponentAccesses.Value.IsSupersetOf(Strings.Value));
         }
 
         [Test]
         public void TestComponentAccessesIsNotSubsetOfStrings()
         {
             // expect
-            Assert.That(!ComponentAccesses.Value.IsSubsetOf(Strings.Value));
+            Assert.False(ComponentAccesses.Value.IsSubsetOf(Strings.Value));
         }
 
         [Test]
         public void TestComponentAccessesIsNotSupersetOfIntervals()
         {
             // expect
-            Assert.That(!ComponentAccesses.Value.IsSupersetOf(
-                Intervals.Value));
+            Assert.False(
+                ComponentAccesses.Value.IsSupersetOf(Intervals.Value));
         }
 
         [Test]
         public void TestComponentAccessesIsNotSubsetOfIntervals()
         {
             // expect
-            Assert.That(!ComponentAccesses.Value.IsSubsetOf(Intervals.Value));
+            Assert.False(ComponentAccesses.Value.IsSubsetOf(Intervals.Value));
         }
 
         [Test]
         public void TestComponentAccessesIsNotSupersetOfBooleans()
         {
             // expect
-            Assert.That(!ComponentAccesses.Value.IsSupersetOf(Booleans.Value));
+            Assert.False(
+                ComponentAccesses.Value.IsSupersetOf(Booleans.Value));
         }
 
         [Test]
         public void TestComponentAccessesIsNotSubsetOfBooleans()
         {
             // expect
-            Assert.That(!ComponentAccesses.Value.IsSubsetOf(Booleans.Value));
+            Assert.False(ComponentAccesses.Value.IsSubsetOf(Booleans.Value));
         }
 
         [Test]
         public void TestComponentAccessesIsNotSupersetOfExpressions()
         {
             // expect
-            Assert.That(
-                !ComponentAccesses.Value.IsSupersetOf(Sets.Expressions.Value));
+            Assert.False(
+                ComponentAccesses.Value.IsSupersetOf(Sets.Expressions.Value));
         }
 
         [Test]
         public void TestComponentAccessesIsSubsetOfExpressions()
         {
             // expect
-            Assert.That(
+            Assert.True(
                 ComponentAccesses.Value.IsSubsetOf(Sets.Expressions.Value));
         }
 
@@ -246,29 +267,31 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.ComponentAccessesT
         public void TestComponentAccessesIsNotSupersetOfLiterals()
         {
             // expect
-            Assert.That(!ComponentAccesses.Value.IsSupersetOf(Literals.Value));
+            Assert.False(
+                ComponentAccesses.Value.IsSupersetOf(Literals.Value));
         }
 
         [Test]
         public void TestComponentAccessesIsNotSubsetOfLiterals()
         {
             // expect
-            Assert.That(!ComponentAccesses.Value.IsSubsetOf(Literals.Value));
+            Assert.False(ComponentAccesses.Value.IsSubsetOf(Literals.Value));
         }
 
         [Test]
         public void TestComponentAccessesIsSupersetOfSelf()
         {
             // expect
-            Assert.That(
-                ComponentAccesses.Value.IsSupersetOf(ComponentAccesses.Value));
+            Assert.True(
+                ComponentAccesses.Value.IsSupersetOf(
+                    ComponentAccesses.Value));
         }
 
         [Test]
         public void TestComponentAccessesIsSubsetOfSelf()
         {
             // expect
-            Assert.That(
+            Assert.True(
                 ComponentAccesses.Value.IsSubsetOf(ComponentAccesses.Value));
         }
 
@@ -276,33 +299,33 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.ComponentAccessesT
         public void TestComponentAccessesIsNotSupersetOfFunctionCalls()
         {
             // expect
-            Assert.That(
-                !ComponentAccesses.Value.IsSupersetOf(FunctionCalls.Value));
+            Assert.False(
+                ComponentAccesses.Value.IsSupersetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestComponentAccessesIsNotSubsetOfFunctionCalls()
         {
             // expect
-            Assert.That(
-                !ComponentAccesses.Value.IsSubsetOf(FunctionCalls.Value));
+            Assert.False(
+                ComponentAccesses.Value.IsSubsetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestComponentAccessesIsNotSupersetOfIntervalExpressions()
         {
             // expect
-            Assert.That(
-                !ComponentAccesses.Value.IsSupersetOf(IntervalExpressions
-                    .Value));
+            Assert.False(
+                ComponentAccesses.Value.IsSupersetOf(
+                    IntervalExpressions.Value));
         }
 
         [Test]
         public void TestComponentAccessesIsNotSubsetOfIntervalExpressions()
         {
             // expect
-            Assert.That(
-                !ComponentAccesses.Value.IsSubsetOf(
+            Assert.False(
+                ComponentAccesses.Value.IsSubsetOf(
                     IntervalExpressions.Value));
         }
 
@@ -310,8 +333,8 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.ComponentAccessesT
         public void TestComponentAccessesIsNotSupersetOfTensorExpressions()
         {
             // expect
-            Assert.That(
-                !ComponentAccesses.Value.IsSupersetOf(
+            Assert.False(
+                ComponentAccesses.Value.IsSupersetOf(
                     TensorExpressions.Value));
         }
 
@@ -319,16 +342,16 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.ComponentAccessesT
         public void TestComponentAccessesIsNotSubsetOfTensorExpressions()
         {
             // expect
-            Assert.That(
-                !ComponentAccesses.Value.IsSubsetOf(TensorExpressions.Value));
+            Assert.False(
+                ComponentAccesses.Value.IsSubsetOf(TensorExpressions.Value));
         }
 
         [Test]
         public void TestComponentAccessesIsNotSupersetOfMatrixExpressions()
         {
             // expect
-            Assert.That(
-                !ComponentAccesses.Value.IsSupersetOf(
+            Assert.False(
+                ComponentAccesses.Value.IsSupersetOf(
                     MatrixExpressions.Value));
         }
 
@@ -336,16 +359,16 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.ComponentAccessesT
         public void TestComponentAccessesIsNotSubsetOfMatrixExpressions()
         {
             // expect
-            Assert.That(
-                !ComponentAccesses.Value.IsSubsetOf(MatrixExpressions.Value));
+            Assert.False(
+                ComponentAccesses.Value.IsSubsetOf(MatrixExpressions.Value));
         }
 
         [Test]
         public void TestComponentAccessesIsNotSupersetOfVectorExpressions()
         {
             // expect
-            Assert.That(
-                !ComponentAccesses.Value.IsSupersetOf(
+            Assert.False(
+                ComponentAccesses.Value.IsSupersetOf(
                     VectorExpressions.Value));
         }
 
@@ -353,24 +376,24 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.ComponentAccessesT
         public void TestComponentAccessesIsNotSubsetOfVectorExpressions()
         {
             // expect
-            Assert.That(
-                !ComponentAccesses.Value.IsSubsetOf(VectorExpressions.Value));
+            Assert.False(
+                ComponentAccesses.Value.IsSubsetOf(VectorExpressions.Value));
         }
 
         [Test]
         public void TestComponentAccessesIsNotSupersetOfVariableAccesses()
         {
             // expect
-            Assert.That(
-                !ComponentAccesses.Value.IsSupersetOf(VariableAccesses.Value));
+            Assert.False(
+                ComponentAccesses.Value.IsSupersetOf(VariableAccesses.Value));
         }
 
         [Test]
         public void TestComponentAccessesIsNotSubsetOfVariableAccesses()
         {
             // expect
-            Assert.That(
-                !ComponentAccesses.Value.IsSubsetOf(VariableAccesses.Value));
+            Assert.False(
+                ComponentAccesses.Value.IsSubsetOf(VariableAccesses.Value));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/SetsT/ExpressionsT/SupersetAndSubsetTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/SetsT/ExpressionsT/SupersetAndSubsetTest.cs
@@ -32,53 +32,54 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.ExpressionsT
         public void TestExpressionsIsNotSupersetOfMathObjects()
         {
             // expect
-            Assert.That(
-                !Sets.Expressions.Value.IsSupersetOf(MathObjects.Value));
+            Assert.False(
+                Sets.Expressions.Value.IsSupersetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestExpressionsIsSubsetOfMathObjects()
         {
             // expect
-            Assert.That(Sets.Expressions.Value.IsSubsetOf(MathObjects.Value));
+            Assert.True(Sets.Expressions.Value.IsSubsetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestExpressionsIsNotSupersetOfSets()
         {
             // expect
-            Assert.That(!Sets.Expressions.Value.IsSupersetOf(Sets.Sets.Value));
+            Assert.False(
+                Sets.Expressions.Value.IsSupersetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestExpressionsIsNotSubsetOfSets()
         {
             // expect
-            Assert.That(!Sets.Expressions.Value.IsSubsetOf(Sets.Sets.Value));
+            Assert.False(Sets.Expressions.Value.IsSubsetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestExpressionsIsNotSupersetOfAllFunctions()
         {
             // expect
-            Assert.That(
-                !Sets.Expressions.Value.IsSupersetOf(AllFunctions.Value));
+            Assert.False(
+                Sets.Expressions.Value.IsSupersetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestExpressionsIsNotSubsetOfAllFunctions()
         {
             // expect
-            Assert.That(!Sets.Expressions.Value.IsSubsetOf(
-                AllFunctions.Value));
+            Assert.False(
+                Sets.Expressions.Value.IsSubsetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestExpressionsIsNotSupersetOfFunctions()
         {
             // expect
-            Assert.That(
-                !Sets.Expressions.Value.IsSupersetOf(
+            Assert.False(
+                Sets.Expressions.Value.IsSupersetOf(
                     Sets.Functions.RealsToReals));
         }
 
@@ -86,148 +87,168 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.ExpressionsT
         public void TestExpressionsIsNotSubsetOfFunctions()
         {
             // expect
-            Assert.That(
-                !Sets.Expressions.Value.IsSubsetOf(Sets.Functions
-                    .RealsToReals));
+            Assert.False(
+                Sets.Expressions.Value.IsSubsetOf(
+                    Sets.Functions.RealsToReals));
+        }
+
+        [Test]
+        public void TestExpressionsIsNotSupersetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                Sets.Expressions.Value.IsSupersetOf(
+                    VariadicFunctions.RealsToReals));
+        }
+
+        [Test]
+        public void TestExpressionsIsNotSubsetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                Sets.Expressions.Value.IsSubsetOf(
+                    VariadicFunctions.RealsToReals));
         }
 
         [Test]
         public void TestExpressionsIsNotSupersetOfTensors()
         {
             // expect
-            Assert.That(!Sets.Expressions.Value.IsSupersetOf(Tensors.Value));
+            Assert.False(Sets.Expressions.Value.IsSupersetOf(Tensors.Value));
         }
 
         [Test]
         public void TestExpressionsIsNotSubsetOfTensors()
         {
             // expect
-            Assert.That(!Sets.Expressions.Value.IsSubsetOf(Tensors.Value));
+            Assert.False(Sets.Expressions.Value.IsSubsetOf(Tensors.Value));
         }
 
         [Test]
         public void TestExpressionsIsNotSupersetOfAllVectors()
         {
             // expect
-            Assert.That(!Sets.Expressions.Value.IsSupersetOf(
-                AllVectors.Value));
+            Assert.False(
+                Sets.Expressions.Value.IsSupersetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestExpressionsIsNotSubsetOfAllVectors()
         {
             // expect
-            Assert.That(!Sets.Expressions.Value.IsSubsetOf(AllVectors.Value));
+            Assert.False(Sets.Expressions.Value.IsSubsetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestExpressionsIsNotSupersetOfVectors()
         {
             // expect
-            Assert.That(!Sets.Expressions.Value.IsSupersetOf(Vectors.R2));
-            Assert.That(!Sets.Expressions.Value.IsSupersetOf(Vectors.R3));
+            Assert.False(Sets.Expressions.Value.IsSupersetOf(Vectors.R2));
+            Assert.False(Sets.Expressions.Value.IsSupersetOf(Vectors.R3));
         }
 
         [Test]
         public void TestExpressionsIsNotSubsetOfVectors()
         {
             // expect
-            Assert.That(!Sets.Expressions.Value.IsSubsetOf(Vectors.R2));
-            Assert.That(!Sets.Expressions.Value.IsSubsetOf(Vectors.R3));
+            Assert.False(Sets.Expressions.Value.IsSubsetOf(Vectors.R2));
+            Assert.False(Sets.Expressions.Value.IsSubsetOf(Vectors.R3));
         }
 
         [Test]
         public void TestExpressionsIsNotSupersetOfAllMatrices()
         {
             // expect
-            Assert.That(
-                !Sets.Expressions.Value.IsSupersetOf(AllMatrices.Value));
+            Assert.False(
+                Sets.Expressions.Value.IsSupersetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestExpressionsIsNotSubsetOfAllMatrices()
         {
             // expect
-            Assert.That(!Sets.Expressions.Value.IsSubsetOf(AllMatrices.Value));
+            Assert.False(
+                Sets.Expressions.Value.IsSubsetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestExpressionsIsNotSupersetOfMatrices()
         {
             // expect
-            Assert.That(!Sets.Expressions.Value.IsSupersetOf(Matrices.M2x2));
-            Assert.That(!Sets.Expressions.Value.IsSupersetOf(Matrices.M3x3));
+            Assert.False(Sets.Expressions.Value.IsSupersetOf(Matrices.M2x2));
+            Assert.False(Sets.Expressions.Value.IsSupersetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestExpressionsIsNotSubsetOfMatrices()
         {
             // expect
-            Assert.That(!Sets.Expressions.Value.IsSubsetOf(Matrices.M2x2));
-            Assert.That(!Sets.Expressions.Value.IsSubsetOf(Matrices.M3x3));
+            Assert.False(Sets.Expressions.Value.IsSubsetOf(Matrices.M2x2));
+            Assert.False(Sets.Expressions.Value.IsSubsetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestExpressionsIsNotSupersetOfReals()
         {
             // expect
-            Assert.That(!Sets.Expressions.Value.IsSupersetOf(Reals.Value));
+            Assert.False(Sets.Expressions.Value.IsSupersetOf(Reals.Value));
         }
 
         [Test]
         public void TestExpressionsIsNotSubsetOfReals()
         {
             // expect
-            Assert.That(!Sets.Expressions.Value.IsSubsetOf(Reals.Value));
+            Assert.False(Sets.Expressions.Value.IsSubsetOf(Reals.Value));
         }
 
         [Test]
         public void TestExpressionsIsNotSupersetOfStrings()
         {
             // expect
-            Assert.That(!Sets.Expressions.Value.IsSupersetOf(Strings.Value));
+            Assert.False(Sets.Expressions.Value.IsSupersetOf(Strings.Value));
         }
 
         [Test]
         public void TestExpressionsIsNotSubsetOfStrings()
         {
             // expect
-            Assert.That(!Sets.Expressions.Value.IsSubsetOf(Strings.Value));
+            Assert.False(Sets.Expressions.Value.IsSubsetOf(Strings.Value));
         }
 
         [Test]
         public void TestExpressionsIsNotSupersetOfIntervals()
         {
             // expect
-            Assert.That(!Sets.Expressions.Value.IsSupersetOf(Intervals.Value));
+            Assert.False(
+                Sets.Expressions.Value.IsSupersetOf(Intervals.Value));
         }
 
         [Test]
         public void TestExpressionsIsNotSubsetOfIntervals()
         {
             // expect
-            Assert.That(!Sets.Expressions.Value.IsSubsetOf(Intervals.Value));
+            Assert.False(Sets.Expressions.Value.IsSubsetOf(Intervals.Value));
         }
 
         [Test]
         public void TestExpressionsIsNotSupersetOfBooleans()
         {
             // expect
-            Assert.That(!Sets.Expressions.Value.IsSupersetOf(Booleans.Value));
+            Assert.False(Sets.Expressions.Value.IsSupersetOf(Booleans.Value));
         }
 
         [Test]
         public void TestExpressionsIsNotSubsetOfBooleans()
         {
             // expect
-            Assert.That(!Sets.Expressions.Value.IsSubsetOf(Booleans.Value));
+            Assert.False(Sets.Expressions.Value.IsSubsetOf(Booleans.Value));
         }
 
         [Test]
         public void TestExpressionsIsSupersetOfSelf()
         {
             // expect
-            Assert.That(
+            Assert.True(
                 Sets.Expressions.Value.IsSupersetOf(Sets.Expressions.Value));
         }
 
@@ -235,7 +256,7 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.ExpressionsT
         public void TestExpressionsIsSubsetOfSelf()
         {
             // expect
-            Assert.That(
+            Assert.True(
                 Sets.Expressions.Value.IsSubsetOf(Sets.Expressions.Value));
         }
 
@@ -243,21 +264,21 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.ExpressionsT
         public void TestExpressionsIsSupersetOfLiterals()
         {
             // expect
-            Assert.That(Sets.Expressions.Value.IsSupersetOf(Literals.Value));
+            Assert.True(Sets.Expressions.Value.IsSupersetOf(Literals.Value));
         }
 
         [Test]
         public void TestExpressionsIsNotSubsetOfLiterals()
         {
             // expect
-            Assert.That(!Sets.Expressions.Value.IsSubsetOf(Literals.Value));
+            Assert.False(Sets.Expressions.Value.IsSubsetOf(Literals.Value));
         }
 
         [Test]
         public void TestExpressionsIsSupersetOfComponentAccesses()
         {
             // expect
-            Assert.That(
+            Assert.True(
                 Sets.Expressions.Value.IsSupersetOf(ComponentAccesses.Value));
         }
 
@@ -265,15 +286,15 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.ExpressionsT
         public void TestExpressionsIsNotSubsetOfComponentAccesses()
         {
             // expect
-            Assert.That(
-                !Sets.Expressions.Value.IsSubsetOf(ComponentAccesses.Value));
+            Assert.False(
+                Sets.Expressions.Value.IsSubsetOf(ComponentAccesses.Value));
         }
 
         [Test]
         public void TestExpressionsIsSupersetOfFunctionCalls()
         {
             // expect
-            Assert.That(
+            Assert.True(
                 Sets.Expressions.Value.IsSupersetOf(FunctionCalls.Value));
         }
 
@@ -281,15 +302,15 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.ExpressionsT
         public void TestExpressionsIsNotSubsetOfFunctionCalls()
         {
             // expect
-            Assert.That(
-                !Sets.Expressions.Value.IsSubsetOf(FunctionCalls.Value));
+            Assert.False(
+                Sets.Expressions.Value.IsSubsetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestExpressionsIsSupersetOfIntervalExpressions()
         {
             // expect
-            Assert.That(
+            Assert.True(
                 Sets.Expressions.Value.IsSupersetOf(
                     IntervalExpressions.Value));
         }
@@ -298,15 +319,15 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.ExpressionsT
         public void TestExpressionsIsNotSubsetOfIntervalExpressions()
         {
             // expect
-            Assert.That(
-                !Sets.Expressions.Value.IsSubsetOf(IntervalExpressions.Value));
+            Assert.False(
+                Sets.Expressions.Value.IsSubsetOf(IntervalExpressions.Value));
         }
 
         [Test]
         public void TestExpressionsIsSupersetOfTensorExpressions()
         {
             // expect
-            Assert.That(
+            Assert.True(
                 Sets.Expressions.Value.IsSupersetOf(TensorExpressions.Value));
         }
 
@@ -314,15 +335,15 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.ExpressionsT
         public void TestExpressionsIsNotSubsetOfTensorExpressions()
         {
             // expect
-            Assert.That(
-                !Sets.Expressions.Value.IsSubsetOf(TensorExpressions.Value));
+            Assert.False(
+                Sets.Expressions.Value.IsSubsetOf(TensorExpressions.Value));
         }
 
         [Test]
         public void TestExpressionsIsSupersetOfMatrixExpressions()
         {
             // expect
-            Assert.That(
+            Assert.True(
                 Sets.Expressions.Value.IsSupersetOf(MatrixExpressions.Value));
         }
 
@@ -330,15 +351,15 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.ExpressionsT
         public void TestExpressionsIsNotSubsetOfMatrixExpressions()
         {
             // expect
-            Assert.That(
-                !Sets.Expressions.Value.IsSubsetOf(MatrixExpressions.Value));
+            Assert.False(
+                Sets.Expressions.Value.IsSubsetOf(MatrixExpressions.Value));
         }
 
         [Test]
         public void TestExpressionsIsSupersetOfVectorExpressions()
         {
             // expect
-            Assert.That(
+            Assert.True(
                 Sets.Expressions.Value.IsSupersetOf(VectorExpressions.Value));
         }
 
@@ -346,15 +367,15 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.ExpressionsT
         public void TestExpressionsIsNotSubsetOfVectorExpressions()
         {
             // expect
-            Assert.That(
-                !Sets.Expressions.Value.IsSubsetOf(VectorExpressions.Value));
+            Assert.False(
+                Sets.Expressions.Value.IsSubsetOf(VectorExpressions.Value));
         }
 
         [Test]
         public void TestExpressionsIsSupersetOfVariableAccesses()
         {
             // expect
-            Assert.That(
+            Assert.True(
                 Sets.Expressions.Value.IsSupersetOf(VariableAccesses.Value));
         }
 
@@ -362,8 +383,8 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.ExpressionsT
         public void TestExpressionsIsNotSubsetOfVariableAccesses()
         {
             // expect
-            Assert.That(
-                !Sets.Expressions.Value.IsSubsetOf(VariableAccesses.Value));
+            Assert.False(
+                Sets.Expressions.Value.IsSubsetOf(VariableAccesses.Value));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/SetsT/FunctionCallsT/SupersetAndSubsetTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/SetsT/FunctionCallsT/SupersetAndSubsetTest.cs
@@ -32,50 +32,51 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.FunctionCallsT
         public void TestFunctionCallsIsNotSupersetOfMathObjects()
         {
             // expect
-            Assert.That(!FunctionCalls.Value.IsSupersetOf(MathObjects.Value));
+            Assert.False(FunctionCalls.Value.IsSupersetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestFunctionCallsIsSubsetOfMathObjects()
         {
             // expect
-            Assert.That(FunctionCalls.Value.IsSubsetOf(MathObjects.Value));
+            Assert.True(FunctionCalls.Value.IsSubsetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestFunctionCallsIsNotSupersetOfSets()
         {
             // expect
-            Assert.That(!FunctionCalls.Value.IsSupersetOf(Sets.Sets.Value));
+            Assert.False(FunctionCalls.Value.IsSupersetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestFunctionCallsIsNotSubsetOfSets()
         {
             // expect
-            Assert.That(!FunctionCalls.Value.IsSubsetOf(Sets.Sets.Value));
+            Assert.False(FunctionCalls.Value.IsSubsetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestFunctionCallsIsNotSupersetOfAllFunctions()
         {
             // expect
-            Assert.That(!FunctionCalls.Value.IsSupersetOf(AllFunctions.Value));
+            Assert.False(
+                FunctionCalls.Value.IsSupersetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestFunctionCallsIsNotSubsetOfAllFunctions()
         {
             // expect
-            Assert.That(!FunctionCalls.Value.IsSubsetOf(AllFunctions.Value));
+            Assert.False(FunctionCalls.Value.IsSubsetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestFunctionCallsIsNotSupersetOfFunctions()
         {
             // expect
-            Assert.That(
-                !FunctionCalls.Value.IsSupersetOf(
+            Assert.False(
+                FunctionCalls.Value.IsSupersetOf(
                     Sets.Functions.RealsToReals));
         }
 
@@ -83,278 +84,297 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.FunctionCallsT
         public void TestFunctionCallsIsNotSubsetOfFunctions()
         {
             // expect
-            Assert.That(
-                !FunctionCalls.Value.IsSubsetOf(Sets.Functions.RealsToReals));
+            Assert.False(
+                FunctionCalls.Value.IsSubsetOf(Sets.Functions.RealsToReals));
+        }
+
+        [Test]
+        public void TestFunctionCallsIsNotSupersetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                FunctionCalls.Value.IsSupersetOf(
+                    VariadicFunctions.RealsToReals));
+        }
+
+        [Test]
+        public void TestFunctionCallsIsNotSubsetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                FunctionCalls.Value.IsSubsetOf(
+                    VariadicFunctions.RealsToReals));
         }
 
         [Test]
         public void TestFunctionCallsIsNotSupersetOfTensors()
         {
             // expect
-            Assert.That(!FunctionCalls.Value.IsSupersetOf(Tensors.Value));
+            Assert.False(FunctionCalls.Value.IsSupersetOf(Tensors.Value));
         }
 
         [Test]
         public void TestFunctionCallsIsNotSubsetOfTensors()
         {
             // expect
-            Assert.That(!FunctionCalls.Value.IsSubsetOf(Tensors.Value));
+            Assert.False(FunctionCalls.Value.IsSubsetOf(Tensors.Value));
         }
 
         [Test]
         public void TestFunctionCallsIsNotSupersetOfAllVectors()
         {
             // expect
-            Assert.That(!FunctionCalls.Value.IsSupersetOf(AllVectors.Value));
+            Assert.False(FunctionCalls.Value.IsSupersetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestFunctionCallsIsNotSubsetOfAllVectors()
         {
             // expect
-            Assert.That(!FunctionCalls.Value.IsSubsetOf(AllVectors.Value));
+            Assert.False(FunctionCalls.Value.IsSubsetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestFunctionCallsIsNotSupersetOfVectors()
         {
             // expect
-            Assert.That(!FunctionCalls.Value.IsSupersetOf(Vectors.R2));
-            Assert.That(!FunctionCalls.Value.IsSupersetOf(Vectors.R3));
+            Assert.False(FunctionCalls.Value.IsSupersetOf(Vectors.R2));
+            Assert.False(FunctionCalls.Value.IsSupersetOf(Vectors.R3));
         }
 
         [Test]
         public void TestFunctionCallsIsNotSubsetOfVectors()
         {
             // expect
-            Assert.That(!FunctionCalls.Value.IsSubsetOf(Vectors.R2));
-            Assert.That(!FunctionCalls.Value.IsSubsetOf(Vectors.R3));
+            Assert.False(FunctionCalls.Value.IsSubsetOf(Vectors.R2));
+            Assert.False(FunctionCalls.Value.IsSubsetOf(Vectors.R3));
         }
 
         [Test]
         public void TestFunctionCallsIsNotSupersetOfAllMatrices()
         {
             // expect
-            Assert.That(!FunctionCalls.Value.IsSupersetOf(AllMatrices.Value));
+            Assert.False(FunctionCalls.Value.IsSupersetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestFunctionCallsIsNotSubsetOfAllMatrices()
         {
             // expect
-            Assert.That(!FunctionCalls.Value.IsSubsetOf(AllMatrices.Value));
+            Assert.False(FunctionCalls.Value.IsSubsetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestFunctionCallsIsNotSupersetOfMatrices()
         {
             // expect
-            Assert.That(!FunctionCalls.Value.IsSupersetOf(Matrices.M2x2));
-            Assert.That(!FunctionCalls.Value.IsSupersetOf(Matrices.M3x3));
+            Assert.False(FunctionCalls.Value.IsSupersetOf(Matrices.M2x2));
+            Assert.False(FunctionCalls.Value.IsSupersetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestFunctionCallsIsNotSubsetOfMatrices()
         {
             // expect
-            Assert.That(!FunctionCalls.Value.IsSubsetOf(Matrices.M2x2));
-            Assert.That(!FunctionCalls.Value.IsSubsetOf(Matrices.M3x3));
+            Assert.False(FunctionCalls.Value.IsSubsetOf(Matrices.M2x2));
+            Assert.False(FunctionCalls.Value.IsSubsetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestFunctionCallsIsNotSupersetOfReals()
         {
             // expect
-            Assert.That(!FunctionCalls.Value.IsSupersetOf(Reals.Value));
+            Assert.False(FunctionCalls.Value.IsSupersetOf(Reals.Value));
         }
 
         [Test]
         public void TestFunctionCallsIsNotSubsetOfReals()
         {
             // expect
-            Assert.That(!FunctionCalls.Value.IsSubsetOf(Reals.Value));
+            Assert.False(FunctionCalls.Value.IsSubsetOf(Reals.Value));
         }
 
         [Test]
         public void TestFunctionCallsIsNotSupersetOfStrings()
         {
             // expect
-            Assert.That(!FunctionCalls.Value.IsSupersetOf(Strings.Value));
+            Assert.False(FunctionCalls.Value.IsSupersetOf(Strings.Value));
         }
 
         [Test]
         public void TestFunctionCallsIsNotSubsetOfStrings()
         {
             // expect
-            Assert.That(!FunctionCalls.Value.IsSubsetOf(Strings.Value));
+            Assert.False(FunctionCalls.Value.IsSubsetOf(Strings.Value));
         }
 
         [Test]
         public void TestFunctionCallsIsNotSupersetOfIntervals()
         {
             // expect
-            Assert.That(!FunctionCalls.Value.IsSupersetOf(Intervals.Value));
+            Assert.False(FunctionCalls.Value.IsSupersetOf(Intervals.Value));
         }
 
         [Test]
         public void TestFunctionCallsIsNotSubsetOfIntervals()
         {
             // expect
-            Assert.That(!FunctionCalls.Value.IsSubsetOf(Intervals.Value));
+            Assert.False(FunctionCalls.Value.IsSubsetOf(Intervals.Value));
         }
 
         [Test]
         public void TestFunctionCallsIsNotSupersetOfBooleans()
         {
             // expect
-            Assert.That(!FunctionCalls.Value.IsSupersetOf(Booleans.Value));
+            Assert.False(FunctionCalls.Value.IsSupersetOf(Booleans.Value));
         }
 
         [Test]
         public void TestFunctionCallsIsNotSubsetOfBooleans()
         {
             // expect
-            Assert.That(!FunctionCalls.Value.IsSubsetOf(Booleans.Value));
+            Assert.False(FunctionCalls.Value.IsSubsetOf(Booleans.Value));
         }
 
         [Test]
         public void TestFunctionCallsIsNotSupersetOfExpressions()
         {
             // expect
-            Assert.That(
-                !FunctionCalls.Value.IsSupersetOf(Sets.Expressions.Value));
+            Assert.False(
+                FunctionCalls.Value.IsSupersetOf(Sets.Expressions.Value));
         }
 
         [Test]
         public void TestFunctionCallsIsSubsetOfExpressions()
         {
             // expect
-            Assert.That(FunctionCalls.Value.IsSubsetOf(
-                Sets.Expressions.Value));
+            Assert.True(
+                FunctionCalls.Value.IsSubsetOf(Sets.Expressions.Value));
         }
 
         [Test]
         public void TestFunctionCallsIsNotSupersetOfLiterals()
         {
             // expect
-            Assert.That(!FunctionCalls.Value.IsSupersetOf(Literals.Value));
+            Assert.False(FunctionCalls.Value.IsSupersetOf(Literals.Value));
         }
 
         [Test]
         public void TestFunctionCallsIsNotSubsetOfLiterals()
         {
             // expect
-            Assert.That(!FunctionCalls.Value.IsSubsetOf(Literals.Value));
+            Assert.False(FunctionCalls.Value.IsSubsetOf(Literals.Value));
         }
 
         [Test]
         public void TestFunctionCallsIsNotSupersetOfComponentAccesses()
         {
             // expect
-            Assert.That(
-                !FunctionCalls.Value.IsSupersetOf(ComponentAccesses.Value));
+            Assert.False(
+                FunctionCalls.Value.IsSupersetOf(ComponentAccesses.Value));
         }
 
         [Test]
         public void TestFunctionCallsIsNotSubsetOfComponentAccesses()
         {
             // expect
-            Assert.That(
-                !FunctionCalls.Value.IsSubsetOf(ComponentAccesses.Value));
+            Assert.False(
+                FunctionCalls.Value.IsSubsetOf(ComponentAccesses.Value));
         }
 
         [Test]
         public void TestFunctionCallsIsSupersetOfSelf()
         {
             // expect
-            Assert.That(FunctionCalls.Value.IsSupersetOf(FunctionCalls.Value));
+            Assert.True(
+                FunctionCalls.Value.IsSupersetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestFunctionCallsIsSubsetOfSelf()
         {
             // expect
-            Assert.That(FunctionCalls.Value.IsSubsetOf(FunctionCalls.Value));
+            Assert.True(FunctionCalls.Value.IsSubsetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestFunctionCallsIsNotSupersetOfIntervalExpressions()
         {
             // expect
-            Assert.That(
-                !FunctionCalls.Value.IsSupersetOf(IntervalExpressions.Value));
+            Assert.False(
+                FunctionCalls.Value.IsSupersetOf(IntervalExpressions.Value));
         }
 
         [Test]
         public void TestFunctionCallsIsNotSubsetOfIntervalExpressions()
         {
             // expect
-            Assert.That(
-                !FunctionCalls.Value.IsSubsetOf(IntervalExpressions.Value));
+            Assert.False(
+                FunctionCalls.Value.IsSubsetOf(IntervalExpressions.Value));
         }
 
         [Test]
         public void TestFunctionCallsIsNotSupersetOfTensorExpressions()
         {
             // expect
-            Assert.That(
-                !FunctionCalls.Value.IsSupersetOf(TensorExpressions.Value));
+            Assert.False(
+                FunctionCalls.Value.IsSupersetOf(TensorExpressions.Value));
         }
 
         [Test]
         public void TestFunctionCallsIsNotSubsetOfTensorExpressions()
         {
             // expect
-            Assert.That(
-                !FunctionCalls.Value.IsSubsetOf(TensorExpressions.Value));
+            Assert.False(
+                FunctionCalls.Value.IsSubsetOf(TensorExpressions.Value));
         }
 
         [Test]
         public void TestFunctionCallsIsNotSupersetOfMatrixExpressions()
         {
             // expect
-            Assert.That(
-                !FunctionCalls.Value.IsSupersetOf(MatrixExpressions.Value));
+            Assert.False(
+                FunctionCalls.Value.IsSupersetOf(MatrixExpressions.Value));
         }
 
         [Test]
         public void TestFunctionCallsIsNotSubsetOfMatrixExpressions()
         {
             // expect
-            Assert.That(
-                !FunctionCalls.Value.IsSubsetOf(MatrixExpressions.Value));
+            Assert.False(
+                FunctionCalls.Value.IsSubsetOf(MatrixExpressions.Value));
         }
 
         [Test]
         public void TestFunctionCallsIsNotSupersetOfVectorExpressions()
         {
             // expect
-            Assert.That(
-                !FunctionCalls.Value.IsSupersetOf(VectorExpressions.Value));
+            Assert.False(
+                FunctionCalls.Value.IsSupersetOf(VectorExpressions.Value));
         }
 
         [Test]
         public void TestFunctionCallsIsNotSubsetOfVectorExpressions()
         {
             // expect
-            Assert.That(
-                !FunctionCalls.Value.IsSubsetOf(VectorExpressions.Value));
+            Assert.False(
+                FunctionCalls.Value.IsSubsetOf(VectorExpressions.Value));
         }
 
         [Test]
         public void TestFunctionCallsIsNotSupersetOfVariableAccesses()
         {
             // expect
-            Assert.That(
-                !FunctionCalls.Value.IsSupersetOf(VariableAccesses.Value));
+            Assert.False(
+                FunctionCalls.Value.IsSupersetOf(VariableAccesses.Value));
         }
 
         [Test]
         public void TestFunctionCallsIsNotSubsetOfVariableAccesses()
         {
             // expect
-            Assert.That(
-                !FunctionCalls.Value.IsSubsetOf(VariableAccesses.Value));
+            Assert.False(
+                FunctionCalls.Value.IsSubsetOf(VariableAccesses.Value));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/SetsT/FunctionsT/ContainsTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/SetsT/FunctionsT/ContainsTest.cs
@@ -41,15 +41,16 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.FunctionsT
             Assert.That(fs.Contains(NaturalLogarithmFunction.Value));
             Assert.That(fs.Contains(Log2Function.Value));
             Assert.That(fs.Contains(Log10Function.Value));
-            Assert.That(!fs.Contains(AdditionOperation.Value));
-            Assert.That(!fs.Contains(DivisionOperation.Value));
-            Assert.That(!fs.Contains(LogarithmFunction.Value));
-            Assert.That(!fs.Contains(SizeFunction.Value));
-            Assert.That(!fs.Contains(MaximumFiniteFunction.Value));
-            Assert.That(!fs.Contains(MaximumFunction.Value));
-            Assert.That(!fs.Contains(MinimumFiniteFunction.Value));
-            Assert.That(!fs.Contains(MinimumFunction.Value));
-            Assert.That(!fs.Contains(NegationOperation.Value));
+
+            Assert.IsFalse(fs.Contains(AdditionOperation.Value));
+            Assert.IsFalse(fs.Contains(DivisionOperation.Value));
+            Assert.IsFalse(fs.Contains(LogarithmFunction.Value));
+            Assert.IsFalse(fs.Contains(SizeFunction.Value));
+            Assert.IsFalse(fs.Contains(MaximumFiniteFunction.Value));
+            Assert.IsFalse(fs.Contains(MaximumFunction.Value));
+            Assert.IsFalse(fs.Contains(MinimumFiniteFunction.Value));
+            Assert.IsFalse(fs.Contains(MinimumFunction.Value));
+            Assert.IsFalse(fs.Contains(NegationOperation.Value));
         }
 
         [Test]

--- a/MetaphysicsIndustries.Solus.Test/SetsT/FunctionsT/GetTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/SetsT/FunctionsT/GetTest.cs
@@ -1,0 +1,75 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Sets;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.SetsT.FunctionsT
+{
+    [TestFixture]
+    public class GetTest
+    {
+        [Test]
+        public void SubsequentInvocationsGiveTheSameObject1()
+        {
+            //given
+            var a = Sets.Functions.Get(Reals.Value, Reals.Value);
+            // when
+            var b = Sets.Functions.Get(Reals.Value, Reals.Value);
+            // then
+            Assert.That(object.ReferenceEquals(a, b));
+        }
+
+        [Test]
+        public void SubsequentInvocationsGiveTheSameObject2()
+        {
+            //given
+            var a = Sets.Functions.Get(Reals.Value, Reals.Value);
+            // when
+            var b = Sets.Functions.RealsToReals;
+            // then
+            Assert.That(object.ReferenceEquals(a, b));
+        }
+
+        [Test]
+        public void SubsequentInvocationsGiveTheSameObject3()
+        {
+            //given
+            var a = Sets.Functions.RealsToReals;
+            // when
+            var b = Sets.Functions.Get(Reals.Value, Reals.Value);
+            // then
+            Assert.That(object.ReferenceEquals(a, b));
+        }
+
+        [Test]
+        public void SubsequentInvocationsGiveTheSameObject4()
+        {
+            //given
+            var a = Sets.Functions.RealsToReals;
+            // when
+            var b = Sets.Functions.RealsToReals;
+            // then
+            Assert.That(object.ReferenceEquals(a, b));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/SetsT/FunctionsT/SupersetAndSubsetTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/SetsT/FunctionsT/SupersetAndSubsetTest.cs
@@ -32,47 +32,47 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.FunctionsT
         public void TestFunctionsIsNotSupersetOfMathObjects()
         {
             // expect
-            Assert.That(!Sets.Functions.RealsToReals.IsSupersetOf(
-                MathObjects.Value));
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSupersetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestFunctionsIsSubsetOfMathObjects()
         {
             // expect
-            Assert.That(Sets.Functions.RealsToReals.IsSubsetOf(
-                MathObjects.Value));
+            Assert.True(
+                Sets.Functions.RealsToReals.IsSubsetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestFunctionsIsNotSupersetOfSets()
         {
             // expect
-            Assert.That(
-                !Sets.Functions.RealsToReals.IsSupersetOf(Sets.Sets.Value));
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSupersetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestFunctionsIsNotSubsetOfSets()
         {
             // expect
-            Assert.That(
-                !Sets.Functions.RealsToReals.IsSubsetOf(Sets.Sets.Value));
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSubsetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestFunctionsIsNotSupersetOfAllFunctions()
         {
             // expect
-            Assert.That(
-                !Sets.Functions.RealsToReals.IsSupersetOf(AllFunctions.Value));
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSupersetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestFunctionsIsSubsetOfAllFunctions()
         {
             // expect
-            Assert.That(
+            Assert.True(
                 Sets.Functions.RealsToReals.IsSubsetOf(AllFunctions.Value));
         }
 
@@ -80,173 +80,193 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.FunctionsT
         public void TestFunctionsIsSupersetOfSelf()
         {
             // expect
-            Assert.That(
-                Sets.Functions.RealsToReals.IsSupersetOf(Sets.Functions
-                    .RealsToReals));
+            Assert.True(
+                Sets.Functions.RealsToReals.IsSupersetOf(
+                    Sets.Functions.RealsToReals));
         }
 
         [Test]
         public void TestFunctionsIsSubsetOfSelf()
         {
             // expect
-            Assert.That(
-                Sets.Functions.RealsToReals.IsSubsetOf(Sets.Functions
-                    .RealsToReals));
+            Assert.True(
+                Sets.Functions.RealsToReals.IsSubsetOf(
+                    Sets.Functions.RealsToReals));
+        }
+
+        [Test]
+        public void TestFunctionsIsNotSupersetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSupersetOf(
+                    VariadicFunctions.RealsToReals));
+        }
+
+        [Test]
+        public void TestFunctionsIsNotSubsetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSubsetOf(
+                    VariadicFunctions.RealsToReals));
         }
 
         [Test]
         public void TestFunctionsIsNotSupersetOfTensors()
         {
             // expect
-            Assert.That(
-                !Sets.Functions.RealsToReals.IsSupersetOf(Tensors.Value));
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSupersetOf(Tensors.Value));
         }
 
         [Test]
         public void TestFunctionsIsNotSubsetOfTensors()
         {
             // expect
-            Assert.That(!Sets.Functions.RealsToReals.IsSubsetOf(
-                Tensors.Value));
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSubsetOf(Tensors.Value));
         }
 
         [Test]
         public void TestFunctionsIsNotSupersetOfAllVectors()
         {
             // expect
-            Assert.That(
-                !Sets.Functions.RealsToReals.IsSupersetOf(AllVectors.Value));
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSupersetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestFunctionsIsNotSubsetOfAllVectors()
         {
             // expect
-            Assert.That(
-                !Sets.Functions.RealsToReals.IsSubsetOf(AllVectors.Value));
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSubsetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestFunctionsIsNotSupersetOfVectors()
         {
             // expect
-            Assert.That(!Sets.Functions.RealsToReals.IsSupersetOf(Vectors.R2));
-            Assert.That(!Sets.Functions.RealsToReals.IsSupersetOf(Vectors.R3));
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSupersetOf(Vectors.R2));
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSupersetOf(Vectors.R3));
         }
 
         [Test]
         public void TestFunctionsIsNotSubsetOfVectors()
         {
             // expect
-            Assert.That(!Sets.Functions.RealsToReals.IsSubsetOf(Vectors.R2));
-            Assert.That(!Sets.Functions.RealsToReals.IsSubsetOf(Vectors.R3));
+            Assert.False(Sets.Functions.RealsToReals.IsSubsetOf(Vectors.R2));
+            Assert.False(Sets.Functions.RealsToReals.IsSubsetOf(Vectors.R3));
         }
 
         [Test]
         public void TestFunctionsIsNotSupersetOfAllMatrices()
         {
             // expect
-            Assert.That(
-                !Sets.Functions.RealsToReals.IsSupersetOf(AllMatrices.Value));
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSupersetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestFunctionsIsNotSubsetOfAllMatrices()
         {
             // expect
-            Assert.That(
-                !Sets.Functions.RealsToReals.IsSubsetOf(AllMatrices.Value));
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSubsetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestFunctionsIsNotSupersetOfMatrices()
         {
             // expect
-            Assert.That(
-                !Sets.Functions.RealsToReals.IsSupersetOf(Matrices.M2x2));
-            Assert.That(
-                !Sets.Functions.RealsToReals.IsSupersetOf(Matrices.M3x3));
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSupersetOf(Matrices.M2x2));
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSupersetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestFunctionsIsNotSubsetOfMatrices()
         {
             // expect
-            Assert.That(!Sets.Functions.RealsToReals.IsSubsetOf(
-                Matrices.M2x2));
-            Assert.That(!Sets.Functions.RealsToReals.IsSubsetOf(
-                Matrices.M3x3));
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSubsetOf(Matrices.M2x2));
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSubsetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestFunctionsIsNotSupersetOfReals()
         {
             // expect
-            Assert.That(!Sets.Functions.RealsToReals.IsSupersetOf(
-                Reals.Value));
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSupersetOf(Reals.Value));
         }
 
         [Test]
         public void TestFunctionsIsNotSubsetOfReals()
         {
             // expect
-            Assert.That(!Sets.Functions.RealsToReals.IsSubsetOf(Reals.Value));
+            Assert.False(Sets.Functions.RealsToReals.IsSubsetOf(Reals.Value));
         }
 
         [Test]
         public void TestFunctionsIsNotSupersetOfStrings()
         {
             // expect
-            Assert.That(
-                !Sets.Functions.RealsToReals.IsSupersetOf(Strings.Value));
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSupersetOf(Strings.Value));
         }
 
         [Test]
         public void TestFunctionsIsNotSubsetOfStrings()
         {
             // expect
-            Assert.That(!Sets.Functions.RealsToReals.IsSubsetOf(
-                Strings.Value));
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSubsetOf(Strings.Value));
         }
 
         [Test]
         public void TestFunctionsIsNotSupersetOfIntervals()
         {
             // expect
-            Assert.That(
-                !Sets.Functions.RealsToReals.IsSupersetOf(Intervals.Value));
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSupersetOf(Intervals.Value));
         }
 
         [Test]
         public void TestFunctionsIsNotSubsetOfIntervals()
         {
             // expect
-            Assert.That(
-                !Sets.Functions.RealsToReals.IsSubsetOf(Intervals.Value));
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSubsetOf(Intervals.Value));
         }
 
         [Test]
         public void TestFunctionsIsNotSupersetOfBooleans()
         {
             // expect
-            Assert.That(
-                !Sets.Functions.RealsToReals.IsSupersetOf(Booleans.Value));
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSupersetOf(Booleans.Value));
         }
 
         [Test]
         public void TestFunctionsIsNotSubsetOfBooleans()
         {
             // expect
-            Assert.That(
-                !Sets.Functions.RealsToReals.IsSubsetOf(Booleans.Value));
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSubsetOf(Booleans.Value));
         }
 
         [Test]
         public void TestFunctionsIsNotSupersetOfExpressions()
         {
             // expect
-            Assert.That(
-                !Sets.Functions.RealsToReals.IsSupersetOf(
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSupersetOf(
                     Sets.Expressions.Value));
         }
 
@@ -254,51 +274,51 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.FunctionsT
         public void TestFunctionsIsNotSubsetOfExpressions()
         {
             // expect
-            Assert.That(
-                !Sets.Functions.RealsToReals.IsSubsetOf(Sets.Expressions
-                    .Value));
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSubsetOf(
+                    Sets.Expressions.Value));
         }
 
         [Test]
         public void TestFunctionsIsNotSupersetOfLiterals()
         {
             // expect
-            Assert.That(
-                !Sets.Functions.RealsToReals.IsSupersetOf(Literals.Value));
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSupersetOf(Literals.Value));
         }
 
         [Test]
         public void TestFunctionsIsNotSubsetOfLiterals()
         {
             // expect
-            Assert.That(
-                !Sets.Functions.RealsToReals.IsSubsetOf(Literals.Value));
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSubsetOf(Literals.Value));
         }
 
         [Test]
         public void TestFunctionsIsNotSupersetOfComponentAccesses()
         {
             // expect
-            Assert.That(
-                !Sets.Functions.RealsToReals.IsSupersetOf(ComponentAccesses
-                    .Value));
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSupersetOf(
+                    ComponentAccesses.Value));
         }
 
         [Test]
         public void TestFunctionsIsNotSubsetOfComponentAccesses()
         {
             // expect
-            Assert.That(
-                !Sets.Functions.RealsToReals.IsSubsetOf(ComponentAccesses
-                    .Value));
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSubsetOf(
+                    ComponentAccesses.Value));
         }
 
         [Test]
         public void TestFunctionsIsNotSupersetOfFunctionCalls()
         {
             // expect
-            Assert.That(
-                !Sets.Functions.RealsToReals.IsSupersetOf(
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSupersetOf(
                     FunctionCalls.Value));
         }
 
@@ -306,88 +326,88 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.FunctionsT
         public void TestFunctionsIsNotSubsetOfFunctionCalls()
         {
             // expect
-            Assert.That(
-                !Sets.Functions.RealsToReals.IsSubsetOf(FunctionCalls.Value));
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSubsetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestFunctionsIsNotSupersetOfIntervalExpressions()
         {
             // expect
-            Assert.That(
-                !Sets.Functions.RealsToReals.IsSupersetOf(IntervalExpressions
-                    .Value));
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSupersetOf(
+                    IntervalExpressions.Value));
         }
 
         [Test]
         public void TestFunctionsIsNotSubsetOfIntervalExpressions()
         {
             // expect
-            Assert.That(
-                !Sets.Functions.RealsToReals.IsSubsetOf(IntervalExpressions
-                    .Value));
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSubsetOf(
+                    IntervalExpressions.Value));
         }
 
         [Test]
         public void TestFunctionsIsNotSupersetOfTensorExpressions()
         {
             // expect
-            Assert.That(
-                !Sets.Functions.RealsToReals.IsSupersetOf(TensorExpressions
-                    .Value));
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSupersetOf(
+                    TensorExpressions.Value));
         }
 
         [Test]
         public void TestFunctionsIsNotSubsetOfTensorExpressions()
         {
             // expect
-            Assert.That(
-                !Sets.Functions.RealsToReals.IsSubsetOf(TensorExpressions
-                    .Value));
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSubsetOf(
+                    TensorExpressions.Value));
         }
 
         [Test]
         public void TestFunctionsIsNotSupersetOfMatrixExpressions()
         {
             // expect
-            Assert.That(
-                !Sets.Functions.RealsToReals.IsSupersetOf(MatrixExpressions
-                    .Value));
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSupersetOf(
+                    MatrixExpressions.Value));
         }
 
         [Test]
         public void TestFunctionsIsNotSubsetOfMatrixExpressions()
         {
             // expect
-            Assert.That(
-                !Sets.Functions.RealsToReals.IsSubsetOf(MatrixExpressions
-                    .Value));
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSubsetOf(
+                    MatrixExpressions.Value));
         }
 
         [Test]
         public void TestFunctionsIsNotSupersetOfVectorExpressions()
         {
             // expect
-            Assert.That(
-                !Sets.Functions.RealsToReals.IsSupersetOf(VectorExpressions
-                    .Value));
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSupersetOf(
+                    VectorExpressions.Value));
         }
 
         [Test]
         public void TestFunctionsIsNotSubsetOfVectorExpressions()
         {
             // expect
-            Assert.That(
-                !Sets.Functions.RealsToReals.IsSubsetOf(VectorExpressions
-                    .Value));
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSubsetOf(
+                    VectorExpressions.Value));
         }
 
         [Test]
         public void TestFunctionsIsNotSupersetOfVariableAccesses()
         {
             // expect
-            Assert.That(
-                !Sets.Functions.RealsToReals.IsSupersetOf(
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSupersetOf(
                     VariableAccesses.Value));
         }
 
@@ -395,9 +415,9 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.FunctionsT
         public void TestFunctionsIsNotSubsetOfVariableAccesses()
         {
             // expect
-            Assert.That(
-                !Sets.Functions.RealsToReals.IsSubsetOf(VariableAccesses
-                    .Value));
+            Assert.False(
+                Sets.Functions.RealsToReals.IsSubsetOf(
+                    VariableAccesses.Value));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/SetsT/IntervalExpressionsT/SupersetAndSubsetTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/SetsT/IntervalExpressionsT/SupersetAndSubsetTest.cs
@@ -32,15 +32,15 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.IntervalExpressionsT
         public void TestIntervalExpressionsIsNotSupersetOfMathObjects()
         {
             // expect
-            Assert.That(
-                !IntervalExpressions.Value.IsSupersetOf(MathObjects.Value));
+            Assert.False(
+                IntervalExpressions.Value.IsSupersetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestIntervalExpressionsIsSubsetOfMathObjects()
         {
             // expect
-            Assert.That(
+            Assert.True(
                 IntervalExpressions.Value.IsSubsetOf(MathObjects.Value));
         }
 
@@ -48,207 +48,226 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.IntervalExpressionsT
         public void TestIntervalExpressionsIsNotSupersetOfSets()
         {
             // expect
-            Assert.That(
-                !IntervalExpressions.Value.IsSupersetOf(Sets.Sets.Value));
+            Assert.False(
+                IntervalExpressions.Value.IsSupersetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestIntervalExpressionsIsNotSubsetOfSets()
         {
             // expect
-            Assert.That(!IntervalExpressions.Value.IsSubsetOf(
-                Sets.Sets.Value));
+            Assert.False(
+                IntervalExpressions.Value.IsSubsetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestIntervalExpressionsIsNotSupersetOfAllFunctions()
         {
             // expect
-            Assert.That(
-                !IntervalExpressions.Value.IsSupersetOf(AllFunctions.Value));
+            Assert.False(
+                IntervalExpressions.Value.IsSupersetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestIntervalExpressionsIsNotSubsetOfAllFunctions()
         {
             // expect
-            Assert.That(
-                !IntervalExpressions.Value.IsSubsetOf(AllFunctions.Value));
+            Assert.False(
+                IntervalExpressions.Value.IsSubsetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestIntervalExpressionsIsNotSupersetOfFunctions()
         {
             // expect
-            Assert.That(
-                !IntervalExpressions.Value.IsSupersetOf(Sets.Functions
-                    .RealsToReals));
+            Assert.False(
+                IntervalExpressions.Value.IsSupersetOf(
+                    Sets.Functions.RealsToReals));
         }
 
         [Test]
         public void TestIntervalExpressionsIsNotSubsetOfFunctions()
         {
             // expect
-            Assert.That(
-                !IntervalExpressions.Value.IsSubsetOf(Sets.Functions
-                    .RealsToReals));
+            Assert.False(
+                IntervalExpressions.Value.IsSubsetOf(
+                    Sets.Functions.RealsToReals));
+        }
+
+        [Test]
+        public void TestIntervalExpressionsIsNotSupersetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                IntervalExpressions.Value.IsSupersetOf(
+                    VariadicFunctions.RealsToReals));
+        }
+
+        [Test]
+        public void TestIntervalExpressionsIsNotSubsetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                IntervalExpressions.Value.IsSubsetOf(
+                    VariadicFunctions.RealsToReals));
         }
 
         [Test]
         public void TestIntervalExpressionsIsNotSupersetOfTensors()
         {
             // expect
-            Assert.That(!IntervalExpressions.Value.IsSupersetOf(
-                Tensors.Value));
+            Assert.False(
+                IntervalExpressions.Value.IsSupersetOf(Tensors.Value));
         }
 
         [Test]
         public void TestIntervalExpressionsIsNotSubsetOfTensors()
         {
             // expect
-            Assert.That(!IntervalExpressions.Value.IsSubsetOf(Tensors.Value));
+            Assert.False(IntervalExpressions.Value.IsSubsetOf(Tensors.Value));
         }
 
         [Test]
         public void TestIntervalExpressionsIsNotSupersetOfAllVectors()
         {
             // expect
-            Assert.That(
-                !IntervalExpressions.Value.IsSupersetOf(AllVectors.Value));
+            Assert.False(
+                IntervalExpressions.Value.IsSupersetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestIntervalExpressionsIsNotSubsetOfAllVectors()
         {
             // expect
-            Assert.That(
-                !IntervalExpressions.Value.IsSubsetOf(AllVectors.Value));
+            Assert.False(
+                IntervalExpressions.Value.IsSubsetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestIntervalExpressionsIsNotSupersetOfVectors()
         {
             // expect
-            Assert.That(!IntervalExpressions.Value.IsSupersetOf(Vectors.R2));
-            Assert.That(!IntervalExpressions.Value.IsSupersetOf(Vectors.R3));
+            Assert.False(IntervalExpressions.Value.IsSupersetOf(Vectors.R2));
+            Assert.False(IntervalExpressions.Value.IsSupersetOf(Vectors.R3));
         }
 
         [Test]
         public void TestIntervalExpressionsIsNotSubsetOfVectors()
         {
             // expect
-            Assert.That(!IntervalExpressions.Value.IsSubsetOf(Vectors.R2));
-            Assert.That(!IntervalExpressions.Value.IsSubsetOf(Vectors.R3));
+            Assert.False(IntervalExpressions.Value.IsSubsetOf(Vectors.R2));
+            Assert.False(IntervalExpressions.Value.IsSubsetOf(Vectors.R3));
         }
 
         [Test]
         public void TestIntervalExpressionsIsNotSupersetOfAllMatrices()
         {
             // expect
-            Assert.That(
-                !IntervalExpressions.Value.IsSupersetOf(AllMatrices.Value));
+            Assert.False(
+                IntervalExpressions.Value.IsSupersetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestIntervalExpressionsIsNotSubsetOfAllMatrices()
         {
             // expect
-            Assert.That(
-                !IntervalExpressions.Value.IsSubsetOf(AllMatrices.Value));
+            Assert.False(
+                IntervalExpressions.Value.IsSubsetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestIntervalExpressionsIsNotSupersetOfMatrices()
         {
             // expect
-            Assert.That(!IntervalExpressions.Value.IsSupersetOf(
-                Matrices.M2x2));
-            Assert.That(!IntervalExpressions.Value.IsSupersetOf(
-                Matrices.M3x3));
+            Assert.False(
+                IntervalExpressions.Value.IsSupersetOf(Matrices.M2x2));
+            Assert.False(
+                IntervalExpressions.Value.IsSupersetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestIntervalExpressionsIsNotSubsetOfMatrices()
         {
             // expect
-            Assert.That(!IntervalExpressions.Value.IsSubsetOf(Matrices.M2x2));
-            Assert.That(!IntervalExpressions.Value.IsSubsetOf(Matrices.M3x3));
+            Assert.False(IntervalExpressions.Value.IsSubsetOf(Matrices.M2x2));
+            Assert.False(IntervalExpressions.Value.IsSubsetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestIntervalExpressionsIsNotSupersetOfReals()
         {
             // expect
-            Assert.That(!IntervalExpressions.Value.IsSupersetOf(Reals.Value));
+            Assert.False(IntervalExpressions.Value.IsSupersetOf(Reals.Value));
         }
 
         [Test]
         public void TestIntervalExpressionsIsNotSubsetOfReals()
         {
             // expect
-            Assert.That(!IntervalExpressions.Value.IsSubsetOf(Reals.Value));
+            Assert.False(IntervalExpressions.Value.IsSubsetOf(Reals.Value));
         }
 
         [Test]
         public void TestIntervalExpressionsIsNotSupersetOfStrings()
         {
             // expect
-            Assert.That(!IntervalExpressions.Value.IsSupersetOf(
-                Strings.Value));
+            Assert.False(
+                IntervalExpressions.Value.IsSupersetOf(Strings.Value));
         }
 
         [Test]
         public void TestIntervalExpressionsIsNotSubsetOfStrings()
         {
             // expect
-            Assert.That(!IntervalExpressions.Value.IsSubsetOf(Strings.Value));
+            Assert.False(IntervalExpressions.Value.IsSubsetOf(Strings.Value));
         }
 
         [Test]
         public void TestIntervalExpressionsIsNotSupersetOfIntervals()
         {
             // expect
-            Assert.That(
-                !IntervalExpressions.Value.IsSupersetOf(Intervals.Value));
+            Assert.False(
+                IntervalExpressions.Value.IsSupersetOf(Intervals.Value));
         }
 
         [Test]
         public void TestIntervalExpressionsIsNotSubsetOfIntervals()
         {
             // expect
-            Assert.That(!IntervalExpressions.Value.IsSubsetOf(
-                Intervals.Value));
+            Assert.False(
+                IntervalExpressions.Value.IsSubsetOf(Intervals.Value));
         }
 
         [Test]
         public void TestIntervalExpressionsIsNotSupersetOfBooleans()
         {
             // expect
-            Assert.That(
-                !IntervalExpressions.Value.IsSupersetOf(Booleans.Value));
+            Assert.False(
+                IntervalExpressions.Value.IsSupersetOf(Booleans.Value));
         }
 
         [Test]
         public void TestIntervalExpressionsIsNotSubsetOfBooleans()
         {
             // expect
-            Assert.That(!IntervalExpressions.Value.IsSubsetOf(Booleans.Value));
+            Assert.False(
+                IntervalExpressions.Value.IsSubsetOf(Booleans.Value));
         }
 
         [Test]
         public void TestIntervalExpressionsIsNotSupersetOfExpressions()
         {
             // expect
-            Assert.That(
-                !IntervalExpressions.Value.IsSupersetOf(Sets.Expressions
-                    .Value));
+            Assert.False(
+                IntervalExpressions.Value.IsSupersetOf(
+                    Sets.Expressions.Value));
         }
 
         [Test]
         public void TestIntervalExpressionsIsSubsetOfExpressions()
         {
             // expect
-            Assert.That(
+            Assert.True(
                 IntervalExpressions.Value.IsSubsetOf(Sets.Expressions.Value));
         }
 
@@ -256,32 +275,33 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.IntervalExpressionsT
         public void TestIntervalExpressionsIsNotSupersetOfLiterals()
         {
             // expect
-            Assert.That(
-                !IntervalExpressions.Value.IsSupersetOf(Literals.Value));
+            Assert.False(
+                IntervalExpressions.Value.IsSupersetOf(Literals.Value));
         }
 
         [Test]
         public void TestIntervalExpressionsIsNotSubsetOfLiterals()
         {
             // expect
-            Assert.That(!IntervalExpressions.Value.IsSubsetOf(Literals.Value));
+            Assert.False(
+                IntervalExpressions.Value.IsSubsetOf(Literals.Value));
         }
 
         [Test]
         public void TestIntervalExpressionsIsNotSupersetOfComponentAccesses()
         {
             // expect
-            Assert.That(
-                !IntervalExpressions.Value.IsSupersetOf(ComponentAccesses
-                    .Value));
+            Assert.False(
+                IntervalExpressions.Value.IsSupersetOf(
+                    ComponentAccesses.Value));
         }
 
         [Test]
         public void TestIntervalExpressionsIsNotSubsetOfComponentAccesses()
         {
             // expect
-            Assert.That(
-                !IntervalExpressions.Value.IsSubsetOf(
+            Assert.False(
+                IntervalExpressions.Value.IsSubsetOf(
                     ComponentAccesses.Value));
         }
 
@@ -289,23 +309,23 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.IntervalExpressionsT
         public void TestIntervalExpressionsIsNotSupersetOfFunctionCalls()
         {
             // expect
-            Assert.That(
-                !IntervalExpressions.Value.IsSupersetOf(FunctionCalls.Value));
+            Assert.False(
+                IntervalExpressions.Value.IsSupersetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestIntervalExpressionsIsNotSubsetOfFunctionCalls()
         {
             // expect
-            Assert.That(
-                !IntervalExpressions.Value.IsSubsetOf(FunctionCalls.Value));
+            Assert.False(
+                IntervalExpressions.Value.IsSubsetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestIntervalExpressionsIsSupersetOfSelf()
         {
             // expect
-            Assert.That(
+            Assert.True(
                 IntervalExpressions.Value.IsSupersetOf(
                     IntervalExpressions.Value));
         }
@@ -314,26 +334,26 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.IntervalExpressionsT
         public void TestIntervalExpressionsIsSubsetOfSelf()
         {
             // expect
-            Assert.That(
-                IntervalExpressions.Value.IsSubsetOf(IntervalExpressions
-                    .Value));
+            Assert.True(
+                IntervalExpressions.Value.IsSubsetOf(
+                    IntervalExpressions.Value));
         }
 
         [Test]
         public void TestIntervalExpressionsIsNotSupersetOfTensorExpressions()
         {
             // expect
-            Assert.That(
-                !IntervalExpressions.Value.IsSupersetOf(TensorExpressions
-                    .Value));
+            Assert.False(
+                IntervalExpressions.Value.IsSupersetOf(
+                    TensorExpressions.Value));
         }
 
         [Test]
         public void TestIntervalExpressionsIsNotSubsetOfTensorExpressions()
         {
             // expect
-            Assert.That(
-                !IntervalExpressions.Value.IsSubsetOf(
+            Assert.False(
+                IntervalExpressions.Value.IsSubsetOf(
                     TensorExpressions.Value));
         }
 
@@ -341,17 +361,17 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.IntervalExpressionsT
         public void TestIntervalExpressionsIsNotSupersetOfMatrixExpressions()
         {
             // expect
-            Assert.That(
-                !IntervalExpressions.Value.IsSupersetOf(MatrixExpressions
-                    .Value));
+            Assert.False(
+                IntervalExpressions.Value.IsSupersetOf(
+                    MatrixExpressions.Value));
         }
 
         [Test]
         public void TestIntervalExpressionsIsNotSubsetOfMatrixExpressions()
         {
             // expect
-            Assert.That(
-                !IntervalExpressions.Value.IsSubsetOf(
+            Assert.False(
+                IntervalExpressions.Value.IsSubsetOf(
                     MatrixExpressions.Value));
         }
 
@@ -359,17 +379,17 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.IntervalExpressionsT
         public void TestIntervalExpressionsIsNotSupersetOfVectorExpressions()
         {
             // expect
-            Assert.That(
-                !IntervalExpressions.Value.IsSupersetOf(VectorExpressions
-                    .Value));
+            Assert.False(
+                IntervalExpressions.Value.IsSupersetOf(
+                    VectorExpressions.Value));
         }
 
         [Test]
         public void TestIntervalExpressionsIsNotSubsetOfVectorExpressions()
         {
             // expect
-            Assert.That(
-                !IntervalExpressions.Value.IsSubsetOf(
+            Assert.False(
+                IntervalExpressions.Value.IsSubsetOf(
                     VectorExpressions.Value));
         }
 
@@ -377,17 +397,17 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.IntervalExpressionsT
         public void TestIntervalExpressionsIsNotSupersetOfVariableAccesses()
         {
             // expect
-            Assert.That(
-                !IntervalExpressions.Value.IsSupersetOf(VariableAccesses
-                    .Value));
+            Assert.False(
+                IntervalExpressions.Value.IsSupersetOf(
+                    VariableAccesses.Value));
         }
 
         [Test]
         public void TestIntervalExpressionsIsNotSubsetOfVariableAccesses()
         {
             // expect
-            Assert.That(
-                !IntervalExpressions.Value.IsSubsetOf(VariableAccesses.Value));
+            Assert.False(
+                IntervalExpressions.Value.IsSubsetOf(VariableAccesses.Value));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/SetsT/IntervalsT/SupersetAndSubsetTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/SetsT/IntervalsT/SupersetAndSubsetTest.cs
@@ -32,320 +32,338 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.IntervalsT
         public void TestIntervalsIsNotSupersetOfMathObjects()
         {
             // expect
-            Assert.That(!Intervals.Value.IsSupersetOf(MathObjects.Value));
+            Assert.False(Intervals.Value.IsSupersetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestIntervalsIsSubsetOfMathObjects()
         {
             // expect
-            Assert.That(Intervals.Value.IsSubsetOf(MathObjects.Value));
+            Assert.True(Intervals.Value.IsSubsetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestIntervalsIsNotSupersetOfSets()
         {
             // expect
-            Assert.That(!Intervals.Value.IsSupersetOf(Sets.Sets.Value));
+            Assert.False(Intervals.Value.IsSupersetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestIntervalsIsNotSubsetOfSets()
         {
             // expect
-            Assert.That(!Intervals.Value.IsSubsetOf(Sets.Sets.Value));
+            Assert.False(Intervals.Value.IsSubsetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestIntervalsIsNotSupersetOfAllFunctions()
         {
             // expect
-            Assert.That(!Intervals.Value.IsSupersetOf(AllFunctions.Value));
+            Assert.False(Intervals.Value.IsSupersetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestIntervalsIsNotSubsetOfAllFunctions()
         {
             // expect
-            Assert.That(!Intervals.Value.IsSubsetOf(AllFunctions.Value));
+            Assert.False(Intervals.Value.IsSubsetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestIntervalsIsNotSupersetOfFunctions()
         {
             // expect
-            Assert.That(
-                !Intervals.Value.IsSupersetOf(Sets.Functions.RealsToReals));
+            Assert.False(
+                Intervals.Value.IsSupersetOf(Sets.Functions.RealsToReals));
         }
 
         [Test]
         public void TestIntervalsIsNotSubsetOfFunctions()
         {
             // expect
-            Assert.That(
-                !Intervals.Value.IsSubsetOf(Sets.Functions.RealsToReals));
+            Assert.False(
+                Intervals.Value.IsSubsetOf(Sets.Functions.RealsToReals));
+        }
+
+        [Test]
+        public void TestIntervalsIsNotSupersetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                Intervals.Value.IsSupersetOf(VariadicFunctions.RealsToReals));
+        }
+
+        [Test]
+        public void TestIntervalsIsNotSubsetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                Intervals.Value.IsSubsetOf(VariadicFunctions.RealsToReals));
         }
 
         [Test]
         public void TestIntervalsIsNotSupersetOfTensors()
         {
             // expect
-            Assert.That(!Intervals.Value.IsSupersetOf(Tensors.Value));
+            Assert.False(Intervals.Value.IsSupersetOf(Tensors.Value));
         }
 
         [Test]
         public void TestIntervalsIsNotSubsetOfTensors()
         {
             // expect
-            Assert.That(!Intervals.Value.IsSubsetOf(Tensors.Value));
+            Assert.False(Intervals.Value.IsSubsetOf(Tensors.Value));
         }
 
         [Test]
         public void TestIntervalsIsNotSupersetOfAllVectors()
         {
             // expect
-            Assert.That(!Intervals.Value.IsSupersetOf(AllVectors.Value));
+            Assert.False(Intervals.Value.IsSupersetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestIntervalsIsNotSubsetOfAllVectors()
         {
             // expect
-            Assert.That(!Intervals.Value.IsSubsetOf(AllVectors.Value));
+            Assert.False(Intervals.Value.IsSubsetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestIntervalsIsNotSupersetOfVectors()
         {
             // expect
-            Assert.That(!Intervals.Value.IsSupersetOf(Vectors.R2));
-            Assert.That(!Intervals.Value.IsSupersetOf(Vectors.R3));
+            Assert.False(Intervals.Value.IsSupersetOf(Vectors.R2));
+            Assert.False(Intervals.Value.IsSupersetOf(Vectors.R3));
         }
 
         [Test]
         public void TestIntervalsIsNotSubsetOfVectors()
         {
             // expect
-            Assert.That(!Intervals.Value.IsSubsetOf(Vectors.R2));
-            Assert.That(!Intervals.Value.IsSubsetOf(Vectors.R3));
+            Assert.False(Intervals.Value.IsSubsetOf(Vectors.R2));
+            Assert.False(Intervals.Value.IsSubsetOf(Vectors.R3));
         }
 
         [Test]
         public void TestIntervalsIsNotSupersetOfAllMatrices()
         {
             // expect
-            Assert.That(!Intervals.Value.IsSupersetOf(AllMatrices.Value));
+            Assert.False(Intervals.Value.IsSupersetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestIntervalsIsNotSubsetOfAllMatrices()
         {
             // expect
-            Assert.That(!Intervals.Value.IsSubsetOf(AllMatrices.Value));
+            Assert.False(Intervals.Value.IsSubsetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestIntervalsIsNotSupersetOfMatrices()
         {
             // expect
-            Assert.That(!Intervals.Value.IsSupersetOf(Matrices.M2x2));
-            Assert.That(!Intervals.Value.IsSupersetOf(Matrices.M3x3));
+            Assert.False(Intervals.Value.IsSupersetOf(Matrices.M2x2));
+            Assert.False(Intervals.Value.IsSupersetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestIntervalsIsNotSubsetOfMatrices()
         {
             // expect
-            Assert.That(!Intervals.Value.IsSubsetOf(Matrices.M2x2));
-            Assert.That(!Intervals.Value.IsSubsetOf(Matrices.M3x3));
+            Assert.False(Intervals.Value.IsSubsetOf(Matrices.M2x2));
+            Assert.False(Intervals.Value.IsSubsetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestIntervalsIsNotSupersetOfReals()
         {
             // expect
-            Assert.That(!Intervals.Value.IsSupersetOf(Reals.Value));
+            Assert.False(Intervals.Value.IsSupersetOf(Reals.Value));
         }
 
         [Test]
         public void TestIntervalsIsNotSubsetOfReals()
         {
             // expect
-            Assert.That(!Intervals.Value.IsSubsetOf(Reals.Value));
+            Assert.False(Intervals.Value.IsSubsetOf(Reals.Value));
         }
 
         [Test]
         public void TestIntervalsIsNotSupersetOfStrings()
         {
             // expect
-            Assert.That(!Intervals.Value.IsSupersetOf(Strings.Value));
+            Assert.False(Intervals.Value.IsSupersetOf(Strings.Value));
         }
 
         [Test]
         public void TestIntervalsIsNotSubsetOfStrings()
         {
             // expect
-            Assert.That(!Intervals.Value.IsSubsetOf(Strings.Value));
+            Assert.False(Intervals.Value.IsSubsetOf(Strings.Value));
         }
 
         [Test]
         public void TestIntervalsIsSupersetOfSelf()
         {
             // expect
-            Assert.That(Intervals.Value.IsSupersetOf(Intervals.Value));
+            Assert.True(Intervals.Value.IsSupersetOf(Intervals.Value));
         }
 
         [Test]
         public void TestIntervalsIsSubsetOfSelf()
         {
             // expect
-            Assert.That(Intervals.Value.IsSubsetOf(Intervals.Value));
+            Assert.True(Intervals.Value.IsSubsetOf(Intervals.Value));
         }
 
         [Test]
         public void TestIntervalsIsNotSupersetOfBooleans()
         {
             // expect
-            Assert.That(!Intervals.Value.IsSupersetOf(Booleans.Value));
+            Assert.False(Intervals.Value.IsSupersetOf(Booleans.Value));
         }
 
         [Test]
         public void TestIntervalsIsNotSubsetOfBooleans()
         {
             // expect
-            Assert.That(!Intervals.Value.IsSubsetOf(Booleans.Value));
+            Assert.False(Intervals.Value.IsSubsetOf(Booleans.Value));
         }
 
         [Test]
         public void TestIntervalsIsNotSupersetOfExpressions()
         {
             // expect
-            Assert.That(!Intervals.Value.IsSupersetOf(Sets.Expressions.Value));
+            Assert.False(
+                Intervals.Value.IsSupersetOf(Sets.Expressions.Value));
         }
 
         [Test]
         public void TestIntervalsIsNotSubsetOfExpressions()
         {
             // expect
-            Assert.That(!Intervals.Value.IsSubsetOf(Sets.Expressions.Value));
+            Assert.False(Intervals.Value.IsSubsetOf(Sets.Expressions.Value));
         }
 
         [Test]
         public void TestIntervalsIsNotSupersetOfLiterals()
         {
             // expect
-            Assert.That(!Intervals.Value.IsSupersetOf(Literals.Value));
+            Assert.False(Intervals.Value.IsSupersetOf(Literals.Value));
         }
 
         [Test]
         public void TestIntervalsIsNotSubsetOfLiterals()
         {
             // expect
-            Assert.That(!Intervals.Value.IsSubsetOf(Literals.Value));
+            Assert.False(Intervals.Value.IsSubsetOf(Literals.Value));
         }
 
         [Test]
         public void TestIntervalsIsNotSupersetOfComponentAccesses()
         {
             // expect
-            Assert.That(!Intervals.Value.IsSupersetOf(
-                ComponentAccesses.Value));
+            Assert.False(
+                Intervals.Value.IsSupersetOf(ComponentAccesses.Value));
         }
 
         [Test]
         public void TestIntervalsIsNotSubsetOfComponentAccesses()
         {
             // expect
-            Assert.That(!Intervals.Value.IsSubsetOf(ComponentAccesses.Value));
+            Assert.False(Intervals.Value.IsSubsetOf(ComponentAccesses.Value));
         }
 
         [Test]
         public void TestIntervalsIsNotSupersetOfFunctionCalls()
         {
             // expect
-            Assert.That(!Intervals.Value.IsSupersetOf(FunctionCalls.Value));
+            Assert.False(Intervals.Value.IsSupersetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestIntervalsIsNotSubsetOfFunctionCalls()
         {
             // expect
-            Assert.That(!Intervals.Value.IsSubsetOf(FunctionCalls.Value));
+            Assert.False(Intervals.Value.IsSubsetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestIntervalsIsNotSupersetOfIntervalExpressions()
         {
             // expect
-            Assert.That(
-                !Intervals.Value.IsSupersetOf(IntervalExpressions.Value));
+            Assert.False(
+                Intervals.Value.IsSupersetOf(IntervalExpressions.Value));
         }
 
         [Test]
         public void TestIntervalsIsNotSubsetOfIntervalExpressions()
         {
             // expect
-            Assert.That(!Intervals.Value.IsSubsetOf(
-                IntervalExpressions.Value));
+            Assert.False(
+                Intervals.Value.IsSubsetOf(IntervalExpressions.Value));
         }
 
         [Test]
         public void TestIntervalsIsNotSupersetOfTensorExpressions()
         {
             // expect
-            Assert.That(!Intervals.Value.IsSupersetOf(
-                TensorExpressions.Value));
+            Assert.False(
+                Intervals.Value.IsSupersetOf(TensorExpressions.Value));
         }
 
         [Test]
         public void TestIntervalsIsNotSubsetOfTensorExpressions()
         {
             // expect
-            Assert.That(!Intervals.Value.IsSubsetOf(TensorExpressions.Value));
+            Assert.False(Intervals.Value.IsSubsetOf(TensorExpressions.Value));
         }
 
         [Test]
         public void TestIntervalsIsNotSupersetOfMatrixExpressions()
         {
             // expect
-            Assert.That(!Intervals.Value.IsSupersetOf(
-                MatrixExpressions.Value));
+            Assert.False(
+                Intervals.Value.IsSupersetOf(MatrixExpressions.Value));
         }
 
         [Test]
         public void TestIntervalsIsNotSubsetOfMatrixExpressions()
         {
             // expect
-            Assert.That(!Intervals.Value.IsSubsetOf(MatrixExpressions.Value));
+            Assert.False(Intervals.Value.IsSubsetOf(MatrixExpressions.Value));
         }
 
         [Test]
         public void TestIntervalsIsNotSupersetOfVectorExpressions()
         {
             // expect
-            Assert.That(!Intervals.Value.IsSupersetOf(
-                VectorExpressions.Value));
+            Assert.False(
+                Intervals.Value.IsSupersetOf(VectorExpressions.Value));
         }
 
         [Test]
         public void TestIntervalsIsNotSubsetOfVectorExpressions()
         {
             // expect
-            Assert.That(!Intervals.Value.IsSubsetOf(VectorExpressions.Value));
+            Assert.False(Intervals.Value.IsSubsetOf(VectorExpressions.Value));
         }
 
         [Test]
         public void TestIntervalsIsNotSupersetOfVariableAccesses()
         {
             // expect
-            Assert.That(!Intervals.Value.IsSupersetOf(VariableAccesses.Value));
+            Assert.False(
+                Intervals.Value.IsSupersetOf(VariableAccesses.Value));
         }
 
         [Test]
         public void TestIntervalsIsNotSubsetOfVariableAccesses()
         {
             // expect
-            Assert.That(!Intervals.Value.IsSubsetOf(VariableAccesses.Value));
+            Assert.False(Intervals.Value.IsSubsetOf(VariableAccesses.Value));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/SetsT/LiteralsT/SupersetAndSubsetTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/SetsT/LiteralsT/SupersetAndSubsetTest.cs
@@ -32,315 +32,336 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.LiteralsT
         public void TestLiteralsIsNotSupersetOfMathObjects()
         {
             // expect
-            Assert.That(!Literals.Value.IsSupersetOf(MathObjects.Value));
+            Assert.False(Literals.Value.IsSupersetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestLiteralsIsSubsetOfMathObjects()
         {
             // expect
-            Assert.That(Literals.Value.IsSubsetOf(MathObjects.Value));
+            Assert.True(Literals.Value.IsSubsetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestLiteralsIsNotSupersetOfSets()
         {
             // expect
-            Assert.That(!Literals.Value.IsSupersetOf(Sets.Sets.Value));
+            Assert.False(Literals.Value.IsSupersetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestLiteralsIsNotSubsetOfSets()
         {
             // expect
-            Assert.That(!Literals.Value.IsSubsetOf(Sets.Sets.Value));
+            Assert.False(Literals.Value.IsSubsetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestLiteralsIsNotSupersetOfAllFunctions()
         {
             // expect
-            Assert.That(!Literals.Value.IsSupersetOf(AllFunctions.Value));
+            Assert.False(Literals.Value.IsSupersetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestLiteralsIsNotSubsetOfAllFunctions()
         {
             // expect
-            Assert.That(!Literals.Value.IsSubsetOf(AllFunctions.Value));
+            Assert.False(Literals.Value.IsSubsetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestLiteralsIsNotSupersetOfFunctions()
         {
             // expect
-            Assert.That(
-                !Literals.Value.IsSupersetOf(Sets.Functions.RealsToReals));
+            Assert.False(
+                Literals.Value.IsSupersetOf(Sets.Functions.RealsToReals));
         }
 
         [Test]
         public void TestLiteralsIsNotSubsetOfFunctions()
         {
             // expect
-            Assert.That(
-                !Literals.Value.IsSubsetOf(Sets.Functions.RealsToReals));
+            Assert.False(
+                Literals.Value.IsSubsetOf(Sets.Functions.RealsToReals));
+        }
+
+        [Test]
+        public void TestLiteralsIsNotSupersetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                Literals.Value.IsSupersetOf(VariadicFunctions.RealsToReals));
+        }
+
+        [Test]
+        public void TestLiteralsIsNotSubsetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                Literals.Value.IsSubsetOf(VariadicFunctions.RealsToReals));
         }
 
         [Test]
         public void TestLiteralsIsNotSupersetOfTensors()
         {
             // expect
-            Assert.That(!Literals.Value.IsSupersetOf(Tensors.Value));
+            Assert.False(Literals.Value.IsSupersetOf(Tensors.Value));
         }
 
         [Test]
         public void TestLiteralsIsNotSubsetOfTensors()
         {
             // expect
-            Assert.That(!Literals.Value.IsSubsetOf(Tensors.Value));
+            Assert.False(Literals.Value.IsSubsetOf(Tensors.Value));
         }
 
         [Test]
         public void TestLiteralsIsNotSupersetOfAllVectors()
         {
             // expect
-            Assert.That(!Literals.Value.IsSupersetOf(AllVectors.Value));
+            Assert.False(Literals.Value.IsSupersetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestLiteralsIsNotSubsetOfAllVectors()
         {
             // expect
-            Assert.That(!Literals.Value.IsSubsetOf(AllVectors.Value));
+            Assert.False(Literals.Value.IsSubsetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestLiteralsIsNotSupersetOfVectors()
         {
             // expect
-            Assert.That(!Literals.Value.IsSupersetOf(Vectors.R2));
-            Assert.That(!Literals.Value.IsSupersetOf(Vectors.R3));
+            Assert.False(Literals.Value.IsSupersetOf(Vectors.R2));
+            Assert.False(Literals.Value.IsSupersetOf(Vectors.R3));
         }
 
         [Test]
         public void TestLiteralsIsNotSubsetOfVectors()
         {
             // expect
-            Assert.That(!Literals.Value.IsSubsetOf(Vectors.R2));
-            Assert.That(!Literals.Value.IsSubsetOf(Vectors.R3));
+            Assert.False(Literals.Value.IsSubsetOf(Vectors.R2));
+            Assert.False(Literals.Value.IsSubsetOf(Vectors.R3));
         }
 
         [Test]
         public void TestLiteralsIsNotSupersetOfAllMatrices()
         {
             // expect
-            Assert.That(!Literals.Value.IsSupersetOf(AllMatrices.Value));
+            Assert.False(Literals.Value.IsSupersetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestLiteralsIsNotSubsetOfAllMatrices()
         {
             // expect
-            Assert.That(!Literals.Value.IsSubsetOf(AllMatrices.Value));
+            Assert.False(Literals.Value.IsSubsetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestLiteralsIsNotSupersetOfMatrices()
         {
             // expect
-            Assert.That(!Literals.Value.IsSupersetOf(Matrices.M2x2));
-            Assert.That(!Literals.Value.IsSupersetOf(Matrices.M3x3));
+            Assert.False(Literals.Value.IsSupersetOf(Matrices.M2x2));
+            Assert.False(Literals.Value.IsSupersetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestLiteralsIsNotSubsetOfMatrices()
         {
             // expect
-            Assert.That(!Literals.Value.IsSubsetOf(Matrices.M2x2));
-            Assert.That(!Literals.Value.IsSubsetOf(Matrices.M3x3));
+            Assert.False(Literals.Value.IsSubsetOf(Matrices.M2x2));
+            Assert.False(Literals.Value.IsSubsetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestLiteralsIsNotSupersetOfReals()
         {
             // expect
-            Assert.That(!Literals.Value.IsSupersetOf(Reals.Value));
+            Assert.False(Literals.Value.IsSupersetOf(Reals.Value));
         }
 
         [Test]
         public void TestLiteralsIsNotSubsetOfReals()
         {
             // expect
-            Assert.That(!Literals.Value.IsSubsetOf(Reals.Value));
+            Assert.False(Literals.Value.IsSubsetOf(Reals.Value));
         }
 
         [Test]
         public void TestLiteralsIsNotSupersetOfStrings()
         {
             // expect
-            Assert.That(!Literals.Value.IsSupersetOf(Strings.Value));
+            Assert.False(Literals.Value.IsSupersetOf(Strings.Value));
         }
 
         [Test]
         public void TestLiteralsIsNotSubsetOfStrings()
         {
             // expect
-            Assert.That(!Literals.Value.IsSubsetOf(Strings.Value));
+            Assert.False(Literals.Value.IsSubsetOf(Strings.Value));
         }
 
         [Test]
         public void TestLiteralsIsNotSupersetOfIntervals()
         {
             // expect
-            Assert.That(!Literals.Value.IsSupersetOf(Intervals.Value));
+            Assert.False(Literals.Value.IsSupersetOf(Intervals.Value));
         }
 
         [Test]
         public void TestLiteralsIsNotSubsetOfIntervals()
         {
             // expect
-            Assert.That(!Literals.Value.IsSubsetOf(Intervals.Value));
+            Assert.False(Literals.Value.IsSubsetOf(Intervals.Value));
         }
 
         [Test]
         public void TestLiteralsIsNotSupersetOfBooleans()
         {
             // expect
-            Assert.That(!Literals.Value.IsSupersetOf(Booleans.Value));
+            Assert.False(Literals.Value.IsSupersetOf(Booleans.Value));
         }
 
         [Test]
         public void TestLiteralsIsNotSubsetOfBooleans()
         {
             // expect
-            Assert.That(!Literals.Value.IsSubsetOf(Booleans.Value));
+            Assert.False(Literals.Value.IsSubsetOf(Booleans.Value));
         }
 
         [Test]
         public void TestLiteralsIsNotSupersetOfExpressions()
         {
             // expect
-            Assert.That(!Literals.Value.IsSupersetOf(Sets.Expressions.Value));
+            Assert.False(Literals.Value.IsSupersetOf(Sets.Expressions.Value));
         }
 
         [Test]
         public void TestLiteralsIsSubsetOfExpressions()
         {
             // expect
-            Assert.That(Literals.Value.IsSubsetOf(Sets.Expressions.Value));
+            Assert.True(Literals.Value.IsSubsetOf(Sets.Expressions.Value));
         }
 
         [Test]
         public void TestLiteralsIsSupersetOfSelf()
         {
             // expect
-            Assert.That(Literals.Value.IsSupersetOf(Literals.Value));
+            Assert.True(Literals.Value.IsSupersetOf(Literals.Value));
         }
 
         [Test]
         public void TestLiteralsIsSubsetOfSelf()
         {
             // expect
-            Assert.That(Literals.Value.IsSubsetOf(Literals.Value));
+            Assert.True(Literals.Value.IsSubsetOf(Literals.Value));
         }
 
         [Test]
         public void TestLiteralsIsNotSupersetOfComponentAccesses()
         {
             // expect
-            Assert.That(!Literals.Value.IsSupersetOf(ComponentAccesses.Value));
+            Assert.False(
+                Literals.Value.IsSupersetOf(ComponentAccesses.Value));
         }
 
         [Test]
         public void TestLiteralsIsNotSubsetOfComponentAccesses()
         {
             // expect
-            Assert.That(!Literals.Value.IsSubsetOf(ComponentAccesses.Value));
+            Assert.False(Literals.Value.IsSubsetOf(ComponentAccesses.Value));
         }
 
         [Test]
         public void TestLiteralsIsNotSupersetOfFunctionCalls()
         {
             // expect
-            Assert.That(!Literals.Value.IsSupersetOf(FunctionCalls.Value));
+            Assert.False(Literals.Value.IsSupersetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestLiteralsIsNotSubsetOfFunctionCalls()
         {
             // expect
-            Assert.That(!Literals.Value.IsSubsetOf(FunctionCalls.Value));
+            Assert.False(Literals.Value.IsSubsetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestLiteralsIsNotSupersetOfIntervalExpressions()
         {
             // expect
-            Assert.That(
-                !Literals.Value.IsSupersetOf(IntervalExpressions.Value));
+            Assert.False(
+                Literals.Value.IsSupersetOf(IntervalExpressions.Value));
         }
 
         [Test]
         public void TestLiteralsIsNotSubsetOfIntervalExpressions()
         {
             // expect
-            Assert.That(!Literals.Value.IsSubsetOf(IntervalExpressions.Value));
+            Assert.False(
+                Literals.Value.IsSubsetOf(IntervalExpressions.Value));
         }
 
         [Test]
         public void TestLiteralsIsNotSupersetOfTensorExpressions()
         {
             // expect
-            Assert.That(!Literals.Value.IsSupersetOf(TensorExpressions.Value));
+            Assert.False(
+                Literals.Value.IsSupersetOf(TensorExpressions.Value));
         }
 
         [Test]
         public void TestLiteralsIsNotSubsetOfTensorExpressions()
         {
             // expect
-            Assert.That(!Literals.Value.IsSubsetOf(TensorExpressions.Value));
+            Assert.False(Literals.Value.IsSubsetOf(TensorExpressions.Value));
         }
 
         [Test]
         public void TestLiteralsIsNotSupersetOfMatrixExpressions()
         {
             // expect
-            Assert.That(!Literals.Value.IsSupersetOf(MatrixExpressions.Value));
+            Assert.False(
+                Literals.Value.IsSupersetOf(MatrixExpressions.Value));
         }
 
         [Test]
         public void TestLiteralsIsNotSubsetOfMatrixExpressions()
         {
             // expect
-            Assert.That(!Literals.Value.IsSubsetOf(MatrixExpressions.Value));
+            Assert.False(Literals.Value.IsSubsetOf(MatrixExpressions.Value));
         }
 
         [Test]
         public void TestLiteralsIsNotSupersetOfVectorExpressions()
         {
             // expect
-            Assert.That(!Literals.Value.IsSupersetOf(VectorExpressions.Value));
+            Assert.False(
+                Literals.Value.IsSupersetOf(VectorExpressions.Value));
         }
 
         [Test]
         public void TestLiteralsIsNotSubsetOfVectorExpressions()
         {
             // expect
-            Assert.That(!Literals.Value.IsSubsetOf(VectorExpressions.Value));
+            Assert.False(Literals.Value.IsSubsetOf(VectorExpressions.Value));
         }
 
         [Test]
         public void TestLiteralsIsNotSupersetOfVariableAccesses()
         {
             // expect
-            Assert.That(!Literals.Value.IsSupersetOf(VariableAccesses.Value));
+            Assert.False(Literals.Value.IsSupersetOf(VariableAccesses.Value));
         }
 
         [Test]
         public void TestLiteralsIsNotSubsetOfVariableAccesses()
         {
             // expect
-            Assert.That(!Literals.Value.IsSubsetOf(VariableAccesses.Value));
+            Assert.False(Literals.Value.IsSubsetOf(VariableAccesses.Value));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/SetsT/MathObjectsT/SupersetAndSubsetTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/SetsT/MathObjectsT/SupersetAndSubsetTest.cs
@@ -32,49 +32,49 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.MathObjectsT
         public void TestMathObjectsIsSupersetOfSelf()
         {
             // expect
-            Assert.That(MathObjects.Value.IsSupersetOf(MathObjects.Value));
+            Assert.True(MathObjects.Value.IsSupersetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestMathObjectsIsSubsetOfSelf()
         {
             // expect
-            Assert.That(MathObjects.Value.IsSubsetOf(MathObjects.Value));
+            Assert.True(MathObjects.Value.IsSubsetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestMathObjectsIsSupersetOfSets()
         {
             // expect
-            Assert.That(MathObjects.Value.IsSupersetOf(Sets.Sets.Value));
+            Assert.True(MathObjects.Value.IsSupersetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestMathObjectsIsNotSubsetOfSets()
         {
             // expect
-            Assert.That(!MathObjects.Value.IsSubsetOf(Sets.Sets.Value));
+            Assert.False(MathObjects.Value.IsSubsetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestMathObjectsIsSupersetOfAllFunctions()
         {
             // expect
-            Assert.That(MathObjects.Value.IsSupersetOf(AllFunctions.Value));
+            Assert.True(MathObjects.Value.IsSupersetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestMathObjectsIsNotSubsetOfAllFunctions()
         {
             // expect
-            Assert.That(!MathObjects.Value.IsSubsetOf(AllFunctions.Value));
+            Assert.False(MathObjects.Value.IsSubsetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestMathObjectsIsSupersetOfFunctions()
         {
             // expect
-            Assert.That(
+            Assert.True(
                 MathObjects.Value.IsSupersetOf(Sets.Functions.RealsToReals));
         }
 
@@ -82,174 +82,192 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.MathObjectsT
         public void TestMathObjectsIsNotSubsetOfFunctions()
         {
             // expect
-            Assert.That(
-                !MathObjects.Value.IsSubsetOf(Sets.Functions.RealsToReals));
+            Assert.False(
+                MathObjects.Value.IsSubsetOf(Sets.Functions.RealsToReals));
+        }
+
+        [Test]
+        public void TestMathObjectsIsSupersetOfVariadicFunctions()
+        {
+            // expect
+            Assert.True(
+                MathObjects.Value.IsSupersetOf(
+                    VariadicFunctions.RealsToReals));
+        }
+
+        [Test]
+        public void TestMathObjectsIsNotSubsetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                MathObjects.Value.IsSubsetOf(VariadicFunctions.RealsToReals));
         }
 
         [Test]
         public void TestMathObjectsIsSupersetOfTensors()
         {
             // expect
-            Assert.That(MathObjects.Value.IsSupersetOf(Tensors.Value));
+            Assert.True(MathObjects.Value.IsSupersetOf(Tensors.Value));
         }
 
         [Test]
         public void TestMathObjectsIsNotSubsetOfTensors()
         {
             // expect
-            Assert.That(!MathObjects.Value.IsSubsetOf(Tensors.Value));
+            Assert.False(MathObjects.Value.IsSubsetOf(Tensors.Value));
         }
 
         [Test]
         public void TestMathObjectsIsSupersetOfAllVectors()
         {
             // expect
-            Assert.That(MathObjects.Value.IsSupersetOf(AllVectors.Value));
+            Assert.True(MathObjects.Value.IsSupersetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestMathObjectsIsNotSubsetOfAllVectors()
         {
             // expect
-            Assert.That(!MathObjects.Value.IsSubsetOf(AllVectors.Value));
+            Assert.False(MathObjects.Value.IsSubsetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestMathObjectsIsSupersetOfVectors()
         {
             // expect
-            Assert.That(MathObjects.Value.IsSupersetOf(Vectors.R2));
-            Assert.That(MathObjects.Value.IsSupersetOf(Vectors.R3));
+            Assert.True(MathObjects.Value.IsSupersetOf(Vectors.R2));
+            Assert.True(MathObjects.Value.IsSupersetOf(Vectors.R3));
         }
 
         [Test]
         public void TestMathObjectsIsNotSubsetOfVectors()
         {
             // expect
-            Assert.That(!MathObjects.Value.IsSubsetOf(Vectors.R2));
-            Assert.That(!MathObjects.Value.IsSubsetOf(Vectors.R3));
+            Assert.False(MathObjects.Value.IsSubsetOf(Vectors.R2));
+            Assert.False(MathObjects.Value.IsSubsetOf(Vectors.R3));
         }
 
         [Test]
         public void TestMathObjectsIsSupersetOfAllMatrices()
         {
             // expect
-            Assert.That(MathObjects.Value.IsSupersetOf(AllMatrices.Value));
+            Assert.True(MathObjects.Value.IsSupersetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestMathObjectsIsNotSubsetOfAllMatrices()
         {
             // expect
-            Assert.That(!MathObjects.Value.IsSubsetOf(AllMatrices.Value));
+            Assert.False(MathObjects.Value.IsSubsetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestMathObjectsIsSupersetOfMatrices()
         {
             // expect
-            Assert.That(MathObjects.Value.IsSupersetOf(Matrices.M2x2));
-            Assert.That(MathObjects.Value.IsSupersetOf(Matrices.M3x3));
+            Assert.True(MathObjects.Value.IsSupersetOf(Matrices.M2x2));
+            Assert.True(MathObjects.Value.IsSupersetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestMathObjectsIsNotSubsetOfMatrices()
         {
             // expect
-            Assert.That(!MathObjects.Value.IsSubsetOf(Matrices.M2x2));
-            Assert.That(!MathObjects.Value.IsSubsetOf(Matrices.M3x3));
+            Assert.False(MathObjects.Value.IsSubsetOf(Matrices.M2x2));
+            Assert.False(MathObjects.Value.IsSubsetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestMathObjectsIsSupersetOfReals()
         {
             // expect
-            Assert.That(MathObjects.Value.IsSupersetOf(Reals.Value));
+            Assert.True(MathObjects.Value.IsSupersetOf(Reals.Value));
         }
 
         [Test]
         public void TestMathObjectsIsNotSubsetOfReals()
         {
             // expect
-            Assert.That(!MathObjects.Value.IsSubsetOf(Reals.Value));
+            Assert.False(MathObjects.Value.IsSubsetOf(Reals.Value));
         }
 
         [Test]
         public void TestMathObjectsIsSupersetOfStrings()
         {
             // expect
-            Assert.That(MathObjects.Value.IsSupersetOf(Strings.Value));
+            Assert.True(MathObjects.Value.IsSupersetOf(Strings.Value));
         }
 
         [Test]
         public void TestMathObjectsIsNotSubsetOfStrings()
         {
             // expect
-            Assert.That(!MathObjects.Value.IsSubsetOf(Strings.Value));
+            Assert.False(MathObjects.Value.IsSubsetOf(Strings.Value));
         }
 
         [Test]
         public void TestMathObjectsIsSupersetOfIntervals()
         {
             // expect
-            Assert.That(MathObjects.Value.IsSupersetOf(Intervals.Value));
+            Assert.True(MathObjects.Value.IsSupersetOf(Intervals.Value));
         }
 
         [Test]
         public void TestMathObjectsIsNotSubsetOfIntervals()
         {
             // expect
-            Assert.That(!MathObjects.Value.IsSubsetOf(Intervals.Value));
+            Assert.False(MathObjects.Value.IsSubsetOf(Intervals.Value));
         }
 
         [Test]
         public void TestMathObjectsIsSupersetOfBooleans()
         {
             // expect
-            Assert.That(MathObjects.Value.IsSupersetOf(Booleans.Value));
+            Assert.True(MathObjects.Value.IsSupersetOf(Booleans.Value));
         }
 
         [Test]
         public void TestMathObjectsIsNotSubsetOfBooleans()
         {
             // expect
-            Assert.That(!MathObjects.Value.IsSubsetOf(Booleans.Value));
+            Assert.False(MathObjects.Value.IsSubsetOf(Booleans.Value));
         }
 
         [Test]
         public void TestMathObjectsIsSupersetOfExpressions()
         {
             // expect
-            Assert.That(MathObjects.Value.IsSupersetOf(
-                Sets.Expressions.Value));
+            Assert.True(
+                MathObjects.Value.IsSupersetOf(Sets.Expressions.Value));
         }
 
         [Test]
         public void TestMathObjectsIsNotSubsetOfExpressions()
         {
             // expect
-            Assert.That(!MathObjects.Value.IsSubsetOf(Sets.Expressions.Value));
+            Assert.False(
+                MathObjects.Value.IsSubsetOf(Sets.Expressions.Value));
         }
 
         [Test]
         public void TestMathObjectsIsSupersetOfLiterals()
         {
             // expect
-            Assert.That(MathObjects.Value.IsSupersetOf(Literals.Value));
+            Assert.True(MathObjects.Value.IsSupersetOf(Literals.Value));
         }
 
         [Test]
         public void TestMathObjectsIsNotSubsetOfLiterals()
         {
             // expect
-            Assert.That(!MathObjects.Value.IsSubsetOf(Literals.Value));
+            Assert.False(MathObjects.Value.IsSubsetOf(Literals.Value));
         }
 
         [Test]
         public void TestMathObjectsIsSupersetOfComponentAccesses()
         {
             // expect
-            Assert.That(
+            Assert.True(
                 MathObjects.Value.IsSupersetOf(ComponentAccesses.Value));
         }
 
@@ -257,29 +275,29 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.MathObjectsT
         public void TestMathObjectsIsNotSubsetOfComponentAccesses()
         {
             // expect
-            Assert.That(!MathObjects.Value.IsSubsetOf(
-                ComponentAccesses.Value));
+            Assert.False(
+                MathObjects.Value.IsSubsetOf(ComponentAccesses.Value));
         }
 
         [Test]
         public void TestMathObjectsIsSupersetOfFunctionCalls()
         {
             // expect
-            Assert.That(MathObjects.Value.IsSupersetOf(FunctionCalls.Value));
+            Assert.True(MathObjects.Value.IsSupersetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestMathObjectsIsNotSubsetOfFunctionCalls()
         {
             // expect
-            Assert.That(!MathObjects.Value.IsSubsetOf(FunctionCalls.Value));
+            Assert.False(MathObjects.Value.IsSubsetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestMathObjectsIsSupersetOfIntervalExpressions()
         {
             // expect
-            Assert.That(
+            Assert.True(
                 MathObjects.Value.IsSupersetOf(IntervalExpressions.Value));
         }
 
@@ -287,15 +305,15 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.MathObjectsT
         public void TestMathObjectsIsNotSubsetOfIntervalExpressions()
         {
             // expect
-            Assert.That(
-                !MathObjects.Value.IsSubsetOf(IntervalExpressions.Value));
+            Assert.False(
+                MathObjects.Value.IsSubsetOf(IntervalExpressions.Value));
         }
 
         [Test]
         public void TestMathObjectsIsSupersetOfTensorExpressions()
         {
             // expect
-            Assert.That(
+            Assert.True(
                 MathObjects.Value.IsSupersetOf(TensorExpressions.Value));
         }
 
@@ -303,15 +321,15 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.MathObjectsT
         public void TestMathObjectsIsNotSubsetOfTensorExpressions()
         {
             // expect
-            Assert.That(!MathObjects.Value.IsSubsetOf(
-                TensorExpressions.Value));
+            Assert.False(
+                MathObjects.Value.IsSubsetOf(TensorExpressions.Value));
         }
 
         [Test]
         public void TestMathObjectsIsSupersetOfMatrixExpressions()
         {
             // expect
-            Assert.That(
+            Assert.True(
                 MathObjects.Value.IsSupersetOf(MatrixExpressions.Value));
         }
 
@@ -319,15 +337,15 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.MathObjectsT
         public void TestMathObjectsIsNotSubsetOfMatrixExpressions()
         {
             // expect
-            Assert.That(!MathObjects.Value.IsSubsetOf(
-                MatrixExpressions.Value));
+            Assert.False(
+                MathObjects.Value.IsSubsetOf(MatrixExpressions.Value));
         }
 
         [Test]
         public void TestMathObjectsIsSupersetOfVectorExpressions()
         {
             // expect
-            Assert.That(
+            Assert.True(
                 MathObjects.Value.IsSupersetOf(VectorExpressions.Value));
         }
 
@@ -335,23 +353,24 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.MathObjectsT
         public void TestMathObjectsIsNotSubsetOfVectorExpressions()
         {
             // expect
-            Assert.That(!MathObjects.Value.IsSubsetOf(
-                VectorExpressions.Value));
+            Assert.False(
+                MathObjects.Value.IsSubsetOf(VectorExpressions.Value));
         }
 
         [Test]
         public void TestMathObjectsIsSupersetOfVariableAccesses()
         {
             // expect
-            Assert.That(MathObjects.Value.IsSupersetOf(
-                VariableAccesses.Value));
+            Assert.True(
+                MathObjects.Value.IsSupersetOf(VariableAccesses.Value));
         }
 
         [Test]
         public void TestMathObjectsIsNotSubsetOfVariableAccesses()
         {
             // expect
-            Assert.That(!MathObjects.Value.IsSubsetOf(VariableAccesses.Value));
+            Assert.False(
+                MathObjects.Value.IsSubsetOf(VariableAccesses.Value));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/SetsT/MatricesT/SupersetAndSubsetTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/SetsT/MatricesT/SupersetAndSubsetTest.cs
@@ -32,366 +32,386 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.MatricesT
         public void TestMatricesIsNotSupersetOfMathObjects()
         {
             // expect
-            Assert.That(!Matrices.M2x2.IsSupersetOf(MathObjects.Value));
-            Assert.That(!Matrices.M3x3.IsSupersetOf(MathObjects.Value));
+            Assert.False(Matrices.M2x2.IsSupersetOf(MathObjects.Value));
+            Assert.False(Matrices.M3x3.IsSupersetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestMatricesIsSubsetOfMathObjects()
         {
             // expect
-            Assert.That(Matrices.M2x2.IsSubsetOf(MathObjects.Value));
-            Assert.That(Matrices.M3x3.IsSubsetOf(MathObjects.Value));
+            Assert.True(Matrices.M2x2.IsSubsetOf(MathObjects.Value));
+            Assert.True(Matrices.M3x3.IsSubsetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestMatricesIsNotSupersetOfSets()
         {
             // expect
-            Assert.That(!Matrices.M2x2.IsSupersetOf(Sets.Sets.Value));
-            Assert.That(!Matrices.M3x3.IsSupersetOf(Sets.Sets.Value));
+            Assert.False(Matrices.M2x2.IsSupersetOf(Sets.Sets.Value));
+            Assert.False(Matrices.M3x3.IsSupersetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestMatricesIsNotSubsetOfSets()
         {
             // expect
-            Assert.That(!Matrices.M2x2.IsSubsetOf(Sets.Sets.Value));
-            Assert.That(!Matrices.M3x3.IsSubsetOf(Sets.Sets.Value));
+            Assert.False(Matrices.M2x2.IsSubsetOf(Sets.Sets.Value));
+            Assert.False(Matrices.M3x3.IsSubsetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestMatricesIsNotSupersetOfAllFunctions()
         {
             // expect
-            Assert.That(!Matrices.M2x2.IsSupersetOf(AllFunctions.Value));
-            Assert.That(!Matrices.M3x3.IsSupersetOf(AllFunctions.Value));
+            Assert.False(Matrices.M2x2.IsSupersetOf(AllFunctions.Value));
+            Assert.False(Matrices.M3x3.IsSupersetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestMatricesIsNotSubsetOfAllFunctions()
         {
             // expect
-            Assert.That(!Matrices.M2x2.IsSubsetOf(AllFunctions.Value));
-            Assert.That(!Matrices.M3x3.IsSubsetOf(AllFunctions.Value));
+            Assert.False(Matrices.M2x2.IsSubsetOf(AllFunctions.Value));
+            Assert.False(Matrices.M3x3.IsSubsetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestMatricesIsNotSupersetOfFunctions()
         {
             // expect
-            Assert.That(
-                !Matrices.M2x2.IsSupersetOf(Sets.Functions.RealsToReals));
-            Assert.That(
-                !Matrices.M3x3.IsSupersetOf(Sets.Functions.RealsToReals));
+            Assert.False(
+                Matrices.M2x2.IsSupersetOf(Sets.Functions.RealsToReals));
+            Assert.False(
+                Matrices.M3x3.IsSupersetOf(Sets.Functions.RealsToReals));
         }
 
         [Test]
         public void TestMatricesIsNotSubsetOfFunctions()
         {
             // expect
-            Assert.That(!Matrices.M2x2.IsSubsetOf(
-                Sets.Functions.RealsToReals));
-            Assert.That(!Matrices.M3x3.IsSubsetOf(
-                Sets.Functions.RealsToReals));
+            Assert.False(
+                Matrices.M2x2.IsSubsetOf(Sets.Functions.RealsToReals));
+            Assert.False(
+                Matrices.M3x3.IsSubsetOf(Sets.Functions.RealsToReals));
+        }
+
+        [Test]
+        public void TestMatricesIsNotSupersetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                Matrices.M2x2.IsSupersetOf(VariadicFunctions.RealsToReals));
+            Assert.False(
+                Matrices.M3x3.IsSupersetOf(VariadicFunctions.RealsToReals));
+        }
+
+        [Test]
+        public void TestMatricesIsNotSubsetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                Matrices.M2x2.IsSubsetOf(VariadicFunctions.RealsToReals));
+            Assert.False(
+                Matrices.M3x3.IsSubsetOf(VariadicFunctions.RealsToReals));
         }
 
         [Test]
         public void TestMatricesIsNotSupersetOfTensors()
         {
             // expect
-            Assert.That(!Matrices.M2x2.IsSupersetOf(Tensors.Value));
-            Assert.That(!Matrices.M3x3.IsSupersetOf(Tensors.Value));
+            Assert.False(Matrices.M2x2.IsSupersetOf(Tensors.Value));
+            Assert.False(Matrices.M3x3.IsSupersetOf(Tensors.Value));
         }
 
         [Test]
         public void TestMatricesIsSubsetOfTensors()
         {
             // expect
-            Assert.That(Matrices.M2x2.IsSubsetOf(Tensors.Value));
-            Assert.That(Matrices.M3x3.IsSubsetOf(Tensors.Value));
+            Assert.True(Matrices.M2x2.IsSubsetOf(Tensors.Value));
+            Assert.True(Matrices.M3x3.IsSubsetOf(Tensors.Value));
         }
 
         [Test]
         public void TestMatricesIsNotSupersetOfAllVectors()
         {
             // expect
-            Assert.That(!Matrices.M2x2.IsSupersetOf(AllVectors.Value));
-            Assert.That(!Matrices.M3x3.IsSupersetOf(AllVectors.Value));
+            Assert.False(Matrices.M2x2.IsSupersetOf(AllVectors.Value));
+            Assert.False(Matrices.M3x3.IsSupersetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestMatricesIsNotSubsetOfAllVectors()
         {
             // expect
-            Assert.That(!Matrices.M2x2.IsSubsetOf(AllVectors.Value));
-            Assert.That(!Matrices.M3x3.IsSubsetOf(AllVectors.Value));
+            Assert.False(Matrices.M2x2.IsSubsetOf(AllVectors.Value));
+            Assert.False(Matrices.M3x3.IsSubsetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestMatricesIsNotSupersetOfVectors()
         {
             // expect
-            Assert.That(!Matrices.M2x2.IsSupersetOf(Vectors.R2));
-            Assert.That(!Matrices.M2x2.IsSupersetOf(Vectors.R3));
-            Assert.That(!Matrices.M3x3.IsSupersetOf(Vectors.R2));
-            Assert.That(!Matrices.M3x3.IsSupersetOf(Vectors.R3));
+            Assert.False(Matrices.M2x2.IsSupersetOf(Vectors.R2));
+            Assert.False(Matrices.M2x2.IsSupersetOf(Vectors.R3));
+            Assert.False(Matrices.M3x3.IsSupersetOf(Vectors.R2));
+            Assert.False(Matrices.M3x3.IsSupersetOf(Vectors.R3));
         }
 
         [Test]
         public void TestMatricesIsNotSubsetOfVectors()
         {
             // expect
-            Assert.That(!Matrices.M2x2.IsSubsetOf(Vectors.R2));
-            Assert.That(!Matrices.M2x2.IsSubsetOf(Vectors.R3));
-            Assert.That(!Matrices.M3x3.IsSubsetOf(Vectors.R2));
-            Assert.That(!Matrices.M3x3.IsSubsetOf(Vectors.R3));
+            Assert.False(Matrices.M2x2.IsSubsetOf(Vectors.R2));
+            Assert.False(Matrices.M2x2.IsSubsetOf(Vectors.R3));
+            Assert.False(Matrices.M3x3.IsSubsetOf(Vectors.R2));
+            Assert.False(Matrices.M3x3.IsSubsetOf(Vectors.R3));
         }
 
         [Test]
         public void TestMatricesIsNotSupersetOfAllMatrices()
         {
             // expect
-            Assert.That(!Matrices.M2x2.IsSupersetOf(AllMatrices.Value));
-            Assert.That(!Matrices.M3x3.IsSupersetOf(AllMatrices.Value));
+            Assert.False(Matrices.M2x2.IsSupersetOf(AllMatrices.Value));
+            Assert.False(Matrices.M3x3.IsSupersetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestMatricesIsSubsetOfAllMatrices()
         {
             // expect
-            Assert.That(Matrices.M2x2.IsSubsetOf(AllMatrices.Value));
-            Assert.That(Matrices.M3x3.IsSubsetOf(AllMatrices.Value));
+            Assert.True(Matrices.M2x2.IsSubsetOf(AllMatrices.Value));
+            Assert.True(Matrices.M3x3.IsSubsetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestMatricesIsSupersetOfSelf()
         {
             // expect
-            Assert.That(Matrices.M2x2.IsSupersetOf(Matrices.M2x2));
-            Assert.That(!Matrices.M2x2.IsSupersetOf(Matrices.M3x3));
-            Assert.That(!Matrices.M3x3.IsSupersetOf(Matrices.M2x2));
-            Assert.That(Matrices.M3x3.IsSupersetOf(Matrices.M3x3));
+            Assert.True(Matrices.M2x2.IsSupersetOf(Matrices.M2x2));
+            Assert.False(Matrices.M2x2.IsSupersetOf(Matrices.M3x3));
+            Assert.False(Matrices.M3x3.IsSupersetOf(Matrices.M2x2));
+            Assert.True(Matrices.M3x3.IsSupersetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestMatricesIsSubsetOfSelf()
         {
             // expect
-            Assert.That(Matrices.M2x2.IsSubsetOf(Matrices.M2x2));
-            Assert.That(!Matrices.M2x2.IsSubsetOf(Matrices.M3x3));
-            Assert.That(!Matrices.M3x3.IsSubsetOf(Matrices.M2x2));
-            Assert.That(Matrices.M3x3.IsSubsetOf(Matrices.M3x3));
+            Assert.True(Matrices.M2x2.IsSubsetOf(Matrices.M2x2));
+            Assert.False(Matrices.M2x2.IsSubsetOf(Matrices.M3x3));
+            Assert.False(Matrices.M3x3.IsSubsetOf(Matrices.M2x2));
+            Assert.True(Matrices.M3x3.IsSubsetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestMatricesIsNotSupersetOfReals()
         {
             // expect
-            Assert.That(!Matrices.M2x2.IsSupersetOf(Reals.Value));
-            Assert.That(!Matrices.M3x3.IsSupersetOf(Reals.Value));
+            Assert.False(Matrices.M2x2.IsSupersetOf(Reals.Value));
+            Assert.False(Matrices.M3x3.IsSupersetOf(Reals.Value));
         }
 
         [Test]
         public void TestMatricesIsNotSubsetOfReals()
         {
             // expect
-            Assert.That(!Matrices.M2x2.IsSubsetOf(Reals.Value));
-            Assert.That(!Matrices.M3x3.IsSubsetOf(Reals.Value));
+            Assert.False(Matrices.M2x2.IsSubsetOf(Reals.Value));
+            Assert.False(Matrices.M3x3.IsSubsetOf(Reals.Value));
         }
 
         [Test]
         public void TestMatricesIsNotSupersetOfStrings()
         {
             // expect
-            Assert.That(!Matrices.M2x2.IsSupersetOf(Strings.Value));
-            Assert.That(!Matrices.M3x3.IsSupersetOf(Strings.Value));
+            Assert.False(Matrices.M2x2.IsSupersetOf(Strings.Value));
+            Assert.False(Matrices.M3x3.IsSupersetOf(Strings.Value));
         }
 
         [Test]
         public void TestMatricesIsNotSubsetOfStrings()
         {
             // expect
-            Assert.That(!Matrices.M2x2.IsSubsetOf(Strings.Value));
-            Assert.That(!Matrices.M3x3.IsSubsetOf(Strings.Value));
+            Assert.False(Matrices.M2x2.IsSubsetOf(Strings.Value));
+            Assert.False(Matrices.M3x3.IsSubsetOf(Strings.Value));
         }
 
         [Test]
         public void TestMatricesIsNotSupersetOfIntervals()
         {
             // expect
-            Assert.That(!Matrices.M2x2.IsSupersetOf(Intervals.Value));
-            Assert.That(!Matrices.M3x3.IsSupersetOf(Intervals.Value));
+            Assert.False(Matrices.M2x2.IsSupersetOf(Intervals.Value));
+            Assert.False(Matrices.M3x3.IsSupersetOf(Intervals.Value));
         }
 
         [Test]
         public void TestMatricesIsNotSubsetOfIntervals()
         {
             // expect
-            Assert.That(!Matrices.M2x2.IsSubsetOf(Intervals.Value));
-            Assert.That(!Matrices.M3x3.IsSubsetOf(Intervals.Value));
+            Assert.False(Matrices.M2x2.IsSubsetOf(Intervals.Value));
+            Assert.False(Matrices.M3x3.IsSubsetOf(Intervals.Value));
         }
 
         [Test]
         public void TestMatricesIsNotSupersetOfBooleans()
         {
             // expect
-            Assert.That(!Matrices.M2x2.IsSupersetOf(Booleans.Value));
-            Assert.That(!Matrices.M3x3.IsSupersetOf(Booleans.Value));
+            Assert.False(Matrices.M2x2.IsSupersetOf(Booleans.Value));
+            Assert.False(Matrices.M3x3.IsSupersetOf(Booleans.Value));
         }
 
         [Test]
         public void TestMatricesIsNotSubsetOfBooleans()
         {
             // expect
-            Assert.That(!Matrices.M2x2.IsSubsetOf(Booleans.Value));
-            Assert.That(!Matrices.M3x3.IsSubsetOf(Booleans.Value));
+            Assert.False(Matrices.M2x2.IsSubsetOf(Booleans.Value));
+            Assert.False(Matrices.M3x3.IsSubsetOf(Booleans.Value));
         }
 
         [Test]
         public void TestMatricesIsNotSupersetOfExpressions()
         {
             // expect
-            Assert.That(!Matrices.M2x2.IsSupersetOf(Sets.Expressions.Value));
-            Assert.That(!Matrices.M3x3.IsSupersetOf(Sets.Expressions.Value));
+            Assert.False(Matrices.M2x2.IsSupersetOf(Sets.Expressions.Value));
+            Assert.False(Matrices.M3x3.IsSupersetOf(Sets.Expressions.Value));
         }
 
         [Test]
         public void TestMatricesIsNotSubsetOfExpressions()
         {
             // expect
-            Assert.That(!Matrices.M2x2.IsSubsetOf(Sets.Expressions.Value));
-            Assert.That(!Matrices.M3x3.IsSubsetOf(Sets.Expressions.Value));
+            Assert.False(Matrices.M2x2.IsSubsetOf(Sets.Expressions.Value));
+            Assert.False(Matrices.M3x3.IsSubsetOf(Sets.Expressions.Value));
         }
 
         [Test]
         public void TestMatricesIsNotSupersetOfLiterals()
         {
             // expect
-            Assert.That(!Matrices.M2x2.IsSupersetOf(Literals.Value));
-            Assert.That(!Matrices.M3x3.IsSupersetOf(Literals.Value));
+            Assert.False(Matrices.M2x2.IsSupersetOf(Literals.Value));
+            Assert.False(Matrices.M3x3.IsSupersetOf(Literals.Value));
         }
 
         [Test]
         public void TestMatricesIsNotSubsetOfLiterals()
         {
             // expect
-            Assert.That(!Matrices.M2x2.IsSubsetOf(Literals.Value));
-            Assert.That(!Matrices.M3x3.IsSubsetOf(Literals.Value));
+            Assert.False(Matrices.M2x2.IsSubsetOf(Literals.Value));
+            Assert.False(Matrices.M3x3.IsSubsetOf(Literals.Value));
         }
 
         [Test]
         public void TestMatricesIsNotSupersetOfComponentAccesses()
         {
             // expect
-            Assert.That(!Matrices.M2x2.IsSupersetOf(ComponentAccesses.Value));
-            Assert.That(!Matrices.M3x3.IsSupersetOf(ComponentAccesses.Value));
+            Assert.False(Matrices.M2x2.IsSupersetOf(ComponentAccesses.Value));
+            Assert.False(Matrices.M3x3.IsSupersetOf(ComponentAccesses.Value));
         }
 
         [Test]
         public void TestMatricesIsNotSubsetOfComponentAccesses()
         {
             // expect
-            Assert.That(!Matrices.M2x2.IsSubsetOf(ComponentAccesses.Value));
-            Assert.That(!Matrices.M3x3.IsSubsetOf(ComponentAccesses.Value));
+            Assert.False(Matrices.M2x2.IsSubsetOf(ComponentAccesses.Value));
+            Assert.False(Matrices.M3x3.IsSubsetOf(ComponentAccesses.Value));
         }
 
         [Test]
         public void TestMatricesIsNotSupersetOfFunctionCalls()
         {
             // expect
-            Assert.That(!Matrices.M2x2.IsSupersetOf(FunctionCalls.Value));
-            Assert.That(!Matrices.M3x3.IsSupersetOf(FunctionCalls.Value));
+            Assert.False(Matrices.M2x2.IsSupersetOf(FunctionCalls.Value));
+            Assert.False(Matrices.M3x3.IsSupersetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestMatricesIsNotSubsetOfFunctionCalls()
         {
             // expect
-            Assert.That(!Matrices.M2x2.IsSubsetOf(FunctionCalls.Value));
-            Assert.That(!Matrices.M3x3.IsSubsetOf(FunctionCalls.Value));
+            Assert.False(Matrices.M2x2.IsSubsetOf(FunctionCalls.Value));
+            Assert.False(Matrices.M3x3.IsSubsetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestMatricesIsNotSupersetOfIntervalExpressions()
         {
             // expect
-            Assert.That(!Matrices.M2x2.IsSupersetOf(
-                IntervalExpressions.Value));
-            Assert.That(!Matrices.M3x3.IsSupersetOf(
-                IntervalExpressions.Value));
+            Assert.False(
+                Matrices.M2x2.IsSupersetOf(IntervalExpressions.Value));
+            Assert.False(
+                Matrices.M3x3.IsSupersetOf(IntervalExpressions.Value));
         }
 
         [Test]
         public void TestMatricesIsNotSubsetOfIntervalExpressions()
         {
             // expect
-            Assert.That(!Matrices.M2x2.IsSubsetOf(IntervalExpressions.Value));
-            Assert.That(!Matrices.M3x3.IsSubsetOf(IntervalExpressions.Value));
+            Assert.False(Matrices.M2x2.IsSubsetOf(IntervalExpressions.Value));
+            Assert.False(Matrices.M3x3.IsSubsetOf(IntervalExpressions.Value));
         }
 
         [Test]
         public void TestMatricesIsNotSupersetOfTensorExpressions()
         {
             // expect
-            Assert.That(!Matrices.M2x2.IsSupersetOf(TensorExpressions.Value));
-            Assert.That(!Matrices.M3x3.IsSupersetOf(TensorExpressions.Value));
+            Assert.False(Matrices.M2x2.IsSupersetOf(TensorExpressions.Value));
+            Assert.False(Matrices.M3x3.IsSupersetOf(TensorExpressions.Value));
         }
 
         [Test]
         public void TestMatricesIsNotSubsetOfTensorExpressions()
         {
             // expect
-            Assert.That(!Matrices.M2x2.IsSubsetOf(TensorExpressions.Value));
-            Assert.That(!Matrices.M3x3.IsSubsetOf(TensorExpressions.Value));
+            Assert.False(Matrices.M2x2.IsSubsetOf(TensorExpressions.Value));
+            Assert.False(Matrices.M3x3.IsSubsetOf(TensorExpressions.Value));
         }
 
         [Test]
         public void TestMatricesIsNotSupersetOfMatrixExpressions()
         {
             // expect
-            Assert.That(!Matrices.M2x2.IsSupersetOf(MatrixExpressions.Value));
-            Assert.That(!Matrices.M3x3.IsSupersetOf(MatrixExpressions.Value));
+            Assert.False(Matrices.M2x2.IsSupersetOf(MatrixExpressions.Value));
+            Assert.False(Matrices.M3x3.IsSupersetOf(MatrixExpressions.Value));
         }
 
         [Test]
         public void TestMatricesIsNotSubsetOfMatrixExpressions()
         {
             // expect
-            Assert.That(!Matrices.M2x2.IsSubsetOf(MatrixExpressions.Value));
-            Assert.That(!Matrices.M3x3.IsSubsetOf(MatrixExpressions.Value));
+            Assert.False(Matrices.M2x2.IsSubsetOf(MatrixExpressions.Value));
+            Assert.False(Matrices.M3x3.IsSubsetOf(MatrixExpressions.Value));
         }
 
         [Test]
         public void TestMatricesIsNotSupersetOfVectorExpressions()
         {
             // expect
-            Assert.That(!Matrices.M2x2.IsSupersetOf(VectorExpressions.Value));
-            Assert.That(!Matrices.M3x3.IsSupersetOf(VectorExpressions.Value));
+            Assert.False(Matrices.M2x2.IsSupersetOf(VectorExpressions.Value));
+            Assert.False(Matrices.M3x3.IsSupersetOf(VectorExpressions.Value));
         }
 
         [Test]
         public void TestMatricesIsNotSubsetOfVectorExpressions()
         {
             // expect
-            Assert.That(!Matrices.M2x2.IsSubsetOf(VectorExpressions.Value));
-            Assert.That(!Matrices.M3x3.IsSubsetOf(VectorExpressions.Value));
+            Assert.False(Matrices.M2x2.IsSubsetOf(VectorExpressions.Value));
+            Assert.False(Matrices.M3x3.IsSubsetOf(VectorExpressions.Value));
         }
 
         [Test]
         public void TestMatricesIsNotSupersetOfVariableAccesses()
         {
             // expect
-            Assert.That(!Matrices.M2x2.IsSupersetOf(VariableAccesses.Value));
-            Assert.That(!Matrices.M3x3.IsSupersetOf(VariableAccesses.Value));
+            Assert.False(Matrices.M2x2.IsSupersetOf(VariableAccesses.Value));
+            Assert.False(Matrices.M3x3.IsSupersetOf(VariableAccesses.Value));
         }
 
         [Test]
         public void TestMatricesIsNotSubsetOfVariableAccesses()
         {
             // expect
-            Assert.That(!Matrices.M2x2.IsSubsetOf(VariableAccesses.Value));
-            Assert.That(!Matrices.M3x3.IsSubsetOf(VariableAccesses.Value));
+            Assert.False(Matrices.M2x2.IsSubsetOf(VariableAccesses.Value));
+            Assert.False(Matrices.M3x3.IsSubsetOf(VariableAccesses.Value));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/SetsT/MatrixExpressionsT/SupersetAndSubsetTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/SetsT/MatrixExpressionsT/SupersetAndSubsetTest.cs
@@ -32,214 +32,234 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.MatrixExpressionsT
         public void TestMatrixExpressionsIsNotSupersetOfMathObjects()
         {
             // expect
-            Assert.That(
-                !MatrixExpressions.Value.IsSupersetOf(MathObjects.Value));
+            Assert.False(
+                MatrixExpressions.Value.IsSupersetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestMatrixExpressionsIsSubsetOfMathObjects()
         {
             // expect
-            Assert.That(MatrixExpressions.Value.IsSubsetOf(
-                MathObjects.Value));
+            Assert.True(
+                MatrixExpressions.Value.IsSubsetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestMatrixExpressionsIsNotSupersetOfSets()
         {
             // expect
-            Assert.That(!MatrixExpressions.Value.IsSupersetOf(
-                Sets.Sets.Value));
+            Assert.False(
+                MatrixExpressions.Value.IsSupersetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestMatrixExpressionsIsNotSubsetOfSets()
         {
             // expect
-            Assert.That(!MatrixExpressions.Value.IsSubsetOf(Sets.Sets.Value));
+            Assert.False(MatrixExpressions.Value.IsSubsetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestMatrixExpressionsIsNotSupersetOfAllFunctions()
         {
             // expect
-            Assert.That(
-                !MatrixExpressions.Value.IsSupersetOf(AllFunctions.Value));
+            Assert.False(
+                MatrixExpressions.Value.IsSupersetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestMatrixExpressionsIsNotSubsetOfAllFunctions()
         {
             // expect
-            Assert.That(
-                !MatrixExpressions.Value.IsSubsetOf(AllFunctions.Value));
+            Assert.False(
+                MatrixExpressions.Value.IsSubsetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestMatrixExpressionsIsNotSupersetOfFunctions()
         {
             // expect
-            Assert.That(
-                !MatrixExpressions.Value.IsSupersetOf(Sets.Functions
-                    .RealsToReals));
+            Assert.False(
+                MatrixExpressions.Value.IsSupersetOf(
+                    Sets.Functions.RealsToReals));
         }
 
         [Test]
         public void TestMatrixExpressionsIsNotSubsetOfFunctions()
         {
             // expect
-            Assert.That(
-                !MatrixExpressions.Value.IsSubsetOf(Sets.Functions
-                    .RealsToReals));
+            Assert.False(
+                MatrixExpressions.Value.IsSubsetOf(
+                    Sets.Functions.RealsToReals));
+        }
+
+        [Test]
+        public void TestMatrixExpressionsIsNotSupersetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                MatrixExpressions.Value.IsSupersetOf(
+                    VariadicFunctions.RealsToReals));
+        }
+
+        [Test]
+        public void TestMatrixExpressionsIsNotSubsetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                MatrixExpressions.Value.IsSubsetOf(
+                    VariadicFunctions.RealsToReals));
         }
 
         [Test]
         public void TestMatrixExpressionsIsNotSupersetOfTensors()
         {
             // expect
-            Assert.That(!MatrixExpressions.Value.IsSupersetOf(Tensors.Value));
+            Assert.False(MatrixExpressions.Value.IsSupersetOf(Tensors.Value));
         }
 
         [Test]
         public void TestMatrixExpressionsIsNotSubsetOfTensors()
         {
             // expect
-            Assert.That(!MatrixExpressions.Value.IsSubsetOf(Tensors.Value));
+            Assert.False(MatrixExpressions.Value.IsSubsetOf(Tensors.Value));
         }
 
         [Test]
         public void TestMatrixExpressionsIsNotSupersetOfAllVectors()
         {
             // expect
-            Assert.That(
-                !MatrixExpressions.Value.IsSupersetOf(AllVectors.Value));
+            Assert.False(
+                MatrixExpressions.Value.IsSupersetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestMatrixExpressionsIsNotSubsetOfAllVectors()
         {
             // expect
-            Assert.That(!MatrixExpressions.Value.IsSubsetOf(AllVectors.Value));
+            Assert.False(
+                MatrixExpressions.Value.IsSubsetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestMatrixExpressionsIsNotSupersetOfVectors()
         {
             // expect
-            Assert.That(!MatrixExpressions.Value.IsSupersetOf(Vectors.R2));
-            Assert.That(!MatrixExpressions.Value.IsSupersetOf(Vectors.R3));
+            Assert.False(MatrixExpressions.Value.IsSupersetOf(Vectors.R2));
+            Assert.False(MatrixExpressions.Value.IsSupersetOf(Vectors.R3));
         }
 
         [Test]
         public void TestMatrixExpressionsIsNotSubsetOfVectors()
         {
             // expect
-            Assert.That(!MatrixExpressions.Value.IsSubsetOf(Vectors.R2));
-            Assert.That(!MatrixExpressions.Value.IsSubsetOf(Vectors.R3));
+            Assert.False(MatrixExpressions.Value.IsSubsetOf(Vectors.R2));
+            Assert.False(MatrixExpressions.Value.IsSubsetOf(Vectors.R3));
         }
 
         [Test]
         public void TestMatrixExpressionsIsNotSupersetOfAllMatrices()
         {
             // expect
-            Assert.That(
-                !MatrixExpressions.Value.IsSupersetOf(AllMatrices.Value));
+            Assert.False(
+                MatrixExpressions.Value.IsSupersetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestMatrixExpressionsIsNotSubsetOfAllMatrices()
         {
             // expect
-            Assert.That(!MatrixExpressions.Value.IsSubsetOf(
-                AllMatrices.Value));
+            Assert.False(
+                MatrixExpressions.Value.IsSubsetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestMatrixExpressionsIsNotSupersetOfMatrices()
         {
             // expect
-            Assert.That(!MatrixExpressions.Value.IsSupersetOf(Matrices.M2x2));
-            Assert.That(!MatrixExpressions.Value.IsSupersetOf(Matrices.M3x3));
+            Assert.False(MatrixExpressions.Value.IsSupersetOf(Matrices.M2x2));
+            Assert.False(MatrixExpressions.Value.IsSupersetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestMatrixExpressionsIsNotSubsetOfMatrices()
         {
             // expect
-            Assert.That(!MatrixExpressions.Value.IsSubsetOf(Matrices.M2x2));
-            Assert.That(!MatrixExpressions.Value.IsSubsetOf(Matrices.M3x3));
+            Assert.False(MatrixExpressions.Value.IsSubsetOf(Matrices.M2x2));
+            Assert.False(MatrixExpressions.Value.IsSubsetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestMatrixExpressionsIsNotSupersetOfReals()
         {
             // expect
-            Assert.That(!MatrixExpressions.Value.IsSupersetOf(Reals.Value));
+            Assert.False(MatrixExpressions.Value.IsSupersetOf(Reals.Value));
         }
 
         [Test]
         public void TestMatrixExpressionsIsNotSubsetOfReals()
         {
             // expect
-            Assert.That(!MatrixExpressions.Value.IsSubsetOf(Reals.Value));
+            Assert.False(MatrixExpressions.Value.IsSubsetOf(Reals.Value));
         }
 
         [Test]
         public void TestMatrixExpressionsIsNotSupersetOfStrings()
         {
             // expect
-            Assert.That(!MatrixExpressions.Value.IsSupersetOf(Strings.Value));
+            Assert.False(MatrixExpressions.Value.IsSupersetOf(Strings.Value));
         }
 
         [Test]
         public void TestMatrixExpressionsIsNotSubsetOfStrings()
         {
             // expect
-            Assert.That(!MatrixExpressions.Value.IsSubsetOf(Strings.Value));
+            Assert.False(MatrixExpressions.Value.IsSubsetOf(Strings.Value));
         }
 
         [Test]
         public void TestMatrixExpressionsIsNotSupersetOfIntervals()
         {
             // expect
-            Assert.That(!MatrixExpressions.Value.IsSupersetOf(
-                Intervals.Value));
+            Assert.False(
+                MatrixExpressions.Value.IsSupersetOf(Intervals.Value));
         }
 
         [Test]
         public void TestMatrixExpressionsIsNotSubsetOfIntervals()
         {
             // expect
-            Assert.That(!MatrixExpressions.Value.IsSubsetOf(Intervals.Value));
+            Assert.False(MatrixExpressions.Value.IsSubsetOf(Intervals.Value));
         }
 
         [Test]
         public void TestMatrixExpressionsIsNotSupersetOfBooleans()
         {
             // expect
-            Assert.That(!MatrixExpressions.Value.IsSupersetOf(Booleans.Value));
+            Assert.False(
+                MatrixExpressions.Value.IsSupersetOf(Booleans.Value));
         }
 
         [Test]
         public void TestMatrixExpressionsIsNotSubsetOfBooleans()
         {
             // expect
-            Assert.That(!MatrixExpressions.Value.IsSubsetOf(Booleans.Value));
+            Assert.False(MatrixExpressions.Value.IsSubsetOf(Booleans.Value));
         }
 
         [Test]
         public void TestMatrixExpressionsIsNotSupersetOfExpressions()
         {
             // expect
-            Assert.That(
-                !MatrixExpressions.Value.IsSupersetOf(Sets.Expressions.Value));
+            Assert.False(
+                MatrixExpressions.Value.IsSupersetOf(Sets.Expressions.Value));
         }
 
         [Test]
         public void TestMatrixExpressionsIsSubsetOfExpressions()
         {
             // expect
-            Assert.That(
+            Assert.True(
                 MatrixExpressions.Value.IsSubsetOf(Sets.Expressions.Value));
         }
 
@@ -247,22 +267,23 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.MatrixExpressionsT
         public void TestMatrixExpressionsIsNotSupersetOfLiterals()
         {
             // expect
-            Assert.That(!MatrixExpressions.Value.IsSupersetOf(Literals.Value));
+            Assert.False(
+                MatrixExpressions.Value.IsSupersetOf(Literals.Value));
         }
 
         [Test]
         public void TestMatrixExpressionsIsNotSubsetOfLiterals()
         {
             // expect
-            Assert.That(!MatrixExpressions.Value.IsSubsetOf(Literals.Value));
+            Assert.False(MatrixExpressions.Value.IsSubsetOf(Literals.Value));
         }
 
         [Test]
         public void TestMatrixExpressionsIsNotSupersetOfComponentAccesses()
         {
             // expect
-            Assert.That(
-                !MatrixExpressions.Value.IsSupersetOf(
+            Assert.False(
+                MatrixExpressions.Value.IsSupersetOf(
                     ComponentAccesses.Value));
         }
 
@@ -270,41 +291,41 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.MatrixExpressionsT
         public void TestMatrixExpressionsIsNotSubsetOfComponentAccesses()
         {
             // expect
-            Assert.That(
-                !MatrixExpressions.Value.IsSubsetOf(ComponentAccesses.Value));
+            Assert.False(
+                MatrixExpressions.Value.IsSubsetOf(ComponentAccesses.Value));
         }
 
         [Test]
         public void TestMatrixExpressionsIsNotSupersetOfFunctionCalls()
         {
             // expect
-            Assert.That(
-                !MatrixExpressions.Value.IsSupersetOf(FunctionCalls.Value));
+            Assert.False(
+                MatrixExpressions.Value.IsSupersetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestMatrixExpressionsIsNotSubsetOfFunctionCalls()
         {
             // expect
-            Assert.That(
-                !MatrixExpressions.Value.IsSubsetOf(FunctionCalls.Value));
+            Assert.False(
+                MatrixExpressions.Value.IsSubsetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestMatrixExpressionsIsNotSupersetOfIntervalExpressions()
         {
             // expect
-            Assert.That(
-                !MatrixExpressions.Value.IsSupersetOf(IntervalExpressions
-                    .Value));
+            Assert.False(
+                MatrixExpressions.Value.IsSupersetOf(
+                    IntervalExpressions.Value));
         }
 
         [Test]
         public void TestMatrixExpressionsIsNotSubsetOfIntervalExpressions()
         {
             // expect
-            Assert.That(
-                !MatrixExpressions.Value.IsSubsetOf(
+            Assert.False(
+                MatrixExpressions.Value.IsSubsetOf(
                     IntervalExpressions.Value));
         }
 
@@ -312,8 +333,8 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.MatrixExpressionsT
         public void TestMatrixExpressionsIsNotSupersetOfTensorExpressions()
         {
             // expect
-            Assert.That(
-                !MatrixExpressions.Value.IsSupersetOf(
+            Assert.False(
+                MatrixExpressions.Value.IsSupersetOf(
                     TensorExpressions.Value));
         }
 
@@ -321,7 +342,7 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.MatrixExpressionsT
         public void TestMatrixExpressionsIsSubsetOfTensorExpressions()
         {
             // expect
-            Assert.That(
+            Assert.True(
                 MatrixExpressions.Value.IsSubsetOf(TensorExpressions.Value));
         }
 
@@ -329,15 +350,16 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.MatrixExpressionsT
         public void TestMatrixExpressionsIsSupersetOfSelf()
         {
             // expect
-            Assert.That(
-                MatrixExpressions.Value.IsSupersetOf(MatrixExpressions.Value));
+            Assert.True(
+                MatrixExpressions.Value.IsSupersetOf(
+                    MatrixExpressions.Value));
         }
 
         [Test]
         public void TestMatrixExpressionsIsSubsetOfSelf()
         {
             // expect
-            Assert.That(
+            Assert.True(
                 MatrixExpressions.Value.IsSubsetOf(MatrixExpressions.Value));
         }
 
@@ -345,8 +367,8 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.MatrixExpressionsT
         public void TestMatrixExpressionsIsNotSupersetOfVectorExpressions()
         {
             // expect
-            Assert.That(
-                !MatrixExpressions.Value.IsSupersetOf(
+            Assert.False(
+                MatrixExpressions.Value.IsSupersetOf(
                     VectorExpressions.Value));
         }
 
@@ -354,24 +376,24 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.MatrixExpressionsT
         public void TestMatrixExpressionsIsNotSubsetOfVectorExpressions()
         {
             // expect
-            Assert.That(
-                !MatrixExpressions.Value.IsSubsetOf(VectorExpressions.Value));
+            Assert.False(
+                MatrixExpressions.Value.IsSubsetOf(VectorExpressions.Value));
         }
 
         [Test]
         public void TestMatrixExpressionsIsNotSupersetOfVariableAccesses()
         {
             // expect
-            Assert.That(
-                !MatrixExpressions.Value.IsSupersetOf(VariableAccesses.Value));
+            Assert.False(
+                MatrixExpressions.Value.IsSupersetOf(VariableAccesses.Value));
         }
 
         [Test]
         public void TestMatrixExpressionsIsNotSubsetOfVariableAccesses()
         {
             // expect
-            Assert.That(
-                !MatrixExpressions.Value.IsSubsetOf(VariableAccesses.Value));
+            Assert.False(
+                MatrixExpressions.Value.IsSubsetOf(VariableAccesses.Value));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/SetsT/RealsT/SupersetAndSubsetTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/SetsT/RealsT/SupersetAndSubsetTest.cs
@@ -32,313 +32,329 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.RealsT
         public void TestRealsIsNotSupersetOfMathObjects()
         {
             // expect
-            Assert.That(!Reals.Value.IsSupersetOf(MathObjects.Value));
+            Assert.False(Reals.Value.IsSupersetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestRealsIsSubsetOfMathObjects()
         {
             // expect
-            Assert.That(Reals.Value.IsSubsetOf(MathObjects.Value));
+            Assert.True(Reals.Value.IsSubsetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestRealsIsNotSupersetOfSets()
         {
             // expect
-            Assert.That(!Reals.Value.IsSupersetOf(Sets.Sets.Value));
+            Assert.False(Reals.Value.IsSupersetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestRealsIsNotSubsetOfSets()
         {
             // expect
-            Assert.That(!Reals.Value.IsSubsetOf(Sets.Sets.Value));
+            Assert.False(Reals.Value.IsSubsetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestRealsIsNotSupersetOfAllFunctions()
         {
             // expect
-            Assert.That(!Reals.Value.IsSupersetOf(AllFunctions.Value));
+            Assert.False(Reals.Value.IsSupersetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestRealsIsNotSubsetOfAllFunctions()
         {
             // expect
-            Assert.That(!Reals.Value.IsSubsetOf(AllFunctions.Value));
+            Assert.False(Reals.Value.IsSubsetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestRealsIsNotSupersetOfFunctions()
         {
             // expect
-            Assert.That(!Reals.Value.IsSupersetOf(
-                Sets.Functions.RealsToReals));
+            Assert.False(
+                Reals.Value.IsSupersetOf(Sets.Functions.RealsToReals));
         }
 
         [Test]
         public void TestRealsIsNotSubsetOfFunctions()
         {
             // expect
-            Assert.That(!Reals.Value.IsSubsetOf(Sets.Functions.RealsToReals));
+            Assert.False(Reals.Value.IsSubsetOf(Sets.Functions.RealsToReals));
+        }
+
+        [Test]
+        public void TestRealsIsNotSupersetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                Reals.Value.IsSupersetOf(VariadicFunctions.RealsToReals));
+        }
+
+        [Test]
+        public void TestRealsIsNotSubsetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                Reals.Value.IsSubsetOf(VariadicFunctions.RealsToReals));
         }
 
         [Test]
         public void TestRealsIsNotSupersetOfTensors()
         {
             // expect
-            Assert.That(!Reals.Value.IsSupersetOf(Tensors.Value));
+            Assert.False(Reals.Value.IsSupersetOf(Tensors.Value));
         }
 
         [Test]
         public void TestRealsIsNotSubsetOfTensors()
         {
             // expect
-            Assert.That(!Reals.Value.IsSubsetOf(Tensors.Value));
+            Assert.False(Reals.Value.IsSubsetOf(Tensors.Value));
         }
 
         [Test]
         public void TestRealsIsNotSupersetOfAllVectors()
         {
             // expect
-            Assert.That(!Reals.Value.IsSupersetOf(AllVectors.Value));
+            Assert.False(Reals.Value.IsSupersetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestRealsIsNotSubsetOfAllVectors()
         {
             // expect
-            Assert.That(!Reals.Value.IsSubsetOf(AllVectors.Value));
+            Assert.False(Reals.Value.IsSubsetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestRealsIsNotSupersetOfVectors()
         {
             // expect
-            Assert.That(!Reals.Value.IsSupersetOf(Vectors.R2));
-            Assert.That(!Reals.Value.IsSupersetOf(Vectors.R3));
+            Assert.False(Reals.Value.IsSupersetOf(Vectors.R2));
+            Assert.False(Reals.Value.IsSupersetOf(Vectors.R3));
         }
 
         [Test]
         public void TestRealsIsNotSubsetOfVectors()
         {
             // expect
-            Assert.That(!Reals.Value.IsSubsetOf(Vectors.R2));
-            Assert.That(!Reals.Value.IsSubsetOf(Vectors.R3));
+            Assert.False(Reals.Value.IsSubsetOf(Vectors.R2));
+            Assert.False(Reals.Value.IsSubsetOf(Vectors.R3));
         }
 
         [Test]
         public void TestRealsIsNotSupersetOfAllMatrices()
         {
             // expect
-            Assert.That(!Reals.Value.IsSupersetOf(AllMatrices.Value));
+            Assert.False(Reals.Value.IsSupersetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestRealsIsNotSubsetOfAllMatrices()
         {
             // expect
-            Assert.That(!Reals.Value.IsSubsetOf(AllMatrices.Value));
+            Assert.False(Reals.Value.IsSubsetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestRealsIsNotSupersetOfMatrices()
         {
             // expect
-            Assert.That(!Reals.Value.IsSupersetOf(Matrices.M2x2));
-            Assert.That(!Reals.Value.IsSupersetOf(Matrices.M3x3));
+            Assert.False(Reals.Value.IsSupersetOf(Matrices.M2x2));
+            Assert.False(Reals.Value.IsSupersetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestRealsIsNotSubsetOfMatrices()
         {
             // expect
-            Assert.That(!Reals.Value.IsSubsetOf(Matrices.M2x2));
-            Assert.That(!Reals.Value.IsSubsetOf(Matrices.M3x3));
+            Assert.False(Reals.Value.IsSubsetOf(Matrices.M2x2));
+            Assert.False(Reals.Value.IsSubsetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestRealsIsSupersetOfSelf()
         {
             // expect
-            Assert.That(Reals.Value.IsSupersetOf(Reals.Value));
+            Assert.True(Reals.Value.IsSupersetOf(Reals.Value));
         }
 
         [Test]
         public void TestRealsIsSubsetOfSelf()
         {
             // expect
-            Assert.That(Reals.Value.IsSubsetOf(Reals.Value));
+            Assert.True(Reals.Value.IsSubsetOf(Reals.Value));
         }
 
         [Test]
         public void TestRealsIsNotSupersetOfStrings()
         {
             // expect
-            Assert.That(!Reals.Value.IsSupersetOf(Strings.Value));
+            Assert.False(Reals.Value.IsSupersetOf(Strings.Value));
         }
 
         [Test]
         public void TestRealsIsNotSubsetOfStrings()
         {
             // expect
-            Assert.That(!Reals.Value.IsSubsetOf(Strings.Value));
+            Assert.False(Reals.Value.IsSubsetOf(Strings.Value));
         }
 
         [Test]
         public void TestRealsIsNotSupersetOfIntervals()
         {
             // expect
-            Assert.That(!Reals.Value.IsSupersetOf(Intervals.Value));
+            Assert.False(Reals.Value.IsSupersetOf(Intervals.Value));
         }
 
         [Test]
         public void TestRealsIsNotSubsetOfIntervals()
         {
             // expect
-            Assert.That(!Reals.Value.IsSubsetOf(Intervals.Value));
+            Assert.False(Reals.Value.IsSubsetOf(Intervals.Value));
         }
 
         [Test]
         public void TestRealsIsNotSupersetOfBooleans()
         {
             // expect
-            Assert.That(!Reals.Value.IsSupersetOf(Booleans.Value));
+            Assert.False(Reals.Value.IsSupersetOf(Booleans.Value));
         }
 
         [Test]
         public void TestRealsIsNotSubsetOfBooleans()
         {
             // expect
-            Assert.That(!Reals.Value.IsSubsetOf(Booleans.Value));
+            Assert.False(Reals.Value.IsSubsetOf(Booleans.Value));
         }
 
         [Test]
         public void TestRealsIsNotSupersetOfExpressions()
         {
             // expect
-            Assert.That(!Reals.Value.IsSupersetOf(Sets.Expressions.Value));
+            Assert.False(Reals.Value.IsSupersetOf(Sets.Expressions.Value));
         }
 
         [Test]
         public void TestRealsIsNotSubsetOfExpressions()
         {
             // expect
-            Assert.That(!Reals.Value.IsSubsetOf(Sets.Expressions.Value));
+            Assert.False(Reals.Value.IsSubsetOf(Sets.Expressions.Value));
         }
 
         [Test]
         public void TestRealsIsNotSupersetOfLiterals()
         {
             // expect
-            Assert.That(!Reals.Value.IsSupersetOf(Literals.Value));
+            Assert.False(Reals.Value.IsSupersetOf(Literals.Value));
         }
 
         [Test]
         public void TestRealsIsNotSubsetOfLiterals()
         {
             // expect
-            Assert.That(!Reals.Value.IsSubsetOf(Literals.Value));
+            Assert.False(Reals.Value.IsSubsetOf(Literals.Value));
         }
 
         [Test]
         public void TestRealsIsNotSupersetOfComponentAccesses()
         {
             // expect
-            Assert.That(!Reals.Value.IsSupersetOf(ComponentAccesses.Value));
+            Assert.False(Reals.Value.IsSupersetOf(ComponentAccesses.Value));
         }
 
         [Test]
         public void TestRealsIsNotSubsetOfComponentAccesses()
         {
             // expect
-            Assert.That(!Reals.Value.IsSubsetOf(ComponentAccesses.Value));
+            Assert.False(Reals.Value.IsSubsetOf(ComponentAccesses.Value));
         }
 
         [Test]
         public void TestRealsIsNotSupersetOfFunctionCalls()
         {
             // expect
-            Assert.That(!Reals.Value.IsSupersetOf(FunctionCalls.Value));
+            Assert.False(Reals.Value.IsSupersetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestRealsIsNotSubsetOfFunctionCalls()
         {
             // expect
-            Assert.That(!Reals.Value.IsSubsetOf(FunctionCalls.Value));
+            Assert.False(Reals.Value.IsSubsetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestRealsIsNotSupersetOfIntervalExpressions()
         {
             // expect
-            Assert.That(!Reals.Value.IsSupersetOf(IntervalExpressions.Value));
+            Assert.False(Reals.Value.IsSupersetOf(IntervalExpressions.Value));
         }
 
         [Test]
         public void TestRealsIsNotSubsetOfIntervalExpressions()
         {
             // expect
-            Assert.That(!Reals.Value.IsSubsetOf(IntervalExpressions.Value));
+            Assert.False(Reals.Value.IsSubsetOf(IntervalExpressions.Value));
         }
 
         [Test]
         public void TestRealsIsNotSupersetOfTensorExpressions()
         {
             // expect
-            Assert.That(!Reals.Value.IsSupersetOf(TensorExpressions.Value));
+            Assert.False(Reals.Value.IsSupersetOf(TensorExpressions.Value));
         }
 
         [Test]
         public void TestRealsIsNotSubsetOfTensorExpressions()
         {
             // expect
-            Assert.That(!Reals.Value.IsSubsetOf(TensorExpressions.Value));
+            Assert.False(Reals.Value.IsSubsetOf(TensorExpressions.Value));
         }
 
         [Test]
         public void TestRealsIsNotSupersetOfMatrixExpressions()
         {
             // expect
-            Assert.That(!Reals.Value.IsSupersetOf(MatrixExpressions.Value));
+            Assert.False(Reals.Value.IsSupersetOf(MatrixExpressions.Value));
         }
 
         [Test]
         public void TestRealsIsNotSubsetOfMatrixExpressions()
         {
             // expect
-            Assert.That(!Reals.Value.IsSubsetOf(MatrixExpressions.Value));
+            Assert.False(Reals.Value.IsSubsetOf(MatrixExpressions.Value));
         }
 
         [Test]
         public void TestRealsIsNotSupersetOfVectorExpressions()
         {
             // expect
-            Assert.That(!Reals.Value.IsSupersetOf(VectorExpressions.Value));
+            Assert.False(Reals.Value.IsSupersetOf(VectorExpressions.Value));
         }
 
         [Test]
         public void TestRealsIsNotSubsetOfVectorExpressions()
         {
             // expect
-            Assert.That(!Reals.Value.IsSubsetOf(VectorExpressions.Value));
+            Assert.False(Reals.Value.IsSubsetOf(VectorExpressions.Value));
         }
 
         [Test]
         public void TestRealsIsNotSupersetOfVariableAccesses()
         {
             // expect
-            Assert.That(!Reals.Value.IsSupersetOf(VariableAccesses.Value));
+            Assert.False(Reals.Value.IsSupersetOf(VariableAccesses.Value));
         }
 
         [Test]
         public void TestRealsIsNotSubsetOfVariableAccesses()
         {
             // expect
-            Assert.That(!Reals.Value.IsSubsetOf(VariableAccesses.Value));
+            Assert.False(Reals.Value.IsSubsetOf(VariableAccesses.Value));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/SetsT/SetsT/SupersetAndSubsetTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/SetsT/SetsT/SupersetAndSubsetTest.cs
@@ -32,320 +32,338 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.SetsT
         public void TestSetsIsNotSupersetOfMathObjects()
         {
             // expect
-            Assert.That(!Sets.Sets.Value.IsSupersetOf(MathObjects.Value));
+            Assert.False(Sets.Sets.Value.IsSupersetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestSetsIsSubsetOfMathObjects()
         {
             // expect
-            Assert.That(Sets.Sets.Value.IsSubsetOf(MathObjects.Value));
+            Assert.True(Sets.Sets.Value.IsSubsetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestSetsIsSupersetOfSelf()
         {
             // expect
-            Assert.That(Sets.Sets.Value.IsSupersetOf(Sets.Sets.Value));
+            Assert.True(Sets.Sets.Value.IsSupersetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestSetsIsSubsetOfSelf()
         {
             // expect
-            Assert.That(Sets.Sets.Value.IsSubsetOf(Sets.Sets.Value));
+            Assert.True(Sets.Sets.Value.IsSubsetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestSetsIsNotSupersetOfAllFunctions()
         {
             // expect
-            Assert.That(!Sets.Sets.Value.IsSupersetOf(AllFunctions.Value));
+            Assert.False(Sets.Sets.Value.IsSupersetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestSetsIsNotSubsetOfAllFunctions()
         {
             // expect
-            Assert.That(!Sets.Sets.Value.IsSubsetOf(AllFunctions.Value));
+            Assert.False(Sets.Sets.Value.IsSubsetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestSetsIsNotSupersetOfFunctions()
         {
             // expect
-            Assert.That(
-                !Sets.Sets.Value.IsSupersetOf(Sets.Functions.RealsToReals));
+            Assert.False(
+                Sets.Sets.Value.IsSupersetOf(Sets.Functions.RealsToReals));
         }
 
         [Test]
         public void TestSetsIsNotSubsetOfFunctions()
         {
             // expect
-            Assert.That(
-                !Sets.Sets.Value.IsSubsetOf(Sets.Functions.RealsToReals));
+            Assert.False(
+                Sets.Sets.Value.IsSubsetOf(Sets.Functions.RealsToReals));
+        }
+
+        [Test]
+        public void TestSetsIsNotSupersetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                Sets.Sets.Value.IsSupersetOf(VariadicFunctions.RealsToReals));
+        }
+
+        [Test]
+        public void TestSetsIsNotSubsetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                Sets.Sets.Value.IsSubsetOf(VariadicFunctions.RealsToReals));
         }
 
         [Test]
         public void TestSetsIsNotSupersetOfTensors()
         {
             // expect
-            Assert.That(!Sets.Sets.Value.IsSupersetOf(Tensors.Value));
+            Assert.False(Sets.Sets.Value.IsSupersetOf(Tensors.Value));
         }
 
         [Test]
         public void TestSetsIsNotSubsetOfTensors()
         {
             // expect
-            Assert.That(!Sets.Sets.Value.IsSubsetOf(Tensors.Value));
+            Assert.False(Sets.Sets.Value.IsSubsetOf(Tensors.Value));
         }
 
         [Test]
         public void TestSetsIsNotSupersetOfAllVectors()
         {
             // expect
-            Assert.That(!Sets.Sets.Value.IsSupersetOf(AllVectors.Value));
+            Assert.False(Sets.Sets.Value.IsSupersetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestSetsIsNotSubsetOfAllVectors()
         {
             // expect
-            Assert.That(!Sets.Sets.Value.IsSubsetOf(AllVectors.Value));
+            Assert.False(Sets.Sets.Value.IsSubsetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestSetsIsNotSupersetOfVectors()
         {
             // expect
-            Assert.That(!Sets.Sets.Value.IsSupersetOf(Vectors.R2));
-            Assert.That(!Sets.Sets.Value.IsSupersetOf(Vectors.R3));
+            Assert.False(Sets.Sets.Value.IsSupersetOf(Vectors.R2));
+            Assert.False(Sets.Sets.Value.IsSupersetOf(Vectors.R3));
         }
 
         [Test]
         public void TestSetsIsNotSubsetOfVectors()
         {
             // expect
-            Assert.That(!Sets.Sets.Value.IsSubsetOf(Vectors.R2));
-            Assert.That(!Sets.Sets.Value.IsSubsetOf(Vectors.R3));
+            Assert.False(Sets.Sets.Value.IsSubsetOf(Vectors.R2));
+            Assert.False(Sets.Sets.Value.IsSubsetOf(Vectors.R3));
         }
 
         [Test]
         public void TestSetsIsNotSupersetOfAllMatrices()
         {
             // expect
-            Assert.That(!Sets.Sets.Value.IsSupersetOf(AllMatrices.Value));
+            Assert.False(Sets.Sets.Value.IsSupersetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestSetsIsNotSubsetOfAllMatrices()
         {
             // expect
-            Assert.That(!Sets.Sets.Value.IsSubsetOf(AllMatrices.Value));
+            Assert.False(Sets.Sets.Value.IsSubsetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestSetsIsNotSupersetOfMatrices()
         {
             // expect
-            Assert.That(!Sets.Sets.Value.IsSupersetOf(Matrices.M2x2));
-            Assert.That(!Sets.Sets.Value.IsSupersetOf(Matrices.M3x3));
+            Assert.False(Sets.Sets.Value.IsSupersetOf(Matrices.M2x2));
+            Assert.False(Sets.Sets.Value.IsSupersetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestSetsIsNotSubsetOfMatrices()
         {
             // expect
-            Assert.That(!Sets.Sets.Value.IsSubsetOf(Matrices.M2x2));
-            Assert.That(!Sets.Sets.Value.IsSubsetOf(Matrices.M3x3));
+            Assert.False(Sets.Sets.Value.IsSubsetOf(Matrices.M2x2));
+            Assert.False(Sets.Sets.Value.IsSubsetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestSetsIsNotSupersetOfReals()
         {
             // expect
-            Assert.That(!Sets.Sets.Value.IsSupersetOf(Reals.Value));
+            Assert.False(Sets.Sets.Value.IsSupersetOf(Reals.Value));
         }
 
         [Test]
         public void TestSetsIsNotSubsetOfReals()
         {
             // expect
-            Assert.That(!Sets.Sets.Value.IsSubsetOf(Reals.Value));
+            Assert.False(Sets.Sets.Value.IsSubsetOf(Reals.Value));
         }
 
         [Test]
         public void TestSetsIsNotSupersetOfStrings()
         {
             // expect
-            Assert.That(!Sets.Sets.Value.IsSupersetOf(Strings.Value));
+            Assert.False(Sets.Sets.Value.IsSupersetOf(Strings.Value));
         }
 
         [Test]
         public void TestSetsIsNotSubsetOfStrings()
         {
             // expect
-            Assert.That(!Sets.Sets.Value.IsSubsetOf(Strings.Value));
+            Assert.False(Sets.Sets.Value.IsSubsetOf(Strings.Value));
         }
 
         [Test]
         public void TestSetsIsNotSupersetOfIntervals()
         {
             // expect
-            Assert.That(!Sets.Sets.Value.IsSupersetOf(Intervals.Value));
+            Assert.False(Sets.Sets.Value.IsSupersetOf(Intervals.Value));
         }
 
         [Test]
         public void TestSetsIsNotSubsetOfIntervals()
         {
             // expect
-            Assert.That(!Sets.Sets.Value.IsSubsetOf(Intervals.Value));
+            Assert.False(Sets.Sets.Value.IsSubsetOf(Intervals.Value));
         }
 
         [Test]
         public void TestSetsIsNotSupersetOfBooleans()
         {
             // expect
-            Assert.That(!Sets.Sets.Value.IsSupersetOf(Booleans.Value));
+            Assert.False(Sets.Sets.Value.IsSupersetOf(Booleans.Value));
         }
 
         [Test]
         public void TestSetsIsNotSubsetOfBooleans()
         {
             // expect
-            Assert.That(!Sets.Sets.Value.IsSubsetOf(Booleans.Value));
+            Assert.False(Sets.Sets.Value.IsSubsetOf(Booleans.Value));
         }
 
         [Test]
         public void TestSetsIsNotSupersetOfExpressions()
         {
             // expect
-            Assert.That(!Sets.Sets.Value.IsSupersetOf(Sets.Expressions.Value));
+            Assert.False(
+                Sets.Sets.Value.IsSupersetOf(Sets.Expressions.Value));
         }
 
         [Test]
         public void TestSetsIsNotSubsetOfExpressions()
         {
             // expect
-            Assert.That(!Sets.Sets.Value.IsSubsetOf(Sets.Expressions.Value));
+            Assert.False(Sets.Sets.Value.IsSubsetOf(Sets.Expressions.Value));
         }
 
         [Test]
         public void TestSetsIsNotSupersetOfLiterals()
         {
             // expect
-            Assert.That(!Sets.Sets.Value.IsSupersetOf(Literals.Value));
+            Assert.False(Sets.Sets.Value.IsSupersetOf(Literals.Value));
         }
 
         [Test]
         public void TestSetsIsNotSubsetOfLiterals()
         {
             // expect
-            Assert.That(!Sets.Sets.Value.IsSubsetOf(Literals.Value));
+            Assert.False(Sets.Sets.Value.IsSubsetOf(Literals.Value));
         }
 
         [Test]
         public void TestSetsIsNotSupersetOfComponentAccesses()
         {
             // expect
-            Assert.That(!Sets.Sets.Value.IsSupersetOf(
-                ComponentAccesses.Value));
+            Assert.False(
+                Sets.Sets.Value.IsSupersetOf(ComponentAccesses.Value));
         }
 
         [Test]
         public void TestSetsIsNotSubsetOfComponentAccesses()
         {
             // expect
-            Assert.That(!Sets.Sets.Value.IsSubsetOf(ComponentAccesses.Value));
+            Assert.False(Sets.Sets.Value.IsSubsetOf(ComponentAccesses.Value));
         }
 
         [Test]
         public void TestSetsIsNotSupersetOfFunctionCalls()
         {
             // expect
-            Assert.That(!Sets.Sets.Value.IsSupersetOf(FunctionCalls.Value));
+            Assert.False(Sets.Sets.Value.IsSupersetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestSetsIsNotSubsetOfFunctionCalls()
         {
             // expect
-            Assert.That(!Sets.Sets.Value.IsSubsetOf(FunctionCalls.Value));
+            Assert.False(Sets.Sets.Value.IsSubsetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestSetsIsNotSupersetOfIntervalExpressions()
         {
             // expect
-            Assert.That(
-                !Sets.Sets.Value.IsSupersetOf(IntervalExpressions.Value));
+            Assert.False(
+                Sets.Sets.Value.IsSupersetOf(IntervalExpressions.Value));
         }
 
         [Test]
         public void TestSetsIsNotSubsetOfIntervalExpressions()
         {
             // expect
-            Assert.That(!Sets.Sets.Value.IsSubsetOf(
-                IntervalExpressions.Value));
+            Assert.False(
+                Sets.Sets.Value.IsSubsetOf(IntervalExpressions.Value));
         }
 
         [Test]
         public void TestSetsIsNotSupersetOfTensorExpressions()
         {
             // expect
-            Assert.That(!Sets.Sets.Value.IsSupersetOf(
-                TensorExpressions.Value));
+            Assert.False(
+                Sets.Sets.Value.IsSupersetOf(TensorExpressions.Value));
         }
 
         [Test]
         public void TestSetsIsNotSubsetOfTensorExpressions()
         {
             // expect
-            Assert.That(!Sets.Sets.Value.IsSubsetOf(TensorExpressions.Value));
+            Assert.False(Sets.Sets.Value.IsSubsetOf(TensorExpressions.Value));
         }
 
         [Test]
         public void TestSetsIsNotSupersetOfMatrixExpressions()
         {
             // expect
-            Assert.That(!Sets.Sets.Value.IsSupersetOf(
-                MatrixExpressions.Value));
+            Assert.False(
+                Sets.Sets.Value.IsSupersetOf(MatrixExpressions.Value));
         }
 
         [Test]
         public void TestSetsIsNotSubsetOfMatrixExpressions()
         {
             // expect
-            Assert.That(!Sets.Sets.Value.IsSubsetOf(MatrixExpressions.Value));
+            Assert.False(Sets.Sets.Value.IsSubsetOf(MatrixExpressions.Value));
         }
 
         [Test]
         public void TestSetsIsNotSupersetOfVectorExpressions()
         {
             // expect
-            Assert.That(!Sets.Sets.Value.IsSupersetOf(
-                VectorExpressions.Value));
+            Assert.False(
+                Sets.Sets.Value.IsSupersetOf(VectorExpressions.Value));
         }
 
         [Test]
         public void TestSetsIsNotSubsetOfVectorExpressions()
         {
             // expect
-            Assert.That(!Sets.Sets.Value.IsSubsetOf(VectorExpressions.Value));
+            Assert.False(Sets.Sets.Value.IsSubsetOf(VectorExpressions.Value));
         }
 
         [Test]
         public void TestSetsIsNotSupersetOfVariableAccesses()
         {
             // expect
-            Assert.That(!Sets.Sets.Value.IsSupersetOf(VariableAccesses.Value));
+            Assert.False(
+                Sets.Sets.Value.IsSupersetOf(VariableAccesses.Value));
         }
 
         [Test]
         public void TestSetsIsNotSubsetOfVariableAccesses()
         {
             // expect
-            Assert.That(!Sets.Sets.Value.IsSubsetOf(VariableAccesses.Value));
+            Assert.False(Sets.Sets.Value.IsSubsetOf(VariableAccesses.Value));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/SetsT/StringsT/SupersetAndSubsetTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/SetsT/StringsT/SupersetAndSubsetTest.cs
@@ -32,315 +32,331 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.StringsT
         public void TestStringsIsNotSupersetOfMathObjects()
         {
             // expect
-            Assert.That(!Strings.Value.IsSupersetOf(MathObjects.Value));
+            Assert.False(Strings.Value.IsSupersetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestStringsIsSubsetOfMathObjects()
         {
             // expect
-            Assert.That(Strings.Value.IsSubsetOf(MathObjects.Value));
+            Assert.True(Strings.Value.IsSubsetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestStringsIsNotSupersetOfSets()
         {
             // expect
-            Assert.That(!Strings.Value.IsSupersetOf(Sets.Sets.Value));
+            Assert.False(Strings.Value.IsSupersetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestStringsIsNotSubsetOfSets()
         {
             // expect
-            Assert.That(!Strings.Value.IsSubsetOf(Sets.Sets.Value));
+            Assert.False(Strings.Value.IsSubsetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestStringsIsNotSupersetOfAllFunctions()
         {
             // expect
-            Assert.That(!Strings.Value.IsSupersetOf(AllFunctions.Value));
+            Assert.False(Strings.Value.IsSupersetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestStringsIsNotSubsetOfAllFunctions()
         {
             // expect
-            Assert.That(!Strings.Value.IsSubsetOf(AllFunctions.Value));
+            Assert.False(Strings.Value.IsSubsetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestStringsIsNotSupersetOfFunctions()
         {
             // expect
-            Assert.That(
-                !Strings.Value.IsSupersetOf(Sets.Functions.RealsToReals));
+            Assert.False(
+                Strings.Value.IsSupersetOf(Sets.Functions.RealsToReals));
         }
 
         [Test]
         public void TestStringsIsNotSubsetOfFunctions()
         {
             // expect
-            Assert.That(!Strings.Value.IsSubsetOf(
-                Sets.Functions.RealsToReals));
+            Assert.False(
+                Strings.Value.IsSubsetOf(Sets.Functions.RealsToReals));
+        }
+
+        [Test]
+        public void TestStringsIsNotSupersetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                Strings.Value.IsSupersetOf(VariadicFunctions.RealsToReals));
+        }
+
+        [Test]
+        public void TestStringsIsNotSubsetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                Strings.Value.IsSubsetOf(VariadicFunctions.RealsToReals));
         }
 
         [Test]
         public void TestStringsIsNotSupersetOfTensors()
         {
             // expect
-            Assert.That(!Strings.Value.IsSupersetOf(Tensors.Value));
+            Assert.False(Strings.Value.IsSupersetOf(Tensors.Value));
         }
 
         [Test]
         public void TestStringsIsNotSubsetOfTensors()
         {
             // expect
-            Assert.That(!Strings.Value.IsSubsetOf(Tensors.Value));
+            Assert.False(Strings.Value.IsSubsetOf(Tensors.Value));
         }
 
         [Test]
         public void TestStringsIsNotSupersetOfAllVectors()
         {
             // expect
-            Assert.That(!Strings.Value.IsSupersetOf(AllVectors.Value));
+            Assert.False(Strings.Value.IsSupersetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestStringsIsNotSubsetOfAllVectors()
         {
             // expect
-            Assert.That(!Strings.Value.IsSubsetOf(AllVectors.Value));
+            Assert.False(Strings.Value.IsSubsetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestStringsIsNotSupersetOfVectors()
         {
             // expect
-            Assert.That(!Strings.Value.IsSupersetOf(Vectors.R2));
-            Assert.That(!Strings.Value.IsSupersetOf(Vectors.R3));
+            Assert.False(Strings.Value.IsSupersetOf(Vectors.R2));
+            Assert.False(Strings.Value.IsSupersetOf(Vectors.R3));
         }
 
         [Test]
         public void TestStringsIsNotSubsetOfVectors()
         {
             // expect
-            Assert.That(!Strings.Value.IsSubsetOf(Vectors.R2));
-            Assert.That(!Strings.Value.IsSubsetOf(Vectors.R3));
+            Assert.False(Strings.Value.IsSubsetOf(Vectors.R2));
+            Assert.False(Strings.Value.IsSubsetOf(Vectors.R3));
         }
 
         [Test]
         public void TestStringsIsNotSupersetOfAllMatrices()
         {
             // expect
-            Assert.That(!Strings.Value.IsSupersetOf(AllMatrices.Value));
+            Assert.False(Strings.Value.IsSupersetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestStringsIsNotSubsetOfAllMatrices()
         {
             // expect
-            Assert.That(!Strings.Value.IsSubsetOf(AllMatrices.Value));
+            Assert.False(Strings.Value.IsSubsetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestStringsIsNotSupersetOfMatrices()
         {
             // expect
-            Assert.That(!Strings.Value.IsSupersetOf(Matrices.M2x2));
-            Assert.That(!Strings.Value.IsSupersetOf(Matrices.M3x3));
+            Assert.False(Strings.Value.IsSupersetOf(Matrices.M2x2));
+            Assert.False(Strings.Value.IsSupersetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestStringsIsNotSubsetOfMatrices()
         {
             // expect
-            Assert.That(!Strings.Value.IsSubsetOf(Matrices.M2x2));
-            Assert.That(!Strings.Value.IsSubsetOf(Matrices.M3x3));
+            Assert.False(Strings.Value.IsSubsetOf(Matrices.M2x2));
+            Assert.False(Strings.Value.IsSubsetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestStringsIsNotSupersetOfReals()
         {
             // expect
-            Assert.That(!Strings.Value.IsSupersetOf(Reals.Value));
+            Assert.False(Strings.Value.IsSupersetOf(Reals.Value));
         }
 
         [Test]
         public void TestStringsIsNotSubsetOfReals()
         {
             // expect
-            Assert.That(!Strings.Value.IsSubsetOf(Reals.Value));
+            Assert.False(Strings.Value.IsSubsetOf(Reals.Value));
         }
 
         [Test]
         public void TestStringsIsSupersetOfSelf()
         {
             // expect
-            Assert.That(Strings.Value.IsSupersetOf(Strings.Value));
+            Assert.True(Strings.Value.IsSupersetOf(Strings.Value));
         }
 
         [Test]
         public void TestStringsIsSubsetOfSelf()
         {
             // expect
-            Assert.That(Strings.Value.IsSubsetOf(Strings.Value));
+            Assert.True(Strings.Value.IsSubsetOf(Strings.Value));
         }
 
         [Test]
         public void TestStringsIsNotSupersetOfIntervals()
         {
             // expect
-            Assert.That(!Strings.Value.IsSupersetOf(Intervals.Value));
+            Assert.False(Strings.Value.IsSupersetOf(Intervals.Value));
         }
 
         [Test]
         public void TestStringsIsNotSubsetOfIntervals()
         {
             // expect
-            Assert.That(!Strings.Value.IsSubsetOf(Intervals.Value));
+            Assert.False(Strings.Value.IsSubsetOf(Intervals.Value));
         }
 
         [Test]
         public void TestStringsIsNotSupersetOfBooleans()
         {
             // expect
-            Assert.That(!Strings.Value.IsSupersetOf(Booleans.Value));
+            Assert.False(Strings.Value.IsSupersetOf(Booleans.Value));
         }
 
         [Test]
         public void TestStringsIsNotSubsetOfBooleans()
         {
             // expect
-            Assert.That(!Strings.Value.IsSubsetOf(Booleans.Value));
+            Assert.False(Strings.Value.IsSubsetOf(Booleans.Value));
         }
 
         [Test]
         public void TestStringsIsNotSupersetOfExpressions()
         {
             // expect
-            Assert.That(!Strings.Value.IsSupersetOf(Sets.Expressions.Value));
+            Assert.False(Strings.Value.IsSupersetOf(Sets.Expressions.Value));
         }
 
         [Test]
         public void TestStringsIsNotSubsetOfExpressions()
         {
             // expect
-            Assert.That(!Strings.Value.IsSubsetOf(Sets.Expressions.Value));
+            Assert.False(Strings.Value.IsSubsetOf(Sets.Expressions.Value));
         }
 
         [Test]
         public void TestStringsIsNotSupersetOfLiterals()
         {
             // expect
-            Assert.That(!Strings.Value.IsSupersetOf(Literals.Value));
+            Assert.False(Strings.Value.IsSupersetOf(Literals.Value));
         }
 
         [Test]
         public void TestStringsIsNotSubsetOfLiterals()
         {
             // expect
-            Assert.That(!Strings.Value.IsSubsetOf(Literals.Value));
+            Assert.False(Strings.Value.IsSubsetOf(Literals.Value));
         }
 
         [Test]
         public void TestStringsIsNotSupersetOfComponentAccesses()
         {
             // expect
-            Assert.That(!Strings.Value.IsSupersetOf(ComponentAccesses.Value));
+            Assert.False(Strings.Value.IsSupersetOf(ComponentAccesses.Value));
         }
 
         [Test]
         public void TestStringsIsNotSubsetOfComponentAccesses()
         {
             // expect
-            Assert.That(!Strings.Value.IsSubsetOf(ComponentAccesses.Value));
+            Assert.False(Strings.Value.IsSubsetOf(ComponentAccesses.Value));
         }
 
         [Test]
         public void TestStringsIsNotSupersetOfFunctionCalls()
         {
             // expect
-            Assert.That(!Strings.Value.IsSupersetOf(FunctionCalls.Value));
+            Assert.False(Strings.Value.IsSupersetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestStringsIsNotSubsetOfFunctionCalls()
         {
             // expect
-            Assert.That(!Strings.Value.IsSubsetOf(FunctionCalls.Value));
+            Assert.False(Strings.Value.IsSubsetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestStringsIsNotSupersetOfIntervalExpressions()
         {
             // expect
-            Assert.That(!Strings.Value.IsSupersetOf(
-                IntervalExpressions.Value));
+            Assert.False(
+                Strings.Value.IsSupersetOf(IntervalExpressions.Value));
         }
 
         [Test]
         public void TestStringsIsNotSubsetOfIntervalExpressions()
         {
             // expect
-            Assert.That(!Strings.Value.IsSubsetOf(IntervalExpressions.Value));
+            Assert.False(Strings.Value.IsSubsetOf(IntervalExpressions.Value));
         }
 
         [Test]
         public void TestStringsIsNotSupersetOfTensorExpressions()
         {
             // expect
-            Assert.That(!Strings.Value.IsSupersetOf(TensorExpressions.Value));
+            Assert.False(Strings.Value.IsSupersetOf(TensorExpressions.Value));
         }
 
         [Test]
         public void TestStringsIsNotSubsetOfTensorExpressions()
         {
             // expect
-            Assert.That(!Strings.Value.IsSubsetOf(TensorExpressions.Value));
+            Assert.False(Strings.Value.IsSubsetOf(TensorExpressions.Value));
         }
 
         [Test]
         public void TestStringsIsNotSupersetOfMatrixExpressions()
         {
             // expect
-            Assert.That(!Strings.Value.IsSupersetOf(MatrixExpressions.Value));
+            Assert.False(Strings.Value.IsSupersetOf(MatrixExpressions.Value));
         }
 
         [Test]
         public void TestStringsIsNotSubsetOfMatrixExpressions()
         {
             // expect
-            Assert.That(!Strings.Value.IsSubsetOf(MatrixExpressions.Value));
+            Assert.False(Strings.Value.IsSubsetOf(MatrixExpressions.Value));
         }
 
         [Test]
         public void TestStringsIsNotSupersetOfVectorExpressions()
         {
             // expect
-            Assert.That(!Strings.Value.IsSupersetOf(VectorExpressions.Value));
+            Assert.False(Strings.Value.IsSupersetOf(VectorExpressions.Value));
         }
 
         [Test]
         public void TestStringsIsNotSubsetOfVectorExpressions()
         {
             // expect
-            Assert.That(!Strings.Value.IsSubsetOf(VectorExpressions.Value));
+            Assert.False(Strings.Value.IsSubsetOf(VectorExpressions.Value));
         }
 
         [Test]
         public void TestStringsIsNotSupersetOfVariableAccesses()
         {
             // expect
-            Assert.That(!Strings.Value.IsSupersetOf(VariableAccesses.Value));
+            Assert.False(Strings.Value.IsSupersetOf(VariableAccesses.Value));
         }
 
         [Test]
         public void TestStringsIsNotSubsetOfVariableAccesses()
         {
             // expect
-            Assert.That(!Strings.Value.IsSubsetOf(VariableAccesses.Value));
+            Assert.False(Strings.Value.IsSubsetOf(VariableAccesses.Value));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/SetsT/TensorExpressionsT/SupersetAndSubsetTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/SetsT/TensorExpressionsT/SupersetAndSubsetTest.cs
@@ -32,213 +32,234 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.TensorExpressionsT
         public void TestTensorExpressionsIsNotSupersetOfMathObjects()
         {
             // expect
-            Assert.That(
-                !TensorExpressions.Value.IsSupersetOf(MathObjects.Value));
+            Assert.False(
+                TensorExpressions.Value.IsSupersetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestTensorExpressionsIsSubsetOfMathObjects()
         {
             // expect
-            Assert.That(TensorExpressions.Value.IsSubsetOf(MathObjects.Value));
+            Assert.True(
+                TensorExpressions.Value.IsSubsetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestTensorExpressionsIsNotSupersetOfSets()
         {
             // expect
-            Assert.That(!TensorExpressions.Value.IsSupersetOf(
-                Sets.Sets.Value));
+            Assert.False(
+                TensorExpressions.Value.IsSupersetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestTensorExpressionsIsNotSubsetOfSets()
         {
             // expect
-            Assert.That(!TensorExpressions.Value.IsSubsetOf(Sets.Sets.Value));
+            Assert.False(TensorExpressions.Value.IsSubsetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestTensorExpressionsIsNotSupersetOfAllFunctions()
         {
             // expect
-            Assert.That(
-                !TensorExpressions.Value.IsSupersetOf(AllFunctions.Value));
+            Assert.False(
+                TensorExpressions.Value.IsSupersetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestTensorExpressionsIsNotSubsetOfAllFunctions()
         {
             // expect
-            Assert.That(
-                !TensorExpressions.Value.IsSubsetOf(AllFunctions.Value));
+            Assert.False(
+                TensorExpressions.Value.IsSubsetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestTensorExpressionsIsNotSupersetOfFunctions()
         {
             // expect
-            Assert.That(
-                !TensorExpressions.Value.IsSupersetOf(Sets.Functions
-                    .RealsToReals));
+            Assert.False(
+                TensorExpressions.Value.IsSupersetOf(
+                    Sets.Functions.RealsToReals));
         }
 
         [Test]
         public void TestTensorExpressionsIsNotSubsetOfFunctions()
         {
             // expect
-            Assert.That(
-                !TensorExpressions.Value.IsSubsetOf(Sets.Functions
-                    .RealsToReals));
+            Assert.False(
+                TensorExpressions.Value.IsSubsetOf(
+                    Sets.Functions.RealsToReals));
+        }
+
+        [Test]
+        public void TestTensorExpressionsIsNotSupersetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                TensorExpressions.Value.IsSupersetOf(
+                    VariadicFunctions.RealsToReals));
+        }
+
+        [Test]
+        public void TestTensorExpressionsIsNotSubsetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                TensorExpressions.Value.IsSubsetOf(
+                    VariadicFunctions.RealsToReals));
         }
 
         [Test]
         public void TestTensorExpressionsIsNotSupersetOfTensors()
         {
             // expect
-            Assert.That(!TensorExpressions.Value.IsSupersetOf(Tensors.Value));
+            Assert.False(TensorExpressions.Value.IsSupersetOf(Tensors.Value));
         }
 
         [Test]
         public void TestTensorExpressionsIsNotSubsetOfTensors()
         {
             // expect
-            Assert.That(!TensorExpressions.Value.IsSubsetOf(Tensors.Value));
+            Assert.False(TensorExpressions.Value.IsSubsetOf(Tensors.Value));
         }
 
         [Test]
         public void TestTensorExpressionsIsNotSupersetOfAllVectors()
         {
             // expect
-            Assert.That(
-                !TensorExpressions.Value.IsSupersetOf(AllVectors.Value));
+            Assert.False(
+                TensorExpressions.Value.IsSupersetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestTensorExpressionsIsNotSubsetOfAllVectors()
         {
             // expect
-            Assert.That(!TensorExpressions.Value.IsSubsetOf(AllVectors.Value));
+            Assert.False(
+                TensorExpressions.Value.IsSubsetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestTensorExpressionsIsNotSupersetOfVectors()
         {
             // expect
-            Assert.That(!TensorExpressions.Value.IsSupersetOf(Vectors.R2));
-            Assert.That(!TensorExpressions.Value.IsSupersetOf(Vectors.R3));
+            Assert.False(TensorExpressions.Value.IsSupersetOf(Vectors.R2));
+            Assert.False(TensorExpressions.Value.IsSupersetOf(Vectors.R3));
         }
 
         [Test]
         public void TestTensorExpressionsIsNotSubsetOfVectors()
         {
             // expect
-            Assert.That(!TensorExpressions.Value.IsSubsetOf(Vectors.R2));
-            Assert.That(!TensorExpressions.Value.IsSubsetOf(Vectors.R3));
+            Assert.False(TensorExpressions.Value.IsSubsetOf(Vectors.R2));
+            Assert.False(TensorExpressions.Value.IsSubsetOf(Vectors.R3));
         }
 
         [Test]
         public void TestTensorExpressionsIsNotSupersetOfAllMatrices()
         {
             // expect
-            Assert.That(
-                !TensorExpressions.Value.IsSupersetOf(AllMatrices.Value));
+            Assert.False(
+                TensorExpressions.Value.IsSupersetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestTensorExpressionsIsNotSubsetOfAllMatrices()
         {
             // expect
-            Assert.That(!TensorExpressions.Value.IsSubsetOf(
-                AllMatrices.Value));
+            Assert.False(
+                TensorExpressions.Value.IsSubsetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestTensorExpressionsIsNotSupersetOfMatrices()
         {
             // expect
-            Assert.That(!TensorExpressions.Value.IsSupersetOf(Matrices.M2x2));
-            Assert.That(!TensorExpressions.Value.IsSupersetOf(Matrices.M3x3));
+            Assert.False(TensorExpressions.Value.IsSupersetOf(Matrices.M2x2));
+            Assert.False(TensorExpressions.Value.IsSupersetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestTensorExpressionsIsNotSubsetOfMatrices()
         {
             // expect
-            Assert.That(!TensorExpressions.Value.IsSubsetOf(Matrices.M2x2));
-            Assert.That(!TensorExpressions.Value.IsSubsetOf(Matrices.M3x3));
+            Assert.False(TensorExpressions.Value.IsSubsetOf(Matrices.M2x2));
+            Assert.False(TensorExpressions.Value.IsSubsetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestTensorExpressionsIsNotSupersetOfReals()
         {
             // expect
-            Assert.That(!TensorExpressions.Value.IsSupersetOf(Reals.Value));
+            Assert.False(TensorExpressions.Value.IsSupersetOf(Reals.Value));
         }
 
         [Test]
         public void TestTensorExpressionsIsNotSubsetOfReals()
         {
             // expect
-            Assert.That(!TensorExpressions.Value.IsSubsetOf(Reals.Value));
+            Assert.False(TensorExpressions.Value.IsSubsetOf(Reals.Value));
         }
 
         [Test]
         public void TestTensorExpressionsIsNotSupersetOfStrings()
         {
             // expect
-            Assert.That(!TensorExpressions.Value.IsSupersetOf(Strings.Value));
+            Assert.False(TensorExpressions.Value.IsSupersetOf(Strings.Value));
         }
 
         [Test]
         public void TestTensorExpressionsIsNotSubsetOfStrings()
         {
             // expect
-            Assert.That(!TensorExpressions.Value.IsSubsetOf(Strings.Value));
+            Assert.False(TensorExpressions.Value.IsSubsetOf(Strings.Value));
         }
 
         [Test]
         public void TestTensorExpressionsIsNotSupersetOfIntervals()
         {
             // expect
-            Assert.That(!TensorExpressions.Value.IsSupersetOf(
-                Intervals.Value));
+            Assert.False(
+                TensorExpressions.Value.IsSupersetOf(Intervals.Value));
         }
 
         [Test]
         public void TestTensorExpressionsIsNotSubsetOfIntervals()
         {
             // expect
-            Assert.That(!TensorExpressions.Value.IsSubsetOf(Intervals.Value));
+            Assert.False(TensorExpressions.Value.IsSubsetOf(Intervals.Value));
         }
 
         [Test]
         public void TestTensorExpressionsIsNotSupersetOfBooleans()
         {
             // expect
-            Assert.That(!TensorExpressions.Value.IsSupersetOf(Booleans.Value));
+            Assert.False(
+                TensorExpressions.Value.IsSupersetOf(Booleans.Value));
         }
 
         [Test]
         public void TestTensorExpressionsIsNotSubsetOfBooleans()
         {
             // expect
-            Assert.That(!TensorExpressions.Value.IsSubsetOf(Booleans.Value));
+            Assert.False(TensorExpressions.Value.IsSubsetOf(Booleans.Value));
         }
 
         [Test]
         public void TestTensorExpressionsIsNotSupersetOfExpressions()
         {
             // expect
-            Assert.That(
-                !TensorExpressions.Value.IsSupersetOf(Sets.Expressions.Value));
+            Assert.False(
+                TensorExpressions.Value.IsSupersetOf(Sets.Expressions.Value));
         }
 
         [Test]
         public void TestTensorExpressionsIsSubsetOfExpressions()
         {
             // expect
-            Assert.That(
+            Assert.True(
                 TensorExpressions.Value.IsSubsetOf(Sets.Expressions.Value));
         }
 
@@ -246,22 +267,23 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.TensorExpressionsT
         public void TestTensorExpressionsIsNotSupersetOfLiterals()
         {
             // expect
-            Assert.That(!TensorExpressions.Value.IsSupersetOf(Literals.Value));
+            Assert.False(
+                TensorExpressions.Value.IsSupersetOf(Literals.Value));
         }
 
         [Test]
         public void TestTensorExpressionsIsNotSubsetOfLiterals()
         {
             // expect
-            Assert.That(!TensorExpressions.Value.IsSubsetOf(Literals.Value));
+            Assert.False(TensorExpressions.Value.IsSubsetOf(Literals.Value));
         }
 
         [Test]
         public void TestTensorExpressionsIsNotSupersetOfComponentAccesses()
         {
             // expect
-            Assert.That(
-                !TensorExpressions.Value.IsSupersetOf(
+            Assert.False(
+                TensorExpressions.Value.IsSupersetOf(
                     ComponentAccesses.Value));
         }
 
@@ -269,41 +291,41 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.TensorExpressionsT
         public void TestTensorExpressionsIsNotSubsetOfComponentAccesses()
         {
             // expect
-            Assert.That(
-                !TensorExpressions.Value.IsSubsetOf(ComponentAccesses.Value));
+            Assert.False(
+                TensorExpressions.Value.IsSubsetOf(ComponentAccesses.Value));
         }
 
         [Test]
         public void TestTensorExpressionsIsNotSupersetOfFunctionCalls()
         {
             // expect
-            Assert.That(
-                !TensorExpressions.Value.IsSupersetOf(FunctionCalls.Value));
+            Assert.False(
+                TensorExpressions.Value.IsSupersetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestTensorExpressionsIsNotSubsetOfFunctionCalls()
         {
             // expect
-            Assert.That(
-                !TensorExpressions.Value.IsSubsetOf(FunctionCalls.Value));
+            Assert.False(
+                TensorExpressions.Value.IsSubsetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestTensorExpressionsIsNotSupersetOfIntervalExpressions()
         {
             // expect
-            Assert.That(
-                !TensorExpressions.Value.IsSupersetOf(IntervalExpressions
-                    .Value));
+            Assert.False(
+                TensorExpressions.Value.IsSupersetOf(
+                    IntervalExpressions.Value));
         }
 
         [Test]
         public void TestTensorExpressionsIsNotSubsetOfIntervalExpressions()
         {
             // expect
-            Assert.That(
-                !TensorExpressions.Value.IsSubsetOf(
+            Assert.False(
+                TensorExpressions.Value.IsSubsetOf(
                     IntervalExpressions.Value));
         }
 
@@ -311,15 +333,16 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.TensorExpressionsT
         public void TestTensorExpressionsIsSupersetOfSelf()
         {
             // expect
-            Assert.That(
-                TensorExpressions.Value.IsSupersetOf(TensorExpressions.Value));
+            Assert.True(
+                TensorExpressions.Value.IsSupersetOf(
+                    TensorExpressions.Value));
         }
 
         [Test]
         public void TestTensorExpressionsIsSubsetOfSelf()
         {
             // expect
-            Assert.That(
+            Assert.True(
                 TensorExpressions.Value.IsSubsetOf(TensorExpressions.Value));
         }
 
@@ -327,48 +350,50 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.TensorExpressionsT
         public void TestTensorExpressionsIsSupersetOfMatrixExpressions()
         {
             // expect
-            Assert.That(
-                TensorExpressions.Value.IsSupersetOf(MatrixExpressions.Value));
+            Assert.True(
+                TensorExpressions.Value.IsSupersetOf(
+                    MatrixExpressions.Value));
         }
 
         [Test]
         public void TestTensorExpressionsIsNotSubsetOfMatrixExpressions()
         {
             // expect
-            Assert.That(
-                !TensorExpressions.Value.IsSubsetOf(MatrixExpressions.Value));
+            Assert.False(
+                TensorExpressions.Value.IsSubsetOf(MatrixExpressions.Value));
         }
 
         [Test]
         public void TestTensorExpressionsIsSupersetOfVectorExpressions()
         {
             // expect
-            Assert.That(
-                TensorExpressions.Value.IsSupersetOf(VectorExpressions.Value));
+            Assert.True(
+                TensorExpressions.Value.IsSupersetOf(
+                    VectorExpressions.Value));
         }
 
         [Test]
         public void TestTensorExpressionsIsNotSubsetOfVectorExpressions()
         {
             // expect
-            Assert.That(
-                !TensorExpressions.Value.IsSubsetOf(VectorExpressions.Value));
+            Assert.False(
+                TensorExpressions.Value.IsSubsetOf(VectorExpressions.Value));
         }
 
         [Test]
         public void TestTensorExpressionsIsNotSupersetOfVariableAccesses()
         {
             // expect
-            Assert.That(
-                !TensorExpressions.Value.IsSupersetOf(VariableAccesses.Value));
+            Assert.False(
+                TensorExpressions.Value.IsSupersetOf(VariableAccesses.Value));
         }
 
         [Test]
         public void TestTensorExpressionsIsNotSubsetOfVariableAccesses()
         {
             // expect
-            Assert.That(
-                !TensorExpressions.Value.IsSubsetOf(VariableAccesses.Value));
+            Assert.False(
+                TensorExpressions.Value.IsSubsetOf(VariableAccesses.Value));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/SetsT/TensorsT/SupersetAndSubsetTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/SetsT/TensorsT/SupersetAndSubsetTest.cs
@@ -32,315 +32,331 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.TensorsT
         public void TestTensorsIsNotSupersetOfMathObjects()
         {
             // expect
-            Assert.That(!Tensors.Value.IsSupersetOf(MathObjects.Value));
+            Assert.False(Tensors.Value.IsSupersetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestTensorsIsSubsetOfMathObjects()
         {
             // expect
-            Assert.That(Tensors.Value.IsSubsetOf(MathObjects.Value));
+            Assert.True(Tensors.Value.IsSubsetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestTensorsIsNotSupersetOfSets()
         {
             // expect
-            Assert.That(!Tensors.Value.IsSupersetOf(Sets.Sets.Value));
+            Assert.False(Tensors.Value.IsSupersetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestTensorsIsNotSubsetOfSets()
         {
             // expect
-            Assert.That(!Tensors.Value.IsSubsetOf(Sets.Sets.Value));
+            Assert.False(Tensors.Value.IsSubsetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestTensorsIsNotSupersetOfAllFunctions()
         {
             // expect
-            Assert.That(!Tensors.Value.IsSupersetOf(AllFunctions.Value));
+            Assert.False(Tensors.Value.IsSupersetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestTensorsIsNotSubsetOfAllFunctions()
         {
             // expect
-            Assert.That(!Tensors.Value.IsSubsetOf(AllFunctions.Value));
+            Assert.False(Tensors.Value.IsSubsetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestTensorsIsNotSupersetOfFunctions()
         {
             // expect
-            Assert.That(
-                !Tensors.Value.IsSupersetOf(Sets.Functions.RealsToReals));
+            Assert.False(
+                Tensors.Value.IsSupersetOf(Sets.Functions.RealsToReals));
         }
 
         [Test]
         public void TestTensorsIsNotSubsetOfFunctions()
         {
             // expect
-            Assert.That(!Tensors.Value.IsSubsetOf(
-                Sets.Functions.RealsToReals));
+            Assert.False(
+                Tensors.Value.IsSubsetOf(Sets.Functions.RealsToReals));
+        }
+
+        [Test]
+        public void TestTensorsIsNotSupersetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                Tensors.Value.IsSupersetOf(VariadicFunctions.RealsToReals));
+        }
+
+        [Test]
+        public void TestTensorsIsNotSubsetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                Tensors.Value.IsSubsetOf(VariadicFunctions.RealsToReals));
         }
 
         [Test]
         public void TestTensorsIsSupersetOfSelf()
         {
             // expect
-            Assert.That(Tensors.Value.IsSupersetOf(Tensors.Value));
+            Assert.True(Tensors.Value.IsSupersetOf(Tensors.Value));
         }
 
         [Test]
         public void TestTensorsIsSubsetOfSelf()
         {
             // expect
-            Assert.That(Tensors.Value.IsSubsetOf(Tensors.Value));
+            Assert.True(Tensors.Value.IsSubsetOf(Tensors.Value));
         }
 
         [Test]
         public void TestTensorsIsSupersetOfAllVectors()
         {
             // expect
-            Assert.That(Tensors.Value.IsSupersetOf(AllVectors.Value));
+            Assert.True(Tensors.Value.IsSupersetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestTensorsIsNotSubsetOfAllVectors()
         {
             // expect
-            Assert.That(!Tensors.Value.IsSubsetOf(AllVectors.Value));
+            Assert.False(Tensors.Value.IsSubsetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestTensorsIsSupersetOfVectors()
         {
             // expect
-            Assert.That(Tensors.Value.IsSupersetOf(Vectors.R2));
-            Assert.That(Tensors.Value.IsSupersetOf(Vectors.R3));
+            Assert.True(Tensors.Value.IsSupersetOf(Vectors.R2));
+            Assert.True(Tensors.Value.IsSupersetOf(Vectors.R3));
         }
 
         [Test]
         public void TestTensorsIsNotSubsetOfVectors()
         {
             // expect
-            Assert.That(!Tensors.Value.IsSubsetOf(Vectors.R2));
-            Assert.That(!Tensors.Value.IsSubsetOf(Vectors.R3));
+            Assert.False(Tensors.Value.IsSubsetOf(Vectors.R2));
+            Assert.False(Tensors.Value.IsSubsetOf(Vectors.R3));
         }
 
         [Test]
         public void TestTensorsIsSupersetOfAllMatrices()
         {
             // expect
-            Assert.That(Tensors.Value.IsSupersetOf(AllMatrices.Value));
+            Assert.True(Tensors.Value.IsSupersetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestTensorsIsNotSubsetOfAllMatrices()
         {
             // expect
-            Assert.That(!Tensors.Value.IsSubsetOf(AllMatrices.Value));
+            Assert.False(Tensors.Value.IsSubsetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestTensorsIsSupersetOfMatrices()
         {
             // expect
-            Assert.That(Tensors.Value.IsSupersetOf(Matrices.M2x2));
-            Assert.That(Tensors.Value.IsSupersetOf(Matrices.M3x3));
+            Assert.True(Tensors.Value.IsSupersetOf(Matrices.M2x2));
+            Assert.True(Tensors.Value.IsSupersetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestTensorsIsNotSubsetOfMatrices()
         {
             // expect
-            Assert.That(!Tensors.Value.IsSubsetOf(Matrices.M2x2));
-            Assert.That(!Tensors.Value.IsSubsetOf(Matrices.M3x3));
+            Assert.False(Tensors.Value.IsSubsetOf(Matrices.M2x2));
+            Assert.False(Tensors.Value.IsSubsetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestTensorsIsNotSupersetOfReals()
         {
             // expect
-            Assert.That(!Tensors.Value.IsSupersetOf(Reals.Value));
+            Assert.False(Tensors.Value.IsSupersetOf(Reals.Value));
         }
 
         [Test]
         public void TestTensorsIsNotSubsetOfReals()
         {
             // expect
-            Assert.That(!Tensors.Value.IsSubsetOf(Reals.Value));
+            Assert.False(Tensors.Value.IsSubsetOf(Reals.Value));
         }
 
         [Test]
         public void TestTensorsIsNotSupersetOfStrings()
         {
             // expect
-            Assert.That(!Tensors.Value.IsSupersetOf(Strings.Value));
+            Assert.False(Tensors.Value.IsSupersetOf(Strings.Value));
         }
 
         [Test]
         public void TestTensorsIsNotSubsetOfStrings()
         {
             // expect
-            Assert.That(!Tensors.Value.IsSubsetOf(Strings.Value));
+            Assert.False(Tensors.Value.IsSubsetOf(Strings.Value));
         }
 
         [Test]
         public void TestTensorsIsNotSupersetOfIntervals()
         {
             // expect
-            Assert.That(!Tensors.Value.IsSupersetOf(Intervals.Value));
+            Assert.False(Tensors.Value.IsSupersetOf(Intervals.Value));
         }
 
         [Test]
         public void TestTensorsIsNotSubsetOfIntervals()
         {
             // expect
-            Assert.That(!Tensors.Value.IsSubsetOf(Intervals.Value));
+            Assert.False(Tensors.Value.IsSubsetOf(Intervals.Value));
         }
 
         [Test]
         public void TestTensorsIsNotSupersetOfBooleans()
         {
             // expect
-            Assert.That(!Tensors.Value.IsSupersetOf(Booleans.Value));
+            Assert.False(Tensors.Value.IsSupersetOf(Booleans.Value));
         }
 
         [Test]
         public void TestTensorsIsNotSubsetOfBooleans()
         {
             // expect
-            Assert.That(!Tensors.Value.IsSubsetOf(Booleans.Value));
+            Assert.False(Tensors.Value.IsSubsetOf(Booleans.Value));
         }
 
         [Test]
         public void TestTensorsIsNotSupersetOfExpressions()
         {
             // expect
-            Assert.That(!Tensors.Value.IsSupersetOf(Sets.Expressions.Value));
+            Assert.False(Tensors.Value.IsSupersetOf(Sets.Expressions.Value));
         }
 
         [Test]
         public void TestTensorsIsNotSubsetOfExpressions()
         {
             // expect
-            Assert.That(!Tensors.Value.IsSubsetOf(Sets.Expressions.Value));
+            Assert.False(Tensors.Value.IsSubsetOf(Sets.Expressions.Value));
         }
 
         [Test]
         public void TestTensorsIsNotSupersetOfLiterals()
         {
             // expect
-            Assert.That(!Tensors.Value.IsSupersetOf(Literals.Value));
+            Assert.False(Tensors.Value.IsSupersetOf(Literals.Value));
         }
 
         [Test]
         public void TestTensorsIsNotSubsetOfLiterals()
         {
             // expect
-            Assert.That(!Tensors.Value.IsSubsetOf(Literals.Value));
+            Assert.False(Tensors.Value.IsSubsetOf(Literals.Value));
         }
 
         [Test]
         public void TestTensorsIsNotSupersetOfComponentAccesses()
         {
             // expect
-            Assert.That(!Tensors.Value.IsSupersetOf(ComponentAccesses.Value));
+            Assert.False(Tensors.Value.IsSupersetOf(ComponentAccesses.Value));
         }
 
         [Test]
         public void TestTensorsIsNotSubsetOfComponentAccesses()
         {
             // expect
-            Assert.That(!Tensors.Value.IsSubsetOf(ComponentAccesses.Value));
+            Assert.False(Tensors.Value.IsSubsetOf(ComponentAccesses.Value));
         }
 
         [Test]
         public void TestTensorsIsNotSupersetOfFunctionCalls()
         {
             // expect
-            Assert.That(!Tensors.Value.IsSupersetOf(FunctionCalls.Value));
+            Assert.False(Tensors.Value.IsSupersetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestTensorsIsNotSubsetOfFunctionCalls()
         {
             // expect
-            Assert.That(!Tensors.Value.IsSubsetOf(FunctionCalls.Value));
+            Assert.False(Tensors.Value.IsSubsetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestTensorsIsNotSupersetOfIntervalExpressions()
         {
             // expect
-            Assert.That(!Tensors.Value.IsSupersetOf(
-                IntervalExpressions.Value));
+            Assert.False(
+                Tensors.Value.IsSupersetOf(IntervalExpressions.Value));
         }
 
         [Test]
         public void TestTensorsIsNotSubsetOfIntervalExpressions()
         {
             // expect
-            Assert.That(!Tensors.Value.IsSubsetOf(IntervalExpressions.Value));
+            Assert.False(Tensors.Value.IsSubsetOf(IntervalExpressions.Value));
         }
 
         [Test]
         public void TestTensorsIsNotSupersetOfTensorExpressions()
         {
             // expect
-            Assert.That(!Tensors.Value.IsSupersetOf(TensorExpressions.Value));
+            Assert.False(Tensors.Value.IsSupersetOf(TensorExpressions.Value));
         }
 
         [Test]
         public void TestTensorsIsNotSubsetOfTensorExpressions()
         {
             // expect
-            Assert.That(!Tensors.Value.IsSubsetOf(TensorExpressions.Value));
+            Assert.False(Tensors.Value.IsSubsetOf(TensorExpressions.Value));
         }
 
         [Test]
         public void TestTensorsIsNotSupersetOfMatrixExpressions()
         {
             // expect
-            Assert.That(!Tensors.Value.IsSupersetOf(MatrixExpressions.Value));
+            Assert.False(Tensors.Value.IsSupersetOf(MatrixExpressions.Value));
         }
 
         [Test]
         public void TestTensorsIsNotSubsetOfMatrixExpressions()
         {
             // expect
-            Assert.That(!Tensors.Value.IsSubsetOf(MatrixExpressions.Value));
+            Assert.False(Tensors.Value.IsSubsetOf(MatrixExpressions.Value));
         }
 
         [Test]
         public void TestTensorsIsNotSupersetOfVectorExpressions()
         {
             // expect
-            Assert.That(!Tensors.Value.IsSupersetOf(VectorExpressions.Value));
+            Assert.False(Tensors.Value.IsSupersetOf(VectorExpressions.Value));
         }
 
         [Test]
         public void TestTensorsIsNotSubsetOfVectorExpressions()
         {
             // expect
-            Assert.That(!Tensors.Value.IsSubsetOf(VectorExpressions.Value));
+            Assert.False(Tensors.Value.IsSubsetOf(VectorExpressions.Value));
         }
 
         [Test]
         public void TestTensorsIsNotSupersetOfVariableAccesses()
         {
             // expect
-            Assert.That(!Tensors.Value.IsSupersetOf(VariableAccesses.Value));
+            Assert.False(Tensors.Value.IsSupersetOf(VariableAccesses.Value));
         }
 
         [Test]
         public void TestTensorsIsNotSubsetOfVariableAccesses()
         {
             // expect
-            Assert.That(!Tensors.Value.IsSubsetOf(VariableAccesses.Value));
+            Assert.False(Tensors.Value.IsSubsetOf(VariableAccesses.Value));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/SetsT/VariableAccessesT/SupersetAndSubsetTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/SetsT/VariableAccessesT/SupersetAndSubsetTest.cs
@@ -32,53 +32,54 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.VariableAccessesT
         public void TestVariableAccessesIsNotSupersetOfMathObjects()
         {
             // expect
-            Assert.That(
-                !VariableAccesses.Value.IsSupersetOf(MathObjects.Value));
+            Assert.False(
+                VariableAccesses.Value.IsSupersetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestVariableAccessesIsSubsetOfMathObjects()
         {
             // expect
-            Assert.That(VariableAccesses.Value.IsSubsetOf(MathObjects.Value));
+            Assert.True(VariableAccesses.Value.IsSubsetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestVariableAccessesIsNotSupersetOfSets()
         {
             // expect
-            Assert.That(!VariableAccesses.Value.IsSupersetOf(Sets.Sets.Value));
+            Assert.False(
+                VariableAccesses.Value.IsSupersetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestVariableAccessesIsNotSubsetOfSets()
         {
             // expect
-            Assert.That(!VariableAccesses.Value.IsSubsetOf(Sets.Sets.Value));
+            Assert.False(VariableAccesses.Value.IsSubsetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestVariableAccessesIsNotSupersetOfAllFunctions()
         {
             // expect
-            Assert.That(
-                !VariableAccesses.Value.IsSupersetOf(AllFunctions.Value));
+            Assert.False(
+                VariableAccesses.Value.IsSupersetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestVariableAccessesIsNotSubsetOfAllFunctions()
         {
             // expect
-            Assert.That(!VariableAccesses.Value.IsSubsetOf(
-                AllFunctions.Value));
+            Assert.False(
+                VariableAccesses.Value.IsSubsetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestVariableAccessesIsNotSupersetOfFunctions()
         {
             // expect
-            Assert.That(
-                !VariableAccesses.Value.IsSupersetOf(
+            Assert.False(
+                VariableAccesses.Value.IsSupersetOf(
                     Sets.Functions.RealsToReals));
         }
 
@@ -86,156 +87,176 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.VariableAccessesT
         public void TestVariableAccessesIsNotSubsetOfFunctions()
         {
             // expect
-            Assert.That(
-                !VariableAccesses.Value.IsSubsetOf(Sets.Functions
-                    .RealsToReals));
+            Assert.False(
+                VariableAccesses.Value.IsSubsetOf(
+                    Sets.Functions.RealsToReals));
+        }
+
+        [Test]
+        public void TestVariableAccessesIsNotSupersetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                VariableAccesses.Value.IsSupersetOf(
+                    VariadicFunctions.RealsToReals));
+        }
+
+        [Test]
+        public void TestVariableAccessesIsNotSubsetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                VariableAccesses.Value.IsSubsetOf(
+                    VariadicFunctions.RealsToReals));
         }
 
         [Test]
         public void TestVariableAccessesIsNotSupersetOfTensors()
         {
             // expect
-            Assert.That(!VariableAccesses.Value.IsSupersetOf(Tensors.Value));
+            Assert.False(VariableAccesses.Value.IsSupersetOf(Tensors.Value));
         }
 
         [Test]
         public void TestVariableAccessesIsNotSubsetOfTensors()
         {
             // expect
-            Assert.That(!VariableAccesses.Value.IsSubsetOf(Tensors.Value));
+            Assert.False(VariableAccesses.Value.IsSubsetOf(Tensors.Value));
         }
 
         [Test]
         public void TestVariableAccessesIsNotSupersetOfAllVectors()
         {
             // expect
-            Assert.That(!VariableAccesses.Value.IsSupersetOf(
-                AllVectors.Value));
+            Assert.False(
+                VariableAccesses.Value.IsSupersetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestVariableAccessesIsNotSubsetOfAllVectors()
         {
             // expect
-            Assert.That(!VariableAccesses.Value.IsSubsetOf(AllVectors.Value));
+            Assert.False(VariableAccesses.Value.IsSubsetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestVariableAccessesIsNotSupersetOfVectors()
         {
             // expect
-            Assert.That(!VariableAccesses.Value.IsSupersetOf(Vectors.R2));
-            Assert.That(!VariableAccesses.Value.IsSupersetOf(Vectors.R3));
+            Assert.False(VariableAccesses.Value.IsSupersetOf(Vectors.R2));
+            Assert.False(VariableAccesses.Value.IsSupersetOf(Vectors.R3));
         }
 
         [Test]
         public void TestVariableAccessesIsNotSubsetOfVectors()
         {
             // expect
-            Assert.That(!VariableAccesses.Value.IsSubsetOf(Vectors.R2));
-            Assert.That(!VariableAccesses.Value.IsSubsetOf(Vectors.R3));
+            Assert.False(VariableAccesses.Value.IsSubsetOf(Vectors.R2));
+            Assert.False(VariableAccesses.Value.IsSubsetOf(Vectors.R3));
         }
 
         [Test]
         public void TestVariableAccessesIsNotSupersetOfAllMatrices()
         {
             // expect
-            Assert.That(
-                !VariableAccesses.Value.IsSupersetOf(AllMatrices.Value));
+            Assert.False(
+                VariableAccesses.Value.IsSupersetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestVariableAccessesIsNotSubsetOfAllMatrices()
         {
             // expect
-            Assert.That(!VariableAccesses.Value.IsSubsetOf(AllMatrices.Value));
+            Assert.False(
+                VariableAccesses.Value.IsSubsetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestVariableAccessesIsNotSupersetOfMatrices()
         {
             // expect
-            Assert.That(!VariableAccesses.Value.IsSupersetOf(Matrices.M2x2));
-            Assert.That(!VariableAccesses.Value.IsSupersetOf(Matrices.M3x3));
+            Assert.False(VariableAccesses.Value.IsSupersetOf(Matrices.M2x2));
+            Assert.False(VariableAccesses.Value.IsSupersetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestVariableAccessesIsNotSubsetOfMatrices()
         {
             // expect
-            Assert.That(!VariableAccesses.Value.IsSubsetOf(Matrices.M2x2));
-            Assert.That(!VariableAccesses.Value.IsSubsetOf(Matrices.M3x3));
+            Assert.False(VariableAccesses.Value.IsSubsetOf(Matrices.M2x2));
+            Assert.False(VariableAccesses.Value.IsSubsetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestVariableAccessesIsNotSupersetOfReals()
         {
             // expect
-            Assert.That(!VariableAccesses.Value.IsSupersetOf(Reals.Value));
+            Assert.False(VariableAccesses.Value.IsSupersetOf(Reals.Value));
         }
 
         [Test]
         public void TestVariableAccessesIsNotSubsetOfReals()
         {
             // expect
-            Assert.That(!VariableAccesses.Value.IsSubsetOf(Reals.Value));
+            Assert.False(VariableAccesses.Value.IsSubsetOf(Reals.Value));
         }
 
         [Test]
         public void TestVariableAccessesIsNotSupersetOfStrings()
         {
             // expect
-            Assert.That(!VariableAccesses.Value.IsSupersetOf(Strings.Value));
+            Assert.False(VariableAccesses.Value.IsSupersetOf(Strings.Value));
         }
 
         [Test]
         public void TestVariableAccessesIsNotSubsetOfStrings()
         {
             // expect
-            Assert.That(!VariableAccesses.Value.IsSubsetOf(Strings.Value));
+            Assert.False(VariableAccesses.Value.IsSubsetOf(Strings.Value));
         }
 
         [Test]
         public void TestVariableAccessesIsNotSupersetOfIntervals()
         {
             // expect
-            Assert.That(!VariableAccesses.Value.IsSupersetOf(Intervals.Value));
+            Assert.False(
+                VariableAccesses.Value.IsSupersetOf(Intervals.Value));
         }
 
         [Test]
         public void TestVariableAccessesIsNotSubsetOfIntervals()
         {
             // expect
-            Assert.That(!VariableAccesses.Value.IsSubsetOf(Intervals.Value));
+            Assert.False(VariableAccesses.Value.IsSubsetOf(Intervals.Value));
         }
 
         [Test]
         public void TestVariableAccessesIsNotSupersetOfBooleans()
         {
             // expect
-            Assert.That(!VariableAccesses.Value.IsSupersetOf(Booleans.Value));
+            Assert.False(VariableAccesses.Value.IsSupersetOf(Booleans.Value));
         }
 
         [Test]
         public void TestVariableAccessesIsNotSubsetOfBooleans()
         {
             // expect
-            Assert.That(!VariableAccesses.Value.IsSubsetOf(Booleans.Value));
+            Assert.False(VariableAccesses.Value.IsSubsetOf(Booleans.Value));
         }
 
         [Test]
         public void TestVariableAccessesIsNotSupersetOfExpressions()
         {
             // expect
-            Assert.That(
-                !VariableAccesses.Value.IsSupersetOf(Sets.Expressions.Value));
+            Assert.False(
+                VariableAccesses.Value.IsSupersetOf(Sets.Expressions.Value));
         }
 
         [Test]
         public void TestVariableAccessesIsSubsetOfExpressions()
         {
             // expect
-            Assert.That(
+            Assert.True(
                 VariableAccesses.Value.IsSubsetOf(Sets.Expressions.Value));
         }
 
@@ -243,118 +264,118 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.VariableAccessesT
         public void TestVariableAccessesIsNotSupersetOfLiterals()
         {
             // expect
-            Assert.That(!VariableAccesses.Value.IsSupersetOf(Literals.Value));
+            Assert.False(VariableAccesses.Value.IsSupersetOf(Literals.Value));
         }
 
         [Test]
         public void TestVariableAccessesIsNotSubsetOfLiterals()
         {
             // expect
-            Assert.That(!VariableAccesses.Value.IsSubsetOf(Literals.Value));
+            Assert.False(VariableAccesses.Value.IsSubsetOf(Literals.Value));
         }
 
         [Test]
         public void TestVariableAccessesIsNotSupersetOfComponentAccesses()
         {
             // expect
-            Assert.That(
-                !VariableAccesses.Value.IsSupersetOf(ComponentAccesses.Value));
+            Assert.False(
+                VariableAccesses.Value.IsSupersetOf(ComponentAccesses.Value));
         }
 
         [Test]
         public void TestVariableAccessesIsNotSubsetOfComponentAccesses()
         {
             // expect
-            Assert.That(
-                !VariableAccesses.Value.IsSubsetOf(ComponentAccesses.Value));
+            Assert.False(
+                VariableAccesses.Value.IsSubsetOf(ComponentAccesses.Value));
         }
 
         [Test]
         public void TestVariableAccessesIsNotSupersetOfFunctionCalls()
         {
             // expect
-            Assert.That(
-                !VariableAccesses.Value.IsSupersetOf(FunctionCalls.Value));
+            Assert.False(
+                VariableAccesses.Value.IsSupersetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestVariableAccessesIsNotSubsetOfFunctionCalls()
         {
             // expect
-            Assert.That(
-                !VariableAccesses.Value.IsSubsetOf(FunctionCalls.Value));
+            Assert.False(
+                VariableAccesses.Value.IsSubsetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestVariableAccessesIsNotSupersetOfIntervalExpressions()
         {
             // expect
-            Assert.That(
-                !VariableAccesses.Value.IsSupersetOf(IntervalExpressions
-                    .Value));
+            Assert.False(
+                VariableAccesses.Value.IsSupersetOf(
+                    IntervalExpressions.Value));
         }
 
         [Test]
         public void TestVariableAccessesIsNotSubsetOfIntervalExpressions()
         {
             // expect
-            Assert.That(
-                !VariableAccesses.Value.IsSubsetOf(IntervalExpressions.Value));
+            Assert.False(
+                VariableAccesses.Value.IsSubsetOf(IntervalExpressions.Value));
         }
 
         [Test]
         public void TestVariableAccessesIsNotSupersetOfTensorExpressions()
         {
             // expect
-            Assert.That(
-                !VariableAccesses.Value.IsSupersetOf(TensorExpressions.Value));
+            Assert.False(
+                VariableAccesses.Value.IsSupersetOf(TensorExpressions.Value));
         }
 
         [Test]
         public void TestVariableAccessesIsNotSubsetOfTensorExpressions()
         {
             // expect
-            Assert.That(
-                !VariableAccesses.Value.IsSubsetOf(TensorExpressions.Value));
+            Assert.False(
+                VariableAccesses.Value.IsSubsetOf(TensorExpressions.Value));
         }
 
         [Test]
         public void TestVariableAccessesIsNotSupersetOfMatrixExpressions()
         {
             // expect
-            Assert.That(
-                !VariableAccesses.Value.IsSupersetOf(MatrixExpressions.Value));
+            Assert.False(
+                VariableAccesses.Value.IsSupersetOf(MatrixExpressions.Value));
         }
 
         [Test]
         public void TestVariableAccessesIsNotSubsetOfMatrixExpressions()
         {
             // expect
-            Assert.That(
-                !VariableAccesses.Value.IsSubsetOf(MatrixExpressions.Value));
+            Assert.False(
+                VariableAccesses.Value.IsSubsetOf(MatrixExpressions.Value));
         }
 
         [Test]
         public void TestVariableAccessesIsNotSupersetOfVectorExpressions()
         {
             // expect
-            Assert.That(
-                !VariableAccesses.Value.IsSupersetOf(VectorExpressions.Value));
+            Assert.False(
+                VariableAccesses.Value.IsSupersetOf(VectorExpressions.Value));
         }
 
         [Test]
         public void TestVariableAccessesIsNotSubsetOfVectorExpressions()
         {
             // expect
-            Assert.That(
-                !VariableAccesses.Value.IsSubsetOf(VectorExpressions.Value));
+            Assert.False(
+                VariableAccesses.Value.IsSubsetOf(VectorExpressions.Value));
         }
 
         [Test]
         public void TestVariableAccessesIsSupersetOfSelf()
         {
             // expect
-            Assert.That(
+            Assert.True(
                 VariableAccesses.Value.IsSupersetOf(VariableAccesses.Value));
         }
 
@@ -362,7 +383,7 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.VariableAccessesT
         public void TestVariableAccessesIsSubsetOfSelf()
         {
             // expect
-            Assert.That(
+            Assert.True(
                 VariableAccesses.Value.IsSubsetOf(VariableAccesses.Value));
         }
     }

--- a/MetaphysicsIndustries.Solus.Test/SetsT/VariadicFunctionsT/SupersetAndSubsetTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/SetsT/VariadicFunctionsT/SupersetAndSubsetTest.cs
@@ -1,0 +1,432 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using MetaphysicsIndustries.Solus.Sets;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Solus.Test.SetsT.VariadicFunctionsT
+{
+    [TestFixture]
+    public class SupersetAndSubsetTest
+    {
+        [Test]
+        public void TestVariadicFunctionsIsNotSupersetOfMathObjects()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSupersetOf(
+                    MathObjects.Value));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsSubsetOfMathObjects()
+        {
+            // expect
+            Assert.True(
+                VariadicFunctions.RealsToReals.IsSubsetOf(MathObjects.Value));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSupersetOfSets()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSupersetOf(Sets.Sets.Value));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSubsetOfSets()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSubsetOf(Sets.Sets.Value));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSupersetOfAllFunctions()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSupersetOf(
+                    AllFunctions.Value));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsSubsetOfAllFunctions()
+        {
+            // expect
+            Assert.True(
+                VariadicFunctions.RealsToReals.IsSubsetOf(
+                    AllFunctions.Value));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSupersetOfFunctions()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSupersetOf(
+                    Sets.Functions.RealsToReals));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSubsetOfFunctions()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSubsetOf(
+                    Sets.Functions.RealsToReals));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsSupersetOfSelf()
+        {
+            // expect
+            Assert.True(
+                VariadicFunctions.RealsToReals.IsSupersetOf(
+                    VariadicFunctions.RealsToReals));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsSubsetOfSelf()
+        {
+            // expect
+            Assert.True(
+                VariadicFunctions.RealsToReals.IsSubsetOf(
+                    VariadicFunctions.RealsToReals));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSupersetOfTensors()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSupersetOf(Tensors.Value));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSubsetOfTensors()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSubsetOf(Tensors.Value));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSupersetOfAllVectors()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSupersetOf(
+                    AllVectors.Value));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSubsetOfAllVectors()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSubsetOf(AllVectors.Value));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSupersetOfVectors()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSupersetOf(Vectors.R2));
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSupersetOf(Vectors.R3));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSubsetOfVectors()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSubsetOf(Vectors.R2));
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSubsetOf(Vectors.R3));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSupersetOfAllMatrices()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSupersetOf(
+                    AllMatrices.Value));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSubsetOfAllMatrices()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSubsetOf(AllMatrices.Value));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSupersetOfMatrices()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSupersetOf(Matrices.M2x2));
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSupersetOf(Matrices.M3x3));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSubsetOfMatrices()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSubsetOf(Matrices.M2x2));
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSubsetOf(Matrices.M3x3));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSupersetOfReals()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSupersetOf(Reals.Value));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSubsetOfReals()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSubsetOf(Reals.Value));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSupersetOfStrings()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSupersetOf(Strings.Value));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSubsetOfStrings()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSubsetOf(Strings.Value));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSupersetOfIntervals()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSupersetOf(Intervals.Value));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSubsetOfIntervals()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSubsetOf(Intervals.Value));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSupersetOfBooleans()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSupersetOf(Booleans.Value));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSubsetOfBooleans()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSubsetOf(Booleans.Value));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSupersetOfExpressions()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSupersetOf(
+                    Sets.Expressions.Value));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSubsetOfExpressions()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSubsetOf(
+                    Sets.Expressions.Value));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSupersetOfLiterals()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSupersetOf(Literals.Value));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSubsetOfLiterals()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSubsetOf(Literals.Value));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSupersetOfComponentAccesses()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSupersetOf(
+                    ComponentAccesses.Value));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSubsetOfComponentAccesses()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSubsetOf(
+                    ComponentAccesses.Value));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSupersetOfFunctionCalls()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSupersetOf(
+                    FunctionCalls.Value));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSubsetOfFunctionCalls()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSubsetOf(
+                    FunctionCalls.Value));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSupersetOfIntervalExpressions()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSupersetOf(
+                    IntervalExpressions.Value));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSubsetOfIntervalExpressions()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSubsetOf(
+                    IntervalExpressions.Value));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSupersetOfTensorExpressions()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSupersetOf(
+                    TensorExpressions.Value));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSubsetOfTensorExpressions()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSubsetOf(
+                    TensorExpressions.Value));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSupersetOfMatrixExpressions()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSupersetOf(
+                    MatrixExpressions.Value));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSubsetOfMatrixExpressions()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSubsetOf(
+                    MatrixExpressions.Value));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSupersetOfVectorExpressions()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSupersetOf(
+                    VectorExpressions.Value));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSubsetOfVectorExpressions()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSubsetOf(
+                    VectorExpressions.Value));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSupersetOfVariableAccesses()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSupersetOf(
+                    VariableAccesses.Value));
+        }
+
+        [Test]
+        public void TestVariadicFunctionsIsNotSubsetOfVariableAccesses()
+        {
+            // expect
+            Assert.False(
+                VariadicFunctions.RealsToReals.IsSubsetOf(
+                    VariableAccesses.Value));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Solus.Test/SetsT/VariadicFunctionsT/SupersetAndSubsetTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/SetsT/VariadicFunctionsT/SupersetAndSubsetTest.cs
@@ -60,6 +60,7 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.VariadicFunctionsT
             // Note: This is incorrect if we treat a function as a set of
             // ordered pairs. In that case, `RealsToReals` is a set of other
             // sets and thus a subset of `Sets`.
+            // TODO: fix this so as to treat functions as sets.
 
             // expect
             Assert.False(

--- a/MetaphysicsIndustries.Solus.Test/SetsT/VariadicFunctionsT/SupersetAndSubsetTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/SetsT/VariadicFunctionsT/SupersetAndSubsetTest.cs
@@ -56,6 +56,11 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.VariadicFunctionsT
         [Test]
         public void TestVariadicFunctionsIsNotSubsetOfSets()
         {
+            // It is a *member* of `Sets`, but not a *subset* of it.
+            // Note: This is incorrect if we treat a function as a set of
+            // ordered pairs. In that case, `RealsToReals` is a set of other
+            // sets and thus a subset of `Sets`.
+
             // expect
             Assert.False(
                 VariadicFunctions.RealsToReals.IsSubsetOf(Sets.Sets.Value));

--- a/MetaphysicsIndustries.Solus.Test/SetsT/VectorExpressionsT/SupersetAndSubsetTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/SetsT/VectorExpressionsT/SupersetAndSubsetTest.cs
@@ -32,213 +32,234 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.VectorExpressionsT
         public void TestVectorExpressionsIsNotSupersetOfMathObjects()
         {
             // expect
-            Assert.That(
-                !VectorExpressions.Value.IsSupersetOf(MathObjects.Value));
+            Assert.False(
+                VectorExpressions.Value.IsSupersetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestVectorExpressionsIsSubsetOfMathObjects()
         {
             // expect
-            Assert.That(VectorExpressions.Value.IsSubsetOf(MathObjects.Value));
+            Assert.True(
+                VectorExpressions.Value.IsSubsetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestVectorExpressionsIsNotSupersetOfSets()
         {
             // expect
-            Assert.That(!VectorExpressions.Value.IsSupersetOf(
-                Sets.Sets.Value));
+            Assert.False(
+                VectorExpressions.Value.IsSupersetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestVectorExpressionsIsNotSubsetOfSets()
         {
             // expect
-            Assert.That(!VectorExpressions.Value.IsSubsetOf(Sets.Sets.Value));
+            Assert.False(VectorExpressions.Value.IsSubsetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestVectorExpressionsIsNotSupersetOfAllFunctions()
         {
             // expect
-            Assert.That(
-                !VectorExpressions.Value.IsSupersetOf(AllFunctions.Value));
+            Assert.False(
+                VectorExpressions.Value.IsSupersetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestVectorExpressionsIsNotSubsetOfAllFunctions()
         {
             // expect
-            Assert.That(
-                !VectorExpressions.Value.IsSubsetOf(AllFunctions.Value));
+            Assert.False(
+                VectorExpressions.Value.IsSubsetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestVectorExpressionsIsNotSupersetOfFunctions()
         {
             // expect
-            Assert.That(
-                !VectorExpressions.Value.IsSupersetOf(Sets.Functions
-                    .RealsToReals));
+            Assert.False(
+                VectorExpressions.Value.IsSupersetOf(
+                    Sets.Functions.RealsToReals));
         }
 
         [Test]
         public void TestVectorExpressionsIsNotSubsetOfFunctions()
         {
             // expect
-            Assert.That(
-                !VectorExpressions.Value.IsSubsetOf(Sets.Functions
-                    .RealsToReals));
+            Assert.False(
+                VectorExpressions.Value.IsSubsetOf(
+                    Sets.Functions.RealsToReals));
+        }
+
+        [Test]
+        public void TestVectorExpressionsIsNotSupersetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                VectorExpressions.Value.IsSupersetOf(
+                    VariadicFunctions.RealsToReals));
+        }
+
+        [Test]
+        public void TestVectorExpressionsIsNotSubsetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                VectorExpressions.Value.IsSubsetOf(
+                    VariadicFunctions.RealsToReals));
         }
 
         [Test]
         public void TestVectorExpressionsIsNotSupersetOfTensors()
         {
             // expect
-            Assert.That(!VectorExpressions.Value.IsSupersetOf(Tensors.Value));
+            Assert.False(VectorExpressions.Value.IsSupersetOf(Tensors.Value));
         }
 
         [Test]
         public void TestVectorExpressionsIsNotSubsetOfTensors()
         {
             // expect
-            Assert.That(!VectorExpressions.Value.IsSubsetOf(Tensors.Value));
+            Assert.False(VectorExpressions.Value.IsSubsetOf(Tensors.Value));
         }
 
         [Test]
         public void TestVectorExpressionsIsNotSupersetOfAllVectors()
         {
             // expect
-            Assert.That(
-                !VectorExpressions.Value.IsSupersetOf(AllVectors.Value));
+            Assert.False(
+                VectorExpressions.Value.IsSupersetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestVectorExpressionsIsNotSubsetOfAllVectors()
         {
             // expect
-            Assert.That(!VectorExpressions.Value.IsSubsetOf(AllVectors.Value));
+            Assert.False(
+                VectorExpressions.Value.IsSubsetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestVectorExpressionsIsNotSupersetOfVectors()
         {
             // expect
-            Assert.That(!VectorExpressions.Value.IsSupersetOf(Vectors.R2));
-            Assert.That(!VectorExpressions.Value.IsSupersetOf(Vectors.R3));
+            Assert.False(VectorExpressions.Value.IsSupersetOf(Vectors.R2));
+            Assert.False(VectorExpressions.Value.IsSupersetOf(Vectors.R3));
         }
 
         [Test]
         public void TestVectorExpressionsIsNotSubsetOfVectors()
         {
             // expect
-            Assert.That(!VectorExpressions.Value.IsSubsetOf(Vectors.R2));
-            Assert.That(!VectorExpressions.Value.IsSubsetOf(Vectors.R3));
+            Assert.False(VectorExpressions.Value.IsSubsetOf(Vectors.R2));
+            Assert.False(VectorExpressions.Value.IsSubsetOf(Vectors.R3));
         }
 
         [Test]
         public void TestVectorExpressionsIsNotSupersetOfAllMatrices()
         {
             // expect
-            Assert.That(
-                !VectorExpressions.Value.IsSupersetOf(AllMatrices.Value));
+            Assert.False(
+                VectorExpressions.Value.IsSupersetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestVectorExpressionsIsNotSubsetOfAllMatrices()
         {
             // expect
-            Assert.That(!VectorExpressions.Value.IsSubsetOf(
-                AllMatrices.Value));
+            Assert.False(
+                VectorExpressions.Value.IsSubsetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestVectorExpressionsIsNotSupersetOfMatrices()
         {
             // expect
-            Assert.That(!VectorExpressions.Value.IsSupersetOf(Matrices.M2x2));
-            Assert.That(!VectorExpressions.Value.IsSupersetOf(Matrices.M3x3));
+            Assert.False(VectorExpressions.Value.IsSupersetOf(Matrices.M2x2));
+            Assert.False(VectorExpressions.Value.IsSupersetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestVectorExpressionsIsNotSubsetOfMatrices()
         {
             // expect
-            Assert.That(!VectorExpressions.Value.IsSubsetOf(Matrices.M2x2));
-            Assert.That(!VectorExpressions.Value.IsSubsetOf(Matrices.M3x3));
+            Assert.False(VectorExpressions.Value.IsSubsetOf(Matrices.M2x2));
+            Assert.False(VectorExpressions.Value.IsSubsetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestVectorExpressionsIsNotSupersetOfReals()
         {
             // expect
-            Assert.That(!VectorExpressions.Value.IsSupersetOf(Reals.Value));
+            Assert.False(VectorExpressions.Value.IsSupersetOf(Reals.Value));
         }
 
         [Test]
         public void TestVectorExpressionsIsNotSubsetOfReals()
         {
             // expect
-            Assert.That(!VectorExpressions.Value.IsSubsetOf(Reals.Value));
+            Assert.False(VectorExpressions.Value.IsSubsetOf(Reals.Value));
         }
 
         [Test]
         public void TestVectorExpressionsIsNotSupersetOfStrings()
         {
             // expect
-            Assert.That(!VectorExpressions.Value.IsSupersetOf(Strings.Value));
+            Assert.False(VectorExpressions.Value.IsSupersetOf(Strings.Value));
         }
 
         [Test]
         public void TestVectorExpressionsIsNotSubsetOfStrings()
         {
             // expect
-            Assert.That(!VectorExpressions.Value.IsSubsetOf(Strings.Value));
+            Assert.False(VectorExpressions.Value.IsSubsetOf(Strings.Value));
         }
 
         [Test]
         public void TestVectorExpressionsIsNotSupersetOfIntervals()
         {
             // expect
-            Assert.That(!VectorExpressions.Value.IsSupersetOf(
-                Intervals.Value));
+            Assert.False(
+                VectorExpressions.Value.IsSupersetOf(Intervals.Value));
         }
 
         [Test]
         public void TestVectorExpressionsIsNotSubsetOfIntervals()
         {
             // expect
-            Assert.That(!VectorExpressions.Value.IsSubsetOf(Intervals.Value));
+            Assert.False(VectorExpressions.Value.IsSubsetOf(Intervals.Value));
         }
 
         [Test]
         public void TestVectorExpressionsIsNotSupersetOfBooleans()
         {
             // expect
-            Assert.That(!VectorExpressions.Value.IsSupersetOf(Booleans.Value));
+            Assert.False(
+                VectorExpressions.Value.IsSupersetOf(Booleans.Value));
         }
 
         [Test]
         public void TestVectorExpressionsIsNotSubsetOfBooleans()
         {
             // expect
-            Assert.That(!VectorExpressions.Value.IsSubsetOf(Booleans.Value));
+            Assert.False(VectorExpressions.Value.IsSubsetOf(Booleans.Value));
         }
 
         [Test]
         public void TestVectorExpressionsIsNotSupersetOfExpressions()
         {
             // expect
-            Assert.That(
-                !VectorExpressions.Value.IsSupersetOf(Sets.Expressions.Value));
+            Assert.False(
+                VectorExpressions.Value.IsSupersetOf(Sets.Expressions.Value));
         }
 
         [Test]
         public void TestVectorExpressionsIsSubsetOfExpressions()
         {
             // expect
-            Assert.That(
+            Assert.True(
                 VectorExpressions.Value.IsSubsetOf(Sets.Expressions.Value));
         }
 
@@ -246,22 +267,23 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.VectorExpressionsT
         public void TestVectorExpressionsIsNotSupersetOfLiterals()
         {
             // expect
-            Assert.That(!VectorExpressions.Value.IsSupersetOf(Literals.Value));
+            Assert.False(
+                VectorExpressions.Value.IsSupersetOf(Literals.Value));
         }
 
         [Test]
         public void TestVectorExpressionsIsNotSubsetOfLiterals()
         {
             // expect
-            Assert.That(!VectorExpressions.Value.IsSubsetOf(Literals.Value));
+            Assert.False(VectorExpressions.Value.IsSubsetOf(Literals.Value));
         }
 
         [Test]
         public void TestVectorExpressionsIsNotSupersetOfComponentAccesses()
         {
             // expect
-            Assert.That(
-                !VectorExpressions.Value.IsSupersetOf(
+            Assert.False(
+                VectorExpressions.Value.IsSupersetOf(
                     ComponentAccesses.Value));
         }
 
@@ -269,41 +291,41 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.VectorExpressionsT
         public void TestVectorExpressionsIsNotSubsetOfComponentAccesses()
         {
             // expect
-            Assert.That(
-                !VectorExpressions.Value.IsSubsetOf(ComponentAccesses.Value));
+            Assert.False(
+                VectorExpressions.Value.IsSubsetOf(ComponentAccesses.Value));
         }
 
         [Test]
         public void TestVectorExpressionsIsNotSupersetOfFunctionCalls()
         {
             // expect
-            Assert.That(
-                !VectorExpressions.Value.IsSupersetOf(FunctionCalls.Value));
+            Assert.False(
+                VectorExpressions.Value.IsSupersetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestVectorExpressionsIsNotSubsetOfFunctionCalls()
         {
             // expect
-            Assert.That(
-                !VectorExpressions.Value.IsSubsetOf(FunctionCalls.Value));
+            Assert.False(
+                VectorExpressions.Value.IsSubsetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestVectorExpressionsIsNotSupersetOfIntervalExpressions()
         {
             // expect
-            Assert.That(
-                !VectorExpressions.Value.IsSupersetOf(IntervalExpressions
-                    .Value));
+            Assert.False(
+                VectorExpressions.Value.IsSupersetOf(
+                    IntervalExpressions.Value));
         }
 
         [Test]
         public void TestVectorExpressionsIsNotSubsetOfIntervalExpressions()
         {
             // expect
-            Assert.That(
-                !VectorExpressions.Value.IsSubsetOf(
+            Assert.False(
+                VectorExpressions.Value.IsSubsetOf(
                     IntervalExpressions.Value));
         }
 
@@ -311,8 +333,8 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.VectorExpressionsT
         public void TestVectorExpressionsIsNotSupersetOfTensorExpressions()
         {
             // expect
-            Assert.That(
-                !VectorExpressions.Value.IsSupersetOf(
+            Assert.False(
+                VectorExpressions.Value.IsSupersetOf(
                     TensorExpressions.Value));
         }
 
@@ -320,7 +342,7 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.VectorExpressionsT
         public void TestVectorExpressionsIsSubsetOfTensorExpressions()
         {
             // expect
-            Assert.That(
+            Assert.True(
                 VectorExpressions.Value.IsSubsetOf(TensorExpressions.Value));
         }
 
@@ -328,8 +350,8 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.VectorExpressionsT
         public void TestVectorExpressionsIsNotSupersetOfMatrixExpressions()
         {
             // expect
-            Assert.That(
-                !VectorExpressions.Value.IsSupersetOf(
+            Assert.False(
+                VectorExpressions.Value.IsSupersetOf(
                     MatrixExpressions.Value));
         }
 
@@ -337,23 +359,24 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.VectorExpressionsT
         public void TestVectorExpressionsIsNotSubsetOfMatrixExpressions()
         {
             // expect
-            Assert.That(
-                !VectorExpressions.Value.IsSubsetOf(MatrixExpressions.Value));
+            Assert.False(
+                VectorExpressions.Value.IsSubsetOf(MatrixExpressions.Value));
         }
 
         [Test]
         public void TestVectorExpressionsIsSupersetOfSelf()
         {
             // expect
-            Assert.That(
-                VectorExpressions.Value.IsSupersetOf(VectorExpressions.Value));
+            Assert.True(
+                VectorExpressions.Value.IsSupersetOf(
+                    VectorExpressions.Value));
         }
 
         [Test]
         public void TestVectorExpressionsIsSubsetOfSelf()
         {
             // expect
-            Assert.That(
+            Assert.True(
                 VectorExpressions.Value.IsSubsetOf(VectorExpressions.Value));
         }
 
@@ -361,16 +384,16 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.VectorExpressionsT
         public void TestVectorExpressionsIsNotSupersetOfVariableAccesses()
         {
             // expect
-            Assert.That(
-                !VectorExpressions.Value.IsSupersetOf(VariableAccesses.Value));
+            Assert.False(
+                VectorExpressions.Value.IsSupersetOf(VariableAccesses.Value));
         }
 
         [Test]
         public void TestVectorExpressionsIsNotSubsetOfVariableAccesses()
         {
             // expect
-            Assert.That(
-                !VectorExpressions.Value.IsSubsetOf(VariableAccesses.Value));
+            Assert.False(
+                VectorExpressions.Value.IsSubsetOf(VariableAccesses.Value));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/SetsT/VectorsT/SupersetAndSubsetTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/SetsT/VectorsT/SupersetAndSubsetTest.cs
@@ -32,360 +32,382 @@ namespace MetaphysicsIndustries.Solus.Test.SetsT.VectorsT
         public void TestVectorsIsNotSupersetOfMathObjects()
         {
             // expect
-            Assert.That(!Vectors.R2.IsSupersetOf(MathObjects.Value));
-            Assert.That(!Vectors.R3.IsSupersetOf(MathObjects.Value));
+            Assert.False(Vectors.R2.IsSupersetOf(MathObjects.Value));
+            Assert.False(Vectors.R3.IsSupersetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestVectorsIsSubsetOfMathObjects()
         {
             // expect
-            Assert.That(Vectors.R2.IsSubsetOf(MathObjects.Value));
-            Assert.That(Vectors.R3.IsSubsetOf(MathObjects.Value));
+            Assert.True(Vectors.R2.IsSubsetOf(MathObjects.Value));
+            Assert.True(Vectors.R3.IsSubsetOf(MathObjects.Value));
         }
 
         [Test]
         public void TestVectorsIsNotSupersetOfSets()
         {
             // expect
-            Assert.That(!Vectors.R2.IsSupersetOf(Sets.Sets.Value));
-            Assert.That(!Vectors.R3.IsSupersetOf(Sets.Sets.Value));
+            Assert.False(Vectors.R2.IsSupersetOf(Sets.Sets.Value));
+            Assert.False(Vectors.R3.IsSupersetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestVectorsIsNotSubsetOfSets()
         {
             // expect
-            Assert.That(!Vectors.R2.IsSubsetOf(Sets.Sets.Value));
-            Assert.That(!Vectors.R3.IsSubsetOf(Sets.Sets.Value));
+            Assert.False(Vectors.R2.IsSubsetOf(Sets.Sets.Value));
+            Assert.False(Vectors.R3.IsSubsetOf(Sets.Sets.Value));
         }
 
         [Test]
         public void TestVectorsIsNotSupersetOfAllFunctions()
         {
             // expect
-            Assert.That(!Vectors.R2.IsSupersetOf(AllFunctions.Value));
-            Assert.That(!Vectors.R3.IsSupersetOf(AllFunctions.Value));
+            Assert.False(Vectors.R2.IsSupersetOf(AllFunctions.Value));
+            Assert.False(Vectors.R3.IsSupersetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestVectorsIsNotSubsetOfAllFunctions()
         {
             // expect
-            Assert.That(!Vectors.R2.IsSubsetOf(AllFunctions.Value));
-            Assert.That(!Vectors.R3.IsSubsetOf(AllFunctions.Value));
+            Assert.False(Vectors.R2.IsSubsetOf(AllFunctions.Value));
+            Assert.False(Vectors.R3.IsSubsetOf(AllFunctions.Value));
         }
 
         [Test]
         public void TestVectorsIsNotSupersetOfFunctions()
         {
             // expect
-            Assert.That(!Vectors.R2.IsSupersetOf(Sets.Functions.RealsToReals));
-            Assert.That(!Vectors.R3.IsSupersetOf(Sets.Functions.RealsToReals));
+            Assert.False(
+                Vectors.R2.IsSupersetOf(Sets.Functions.RealsToReals));
+            Assert.False(
+                Vectors.R3.IsSupersetOf(Sets.Functions.RealsToReals));
         }
 
         [Test]
         public void TestVectorsIsNotSubsetOfFunctions()
         {
             // expect
-            Assert.That(!Vectors.R2.IsSubsetOf(Sets.Functions.RealsToReals));
-            Assert.That(!Vectors.R3.IsSubsetOf(Sets.Functions.RealsToReals));
+            Assert.False(Vectors.R2.IsSubsetOf(Sets.Functions.RealsToReals));
+            Assert.False(Vectors.R3.IsSubsetOf(Sets.Functions.RealsToReals));
+        }
+
+        [Test]
+        public void TestVectorsIsNotSupersetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                Vectors.R2.IsSupersetOf(VariadicFunctions.RealsToReals));
+            Assert.False(
+                Vectors.R3.IsSupersetOf(VariadicFunctions.RealsToReals));
+        }
+
+        [Test]
+        public void TestVectorsIsNotSubsetOfVariadicFunctions()
+        {
+            // expect
+            Assert.False(
+                Vectors.R2.IsSubsetOf(VariadicFunctions.RealsToReals));
+            Assert.False(
+                Vectors.R3.IsSubsetOf(VariadicFunctions.RealsToReals));
         }
 
         [Test]
         public void TestVectorsIsNotSupersetOfTensors()
         {
             // expect
-            Assert.That(!Vectors.R2.IsSupersetOf(Tensors.Value));
-            Assert.That(!Vectors.R3.IsSupersetOf(Tensors.Value));
+            Assert.False(Vectors.R2.IsSupersetOf(Tensors.Value));
+            Assert.False(Vectors.R3.IsSupersetOf(Tensors.Value));
         }
 
         [Test]
         public void TestVectorsIsSubsetOfTensors()
         {
             // expect
-            Assert.That(Vectors.R2.IsSubsetOf(Tensors.Value));
-            Assert.That(Vectors.R3.IsSubsetOf(Tensors.Value));
+            Assert.True(Vectors.R2.IsSubsetOf(Tensors.Value));
+            Assert.True(Vectors.R3.IsSubsetOf(Tensors.Value));
         }
 
         [Test]
         public void TestVectorsIsNotSupersetOfAllVectors()
         {
             // expect
-            Assert.That(!Vectors.R2.IsSupersetOf(AllVectors.Value));
-            Assert.That(!Vectors.R3.IsSupersetOf(AllVectors.Value));
+            Assert.False(Vectors.R2.IsSupersetOf(AllVectors.Value));
+            Assert.False(Vectors.R3.IsSupersetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestVectorsIsSubsetOfAllVectors()
         {
             // expect
-            Assert.That(Vectors.R2.IsSubsetOf(AllVectors.Value));
-            Assert.That(Vectors.R3.IsSubsetOf(AllVectors.Value));
+            Assert.True(Vectors.R2.IsSubsetOf(AllVectors.Value));
+            Assert.True(Vectors.R3.IsSubsetOf(AllVectors.Value));
         }
 
         [Test]
         public void TestVectorsIsSupersetOfSelf()
         {
             // expect
-            Assert.That(Vectors.R2.IsSupersetOf(Vectors.R2));
-            Assert.That(!Vectors.R2.IsSupersetOf(Vectors.R3));
-            Assert.That(!Vectors.R3.IsSupersetOf(Vectors.R2));
-            Assert.That(Vectors.R3.IsSupersetOf(Vectors.R3));
+            Assert.True(Vectors.R2.IsSupersetOf(Vectors.R2));
+            Assert.False(Vectors.R2.IsSupersetOf(Vectors.R3));
+            Assert.False(Vectors.R3.IsSupersetOf(Vectors.R2));
+            Assert.True(Vectors.R3.IsSupersetOf(Vectors.R3));
         }
 
         [Test]
         public void TestVectorsIsSubsetOfSelf()
         {
             // expect
-            Assert.That(Vectors.R2.IsSubsetOf(Vectors.R2));
-            Assert.That(!Vectors.R2.IsSubsetOf(Vectors.R3));
-            Assert.That(!Vectors.R3.IsSubsetOf(Vectors.R2));
-            Assert.That(Vectors.R3.IsSubsetOf(Vectors.R3));
+            Assert.True(Vectors.R2.IsSubsetOf(Vectors.R2));
+            Assert.False(Vectors.R2.IsSubsetOf(Vectors.R3));
+            Assert.False(Vectors.R3.IsSubsetOf(Vectors.R2));
+            Assert.True(Vectors.R3.IsSubsetOf(Vectors.R3));
         }
 
         [Test]
         public void TestVectorsIsNotSupersetOfAllMatrices()
         {
             // expect
-            Assert.That(!Vectors.R2.IsSupersetOf(AllMatrices.Value));
-            Assert.That(!Vectors.R3.IsSupersetOf(AllMatrices.Value));
+            Assert.False(Vectors.R2.IsSupersetOf(AllMatrices.Value));
+            Assert.False(Vectors.R3.IsSupersetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestVectorsIsNotSubsetOfAllMatrices()
         {
             // expect
-            Assert.That(!Vectors.R2.IsSubsetOf(AllMatrices.Value));
-            Assert.That(!Vectors.R3.IsSubsetOf(AllMatrices.Value));
+            Assert.False(Vectors.R2.IsSubsetOf(AllMatrices.Value));
+            Assert.False(Vectors.R3.IsSubsetOf(AllMatrices.Value));
         }
 
         [Test]
         public void TestVectorsIsNotSupersetOfMatrices()
         {
             // expect
-            Assert.That(!Vectors.R2.IsSupersetOf(Matrices.M2x2));
-            Assert.That(!Vectors.R2.IsSupersetOf(Matrices.M3x3));
-            Assert.That(!Vectors.R3.IsSupersetOf(Matrices.M2x2));
-            Assert.That(!Vectors.R3.IsSupersetOf(Matrices.M3x3));
+            Assert.False(Vectors.R2.IsSupersetOf(Matrices.M2x2));
+            Assert.False(Vectors.R2.IsSupersetOf(Matrices.M3x3));
+            Assert.False(Vectors.R3.IsSupersetOf(Matrices.M2x2));
+            Assert.False(Vectors.R3.IsSupersetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestVectorsIsNotSubsetOfMatrices()
         {
             // expect
-            Assert.That(!Vectors.R2.IsSubsetOf(Matrices.M2x2));
-            Assert.That(!Vectors.R2.IsSubsetOf(Matrices.M3x3));
-            Assert.That(!Vectors.R3.IsSubsetOf(Matrices.M2x2));
-            Assert.That(!Vectors.R3.IsSubsetOf(Matrices.M3x3));
+            Assert.False(Vectors.R2.IsSubsetOf(Matrices.M2x2));
+            Assert.False(Vectors.R2.IsSubsetOf(Matrices.M3x3));
+            Assert.False(Vectors.R3.IsSubsetOf(Matrices.M2x2));
+            Assert.False(Vectors.R3.IsSubsetOf(Matrices.M3x3));
         }
 
         [Test]
         public void TestVectorsIsNotSupersetOfReals()
         {
             // expect
-            Assert.That(!Vectors.R2.IsSupersetOf(Reals.Value));
-            Assert.That(!Vectors.R3.IsSupersetOf(Reals.Value));
+            Assert.False(Vectors.R2.IsSupersetOf(Reals.Value));
+            Assert.False(Vectors.R3.IsSupersetOf(Reals.Value));
         }
 
         [Test]
         public void TestVectorsIsNotSubsetOfReals()
         {
             // expect
-            Assert.That(!Vectors.R2.IsSubsetOf(Reals.Value));
-            Assert.That(!Vectors.R3.IsSubsetOf(Reals.Value));
+            Assert.False(Vectors.R2.IsSubsetOf(Reals.Value));
+            Assert.False(Vectors.R3.IsSubsetOf(Reals.Value));
         }
 
         [Test]
         public void TestVectorsIsNotSupersetOfStrings()
         {
             // expect
-            Assert.That(!Vectors.R2.IsSupersetOf(Strings.Value));
-            Assert.That(!Vectors.R3.IsSupersetOf(Strings.Value));
+            Assert.False(Vectors.R2.IsSupersetOf(Strings.Value));
+            Assert.False(Vectors.R3.IsSupersetOf(Strings.Value));
         }
 
         [Test]
         public void TestVectorsIsNotSubsetOfStrings()
         {
             // expect
-            Assert.That(!Vectors.R2.IsSubsetOf(Strings.Value));
-            Assert.That(!Vectors.R3.IsSubsetOf(Strings.Value));
+            Assert.False(Vectors.R2.IsSubsetOf(Strings.Value));
+            Assert.False(Vectors.R3.IsSubsetOf(Strings.Value));
         }
 
         [Test]
         public void TestVectorsIsNotSupersetOfIntervals()
         {
             // expect
-            Assert.That(!Vectors.R2.IsSupersetOf(Intervals.Value));
-            Assert.That(!Vectors.R3.IsSupersetOf(Intervals.Value));
+            Assert.False(Vectors.R2.IsSupersetOf(Intervals.Value));
+            Assert.False(Vectors.R3.IsSupersetOf(Intervals.Value));
         }
 
         [Test]
         public void TestVectorsIsNotSubsetOfIntervals()
         {
             // expect
-            Assert.That(!Vectors.R2.IsSubsetOf(Intervals.Value));
-            Assert.That(!Vectors.R3.IsSubsetOf(Intervals.Value));
+            Assert.False(Vectors.R2.IsSubsetOf(Intervals.Value));
+            Assert.False(Vectors.R3.IsSubsetOf(Intervals.Value));
         }
 
         [Test]
         public void TestVectorsIsNotSupersetOfBooleans()
         {
             // expect
-            Assert.That(!Vectors.R2.IsSupersetOf(Booleans.Value));
-            Assert.That(!Vectors.R3.IsSupersetOf(Booleans.Value));
+            Assert.False(Vectors.R2.IsSupersetOf(Booleans.Value));
+            Assert.False(Vectors.R3.IsSupersetOf(Booleans.Value));
         }
 
         [Test]
         public void TestVectorsIsNotSubsetOfBooleans()
         {
             // expect
-            Assert.That(!Vectors.R2.IsSubsetOf(Booleans.Value));
-            Assert.That(!Vectors.R3.IsSubsetOf(Booleans.Value));
+            Assert.False(Vectors.R2.IsSubsetOf(Booleans.Value));
+            Assert.False(Vectors.R3.IsSubsetOf(Booleans.Value));
         }
 
         [Test]
         public void TestVectorsIsNotSupersetOfExpressions()
         {
             // expect
-            Assert.That(!Vectors.R2.IsSupersetOf(Sets.Expressions.Value));
-            Assert.That(!Vectors.R3.IsSupersetOf(Sets.Expressions.Value));
+            Assert.False(Vectors.R2.IsSupersetOf(Sets.Expressions.Value));
+            Assert.False(Vectors.R3.IsSupersetOf(Sets.Expressions.Value));
         }
 
         [Test]
         public void TestVectorsIsNotSubsetOfExpressions()
         {
             // expect
-            Assert.That(!Vectors.R2.IsSubsetOf(Sets.Expressions.Value));
-            Assert.That(!Vectors.R3.IsSubsetOf(Sets.Expressions.Value));
+            Assert.False(Vectors.R2.IsSubsetOf(Sets.Expressions.Value));
+            Assert.False(Vectors.R3.IsSubsetOf(Sets.Expressions.Value));
         }
 
         [Test]
         public void TestVectorsIsNotSupersetOfLiterals()
         {
             // expect
-            Assert.That(!Vectors.R2.IsSupersetOf(Literals.Value));
-            Assert.That(!Vectors.R3.IsSupersetOf(Literals.Value));
+            Assert.False(Vectors.R2.IsSupersetOf(Literals.Value));
+            Assert.False(Vectors.R3.IsSupersetOf(Literals.Value));
         }
 
         [Test]
         public void TestVectorsIsNotSubsetOfLiterals()
         {
             // expect
-            Assert.That(!Vectors.R2.IsSubsetOf(Literals.Value));
-            Assert.That(!Vectors.R3.IsSubsetOf(Literals.Value));
+            Assert.False(Vectors.R2.IsSubsetOf(Literals.Value));
+            Assert.False(Vectors.R3.IsSubsetOf(Literals.Value));
         }
 
         [Test]
         public void TestVectorsIsNotSupersetOfComponentAccesses()
         {
             // expect
-            Assert.That(!Vectors.R2.IsSupersetOf(ComponentAccesses.Value));
-            Assert.That(!Vectors.R3.IsSupersetOf(ComponentAccesses.Value));
+            Assert.False(Vectors.R2.IsSupersetOf(ComponentAccesses.Value));
+            Assert.False(Vectors.R3.IsSupersetOf(ComponentAccesses.Value));
         }
 
         [Test]
         public void TestVectorsIsNotSubsetOfComponentAccesses()
         {
             // expect
-            Assert.That(!Vectors.R2.IsSubsetOf(ComponentAccesses.Value));
-            Assert.That(!Vectors.R3.IsSubsetOf(ComponentAccesses.Value));
+            Assert.False(Vectors.R2.IsSubsetOf(ComponentAccesses.Value));
+            Assert.False(Vectors.R3.IsSubsetOf(ComponentAccesses.Value));
         }
 
         [Test]
         public void TestVectorsIsNotSupersetOfFunctionCalls()
         {
             // expect
-            Assert.That(!Vectors.R2.IsSupersetOf(FunctionCalls.Value));
-            Assert.That(!Vectors.R3.IsSupersetOf(FunctionCalls.Value));
+            Assert.False(Vectors.R2.IsSupersetOf(FunctionCalls.Value));
+            Assert.False(Vectors.R3.IsSupersetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestVectorsIsNotSubsetOfFunctionCalls()
         {
             // expect
-            Assert.That(!Vectors.R2.IsSubsetOf(FunctionCalls.Value));
-            Assert.That(!Vectors.R3.IsSubsetOf(FunctionCalls.Value));
+            Assert.False(Vectors.R2.IsSubsetOf(FunctionCalls.Value));
+            Assert.False(Vectors.R3.IsSubsetOf(FunctionCalls.Value));
         }
 
         [Test]
         public void TestVectorsIsNotSupersetOfIntervalExpressions()
         {
             // expect
-            Assert.That(!Vectors.R2.IsSupersetOf(IntervalExpressions.Value));
-            Assert.That(!Vectors.R3.IsSupersetOf(IntervalExpressions.Value));
+            Assert.False(Vectors.R2.IsSupersetOf(IntervalExpressions.Value));
+            Assert.False(Vectors.R3.IsSupersetOf(IntervalExpressions.Value));
         }
 
         [Test]
         public void TestVectorsIsNotSubsetOfIntervalExpressions()
         {
             // expect
-            Assert.That(!Vectors.R2.IsSubsetOf(IntervalExpressions.Value));
-            Assert.That(!Vectors.R3.IsSubsetOf(IntervalExpressions.Value));
+            Assert.False(Vectors.R2.IsSubsetOf(IntervalExpressions.Value));
+            Assert.False(Vectors.R3.IsSubsetOf(IntervalExpressions.Value));
         }
 
         [Test]
         public void TestVectorsIsNotSupersetOfTensorExpressions()
         {
             // expect
-            Assert.That(!Vectors.R2.IsSupersetOf(TensorExpressions.Value));
-            Assert.That(!Vectors.R3.IsSupersetOf(TensorExpressions.Value));
+            Assert.False(Vectors.R2.IsSupersetOf(TensorExpressions.Value));
+            Assert.False(Vectors.R3.IsSupersetOf(TensorExpressions.Value));
         }
 
         [Test]
         public void TestVectorsIsNotSubsetOfTensorExpressions()
         {
             // expect
-            Assert.That(!Vectors.R2.IsSubsetOf(TensorExpressions.Value));
-            Assert.That(!Vectors.R3.IsSubsetOf(TensorExpressions.Value));
+            Assert.False(Vectors.R2.IsSubsetOf(TensorExpressions.Value));
+            Assert.False(Vectors.R3.IsSubsetOf(TensorExpressions.Value));
         }
 
         [Test]
         public void TestVectorsIsNotSupersetOfMatrixExpressions()
         {
             // expect
-            Assert.That(!Vectors.R2.IsSupersetOf(MatrixExpressions.Value));
-            Assert.That(!Vectors.R3.IsSupersetOf(MatrixExpressions.Value));
+            Assert.False(Vectors.R2.IsSupersetOf(MatrixExpressions.Value));
+            Assert.False(Vectors.R3.IsSupersetOf(MatrixExpressions.Value));
         }
 
         [Test]
         public void TestVectorsIsNotSubsetOfMatrixExpressions()
         {
             // expect
-            Assert.That(!Vectors.R2.IsSubsetOf(MatrixExpressions.Value));
-            Assert.That(!Vectors.R3.IsSubsetOf(MatrixExpressions.Value));
+            Assert.False(Vectors.R2.IsSubsetOf(MatrixExpressions.Value));
+            Assert.False(Vectors.R3.IsSubsetOf(MatrixExpressions.Value));
         }
 
         [Test]
         public void TestVectorsIsNotSupersetOfVectorExpressions()
         {
             // expect
-            Assert.That(!Vectors.R2.IsSupersetOf(VectorExpressions.Value));
-            Assert.That(!Vectors.R3.IsSupersetOf(VectorExpressions.Value));
+            Assert.False(Vectors.R2.IsSupersetOf(VectorExpressions.Value));
+            Assert.False(Vectors.R3.IsSupersetOf(VectorExpressions.Value));
         }
 
         [Test]
         public void TestVectorsIsNotSubsetOfVectorExpressions()
         {
             // expect
-            Assert.That(!Vectors.R2.IsSubsetOf(VectorExpressions.Value));
-            Assert.That(!Vectors.R3.IsSubsetOf(VectorExpressions.Value));
+            Assert.False(Vectors.R2.IsSubsetOf(VectorExpressions.Value));
+            Assert.False(Vectors.R3.IsSubsetOf(VectorExpressions.Value));
         }
 
         [Test]
         public void TestVectorsIsNotSupersetOfVariableAccesses()
         {
             // expect
-            Assert.That(!Vectors.R2.IsSupersetOf(VariableAccesses.Value));
-            Assert.That(!Vectors.R3.IsSupersetOf(VariableAccesses.Value));
+            Assert.False(Vectors.R2.IsSupersetOf(VariableAccesses.Value));
+            Assert.False(Vectors.R3.IsSupersetOf(VariableAccesses.Value));
         }
 
         [Test]
         public void TestVectorsIsNotSubsetOfVariableAccesses()
         {
             // expect
-            Assert.That(!Vectors.R2.IsSubsetOf(VariableAccesses.Value));
-            Assert.That(!Vectors.R3.IsSubsetOf(VariableAccesses.Value));
+            Assert.False(Vectors.R2.IsSubsetOf(VariableAccesses.Value));
+            Assert.False(Vectors.R3.IsSubsetOf(VariableAccesses.Value));
         }
     }
 }

--- a/MetaphysicsIndustries.Solus.Test/SetsT/gen_subset_superset_tests.py
+++ b/MetaphysicsIndustries.Solus.Test/SetsT/gen_subset_superset_tests.py
@@ -1,8 +1,9 @@
 types={
 "MathObjects": ["Sets","AllFunctions", "Tensors", "Booleans", "Reals", "Strings", "Intervals", "Expressions",],
     "Sets": [],
-    "AllFunctions": ["Functions"],
+    "AllFunctions": ["Functions", "VariadicFunctions"],
         "Functions": [],
+        "VariadicFunctions": [],
     "Tensors": ["AllVectors", "AllMatrices",],
         "AllVectors": ["Vectors",],
             "Vectors": [],
@@ -58,6 +59,7 @@ for type in all_types:
 get_type_by_name("Vectors").fields = ["R2", "R3"]
 get_type_by_name("Matrices").fields = ["M2x2", "M3x3"]
 get_type_by_name("Functions").fields = ["RealsToReals"]
+get_type_by_name("VariadicFunctions").fields = ["RealsToReals"]
 get_type_by_name("Sets").display_name = 'Sets.Sets'
 get_type_by_name("Functions").display_name = 'Sets.Functions'
 get_type_by_name("Expressions").display_name = 'Sets.Expressions'
@@ -65,10 +67,11 @@ get_type_by_name("Expressions").display_name = 'Sets.Expressions'
 def gen_test(type1, type2, super_vs_sub, is_x_of):
     lines = []
     not_ = ''
-    exclam = ''
     if not is_x_of:
         not_ = 'Not'
-        exclam = '!'
+    assert_ = 'Assert.True'
+    if not is_x_of:
+        assert_ = 'Assert.False'
     type2_title = type2.name
     if type1 is type2:
         type2_title = 'Self'
@@ -83,9 +86,28 @@ f'''        [Test]
 ''')
     for f1 in type1.fields:
         for f2 in type2.fields:
-            lines.append(
-f'''            Assert.That({exclam}{type1.display_name}.{f1}.Is{super_sub}setOf({type2.display_name}.{f2}));
-''')
+            attempt1 = \
+f'''            {assert_}({type1.display_name}.{f1}.\
+Is{super_sub}setOf({type2.display_name}.{f2}));
+'''
+            if len(attempt1.rstrip()) < 79:
+                lines.append(attempt1)
+            else:
+                attempt2 = \
+f'''            {assert_}(
+                {type1.display_name}.{f1}.\
+Is{super_sub}setOf({type2.display_name}.{f2}));
+'''
+                if len(attempt2.splitlines()[1]) < 79:
+                    lines.append(attempt2)
+                else:
+                    attempt3 = \
+f'''            {assert_}(
+                {type1.display_name}.{f1}.Is{super_sub}setOf(
+                    {type2.display_name}.{f2}));
+'''
+                    lines.append(attempt3)
+
     lines.append(
 '''        }
 ''')
@@ -108,15 +130,30 @@ f'''        [Test]
 ''')
     for f1 in type1.fields:
         for f2 in type2.fields:
-            if f1 == f2:
-                lines.append(
-f'''            Assert.That({type1.display_name}.{f1}.Is{super_sub}setOf({type2.display_name}.{f2}));
-''')
+            assert_ = 'Assert.True'
+            if f1 != f2:
+                assert_ = 'Assert.False'
+            attempt1 = \
+f'''            {assert_}({type1.display_name}.{f1}.\
+Is{super_sub}setOf({type2.display_name}.{f2}));
+'''
+            if len(attempt1.rstrip()) < 79:
+                lines.append(attempt1)
             else:
-                lines.append(
-f'''            Assert.That(!{type1.display_name}.{f1}.Is{super_sub}setOf({type2.display_name}.{f2}));
-''')
-
+                attempt2 = \
+                    f'''            {assert_}(
+                {type1.display_name}.{f1}.\
+Is{super_sub}setOf({type2.display_name}.{f2}));
+'''
+                if len(attempt2.splitlines()[1]) < 79:
+                    lines.append(attempt2)
+                else:
+                    attempt3 = \
+                        f'''            {assert_}(
+                {type1.display_name}.{f1}.Is{super_sub}setOf(
+                    {type2.display_name}.{f2}));
+'''
+                    lines.append(attempt3)
     lines.append(
 '''        }
 ''')

--- a/MetaphysicsIndustries.Solus.Test/SolusParserT/SolusParserTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/SolusParserT/SolusParserTest.cs
@@ -590,6 +590,8 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             {
                 throw new NotImplementedException();
             }
+            public override IFunctionType FunctionType =>
+                throw new NotImplementedException();
         }
 
         [Test]
@@ -630,6 +632,8 @@ namespace MetaphysicsIndustries.Solus.Test.SolusParserT
             {
                 throw new NotImplementedException();
             }
+            public override IFunctionType FunctionType =>
+                throw new NotImplementedException();
         }
 
         [Test]

--- a/MetaphysicsIndustries.Solus.Test/ValuesT/VectorT/VectorTest.cs
+++ b/MetaphysicsIndustries.Solus.Test/ValuesT/VectorT/VectorTest.cs
@@ -101,5 +101,43 @@ namespace MetaphysicsIndustries.Solus.Test.ValuesT.VectorT
             // then
             Assert.That(result, Is.EqualTo("[1, 2, 3]"));
         }
+
+        [Test]
+        public void VectorIsEqualToVector2()
+        {
+            // given
+            var a = new Vector(new float[] { 2, 3 });
+            var b = new Vector2(2, 3);
+            // expect
+            // ReSharper disable once SuspiciousTypeConversion.Global
+            Assert.That(a.Equals(b));
+            // ReSharper disable once SuspiciousTypeConversion.Global
+            Assert.That(b.Equals(a));
+#pragma warning disable NUnit2021
+            Assert.That(a, Is.EqualTo(b));
+            Assert.That(b, Is.EqualTo(a));
+#pragma warning restore NUnit2021
+            Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
+            Assert.That(b.GetHashCode(), Is.EqualTo(a.GetHashCode()));
+        }
+
+        [Test]
+        public void VectorIsEqualToVector3()
+        {
+            // given
+            var a = new Vector(new float[] { 5, 7, 11 });
+            var b = new Vector3(5, 7, 11);
+            // expect
+            // ReSharper disable once SuspiciousTypeConversion.Global
+            Assert.That(a.Equals(b));
+            // ReSharper disable once SuspiciousTypeConversion.Global
+            Assert.That(b.Equals(a));
+#pragma warning disable NUnit2021
+            Assert.That(a, Is.EqualTo(b));
+            Assert.That(b, Is.EqualTo(a));
+#pragma warning restore NUnit2021
+            Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
+            Assert.That(b.GetHashCode(), Is.EqualTo(a.GetHashCode()));
+        }
     }
 }

--- a/PrefixTree.cs
+++ b/PrefixTree.cs
@@ -1,0 +1,57 @@
+
+/*
+ *  MetaphysicsIndustries.Solus
+ *  Copyright (C) 2006-2022 Metaphysics Industries, Inc., Richard Sartor
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+using System;
+using System.Collections.Generic;
+
+namespace MetaphysicsIndustries.Solus
+{
+    public class PrefixTree<TKey, TValue>
+    {
+        public PrefixTree(TValue value)
+        {
+            Value = value;
+        }
+
+        public readonly TValue Value;
+
+        public readonly Dictionary<TKey, PrefixTree<TKey, TValue>>
+            Subtrees =
+                new Dictionary<TKey, PrefixTree<TKey, TValue>>();
+
+        public TValue Get(TKey[] parameterTypes, int index,
+            Func<TKey[], int, TValue> allocate)
+        {
+            var key = parameterTypes[index];
+            if (!Subtrees.ContainsKey(key))
+            {
+                var value = allocate(parameterTypes, index);
+                Subtrees[key] = new PrefixTree<TKey, TValue>(value);
+            }
+
+            var sub = Subtrees[key];
+            if (index + 1 == parameterTypes.Length)
+                return sub.Value;
+            return sub.Get(parameterTypes, index + 1, allocate);
+        }
+    }
+}

--- a/Sets/Booleans.cs
+++ b/Sets/Booleans.cs
@@ -31,8 +31,9 @@ namespace MetaphysicsIndustries.Solus.Sets
         }
 
         public bool Contains(IMathObject mo) => mo.IsIsBoolean(null);
-        public bool IsSupersetOf(ISet other) => other == this;
-
+        public bool IsSupersetOf(ISet other) =>
+            other == this ||
+            other.IsSubsetOf(this);
         public bool IsSubsetOf(ISet other) =>
             other == this ||
             other is MathObjects;

--- a/Sets/Expressions.cs
+++ b/Sets/Expressions.cs
@@ -32,17 +32,9 @@ namespace MetaphysicsIndustries.Solus.Sets
 
         public bool Contains(IMathObject mo) => mo.IsIsExpression(null);
         public string DisplayName => "Expression";
-
         public bool IsSupersetOf(ISet other) =>
-            other is Expressions ||
-            other is TensorExpressions ||
-            other is MatrixExpressions ||
-            other is VectorExpressions ||
-            other is Literals ||
-            other is ComponentAccesses ||
-            other is FunctionCalls ||
-            other is IntervalExpressions ||
-            other is VariableAccesses;
+            other == this ||
+            other.IsSubsetOf(this);
         public bool IsSubsetOf(ISet other) =>
             other is Expressions ||
             other is MathObjects;
@@ -76,7 +68,9 @@ namespace MetaphysicsIndustries.Solus.Sets
 
         public bool Contains(IMathObject mo) => mo.IsIsComponentAccess();
         public string DisplayName => "ComponentAccess";
-        public bool IsSupersetOf(ISet other) => other is ComponentAccesses;
+        public bool IsSupersetOf(ISet other) =>
+            other == this ||
+            other.IsSubsetOf(this);
         public bool IsSubsetOf(ISet other) =>
             other is ComponentAccesses ||
             other is Expressions ||
@@ -110,7 +104,9 @@ namespace MetaphysicsIndustries.Solus.Sets
 
         public bool Contains(IMathObject mo) => mo.IsIsFunctionCall();
         public string DisplayName => "FunctionCall";
-        public bool IsSupersetOf(ISet other) => other is FunctionCalls;
+        public bool IsSupersetOf(ISet other) =>
+            other == this ||
+            other.IsSubsetOf(this);
         public bool IsSubsetOf(ISet other) =>
             other is FunctionCalls ||
             other is Expressions ||
@@ -145,7 +141,9 @@ namespace MetaphysicsIndustries.Solus.Sets
 
         public bool Contains(IMathObject mo) => mo.IsIsIntervalExpression();
         public string DisplayName => "IntervalExpression";
-        public bool IsSupersetOf(ISet other) => other is IntervalExpressions;
+        public bool IsSupersetOf(ISet other) =>
+            other == this ||
+            other.IsSubsetOf(this);
         public bool IsSubsetOf(ISet other) =>
             other is IntervalExpressions ||
             other is Expressions ||
@@ -179,7 +177,9 @@ namespace MetaphysicsIndustries.Solus.Sets
 
         public bool Contains(IMathObject mo) => mo.IsIsLiteral();
         public string DisplayName => "Literal";
-        public bool IsSupersetOf(ISet other) => other is Literals;
+        public bool IsSupersetOf(ISet other) =>
+            other == this ||
+            other.IsSubsetOf(this);
         public bool IsSubsetOf(ISet other) =>
             other is Literals ||
             other is Expressions ||
@@ -215,9 +215,8 @@ namespace MetaphysicsIndustries.Solus.Sets
         public bool Contains(IMathObject mo) => mo.IsIsTensorExpression();
         public string DisplayName => "TensorExpression";
         public bool IsSupersetOf(ISet other) =>
-            other is TensorExpressions ||
-            other is VectorExpressions ||
-            other is MatrixExpressions;
+            other == this ||
+            other.IsSubsetOf(this);
         public bool IsSubsetOf(ISet other) =>
             other is TensorExpressions ||
             other is Expressions ||
@@ -252,7 +251,9 @@ namespace MetaphysicsIndustries.Solus.Sets
 
         public bool Contains(IMathObject mo) => mo.IsIsMatrixExpression();
         public string DisplayName => "MatrixExpression";
-        public bool IsSupersetOf(ISet other) => other is MatrixExpressions;
+        public bool IsSupersetOf(ISet other) =>
+            other == this ||
+            other.IsSubsetOf(this);
         public bool IsSubsetOf(ISet other) =>
             other is TensorExpressions ||
             other is MatrixExpressions ||
@@ -288,7 +289,9 @@ namespace MetaphysicsIndustries.Solus.Sets
 
         public bool Contains(IMathObject mo) => mo.IsIsVectorExpression();
         public string DisplayName => "VectorExpression";
-        public bool IsSupersetOf(ISet other) => other is VectorExpressions;
+        public bool IsSupersetOf(ISet other) =>
+            other == this ||
+            other.IsSubsetOf(this);
         public bool IsSubsetOf(ISet other) =>
             other is TensorExpressions ||
             other is VectorExpressions ||
@@ -324,7 +327,9 @@ namespace MetaphysicsIndustries.Solus.Sets
 
         public bool Contains(IMathObject mo) => mo.IsIsVariableAccess();
         public string DisplayName => "VariableAccess";
-        public bool IsSupersetOf(ISet other) => other is VariableAccesses;
+        public bool IsSupersetOf(ISet other) =>
+            other == this ||
+            other.IsSubsetOf(this);
         public bool IsSubsetOf(ISet other) =>
             other is VariableAccesses ||
             other is Expressions ||

--- a/Sets/Functions.cs
+++ b/Sets/Functions.cs
@@ -32,23 +32,40 @@ namespace MetaphysicsIndustries.Solus.Sets
     /// </summary>
     public class Functions : ISet
     {
-        protected static Dictionary<ISet, Dictionary<ISet[], Functions>> sets =
-            new Dictionary<ISet, Dictionary<ISet[], Functions>>();
+        protected static Dictionary<ISet, PrefixTree<ISet, Functions>> sets2 =
+            new Dictionary<ISet, PrefixTree<ISet, Functions>>();
+
         public static Functions Get(ISet returnType,
             params ISet[] parameterTypes)
         {
-            if (!sets.ContainsKey(returnType))
-                sets[returnType] = new Dictionary<ISet[], Functions>();
-            if (!sets[returnType].ContainsKey(parameterTypes))
-                sets[returnType][parameterTypes] =
-                    new Functions(returnType, parameterTypes);
-            return sets[returnType][parameterTypes];
+            if (!sets2.ContainsKey(returnType))
+                sets2[returnType] =
+                    new PrefixTree<ISet, Functions>(new Functions(returnType,
+                        Array.Empty<ISet>()));
+            var x = sets2[returnType].Get(parameterTypes, 0,
+                (ptypes, index) => Allocate(returnType, ptypes, index));
+            return x;
         }
 
-        public static Functions RealsToReals = Get(Reals.Value, Reals.Value);
+        public static Functions Allocate(ISet returnType,
+            ISet[] parameterTypes, int index)
+        {
+            var ptypes2 = new ISet[index + 1];
+            int i;
+            for (i = 0; i <= index; i++)
+                ptypes2[i] = parameterTypes[i];
+            return new Functions(returnType, ptypes2);
+        }
+
+        public static readonly Functions RealsToReals =
+            Get(Reals.Value, Reals.Value);
+
+        private static int __id = 1;
+        public readonly int ID;
 
         protected Functions(ISet returnType, ISet[] parameterTypes)
         {
+            ID = __id++;
             ReturnType = returnType;
             ParameterTypes = Array.AsReadOnly(parameterTypes);
         }

--- a/Sets/Functions.cs
+++ b/Sets/Functions.cs
@@ -34,26 +34,60 @@ namespace MetaphysicsIndustries.Solus.Sets
 
     /// <summary>
     /// The set of functions of fixed arity, and whose parameters' types are
-    /// subsets of the types given in `this.ParameterTypes`, and whose return
-    /// types are subsets of `this.ReturnType`.
+    /// supersets of the types given in `this.ParameterTypes`, and whose
+    /// return type is a subset of `this.ReturnType`. A function can be a
+    /// member of more than one function type, as the `ParameterTypes` and
+    /// `ReturnType` do not require strict equality for a function to be
+    /// considered a member.
+    ///
+    /// In brief, the `ParameterTypes` field answers the question "Can the
+    /// function accept arguments that are members of these sets?". The
+    /// `ReturnType` field answers the question "Will the output of the
+    /// function be a member of this set?".
     ///
     /// Example: A function having the reals as both its domain and
     /// codomain is a member of `Functions.RealsToReals`.
     ///
     /// Example: A function having the integers as both its domain and
-    /// codomain is considered a member of `Functions.RealsToReals`.
+    /// codomain is considered a member of
+    /// `Functions.Get(Integers, Integers)`.
+    ///
+    /// Example: A function having the integers as both its domain and
+    /// codomain is also considered a member of
+    /// `Functions.Get(Reals.Value, Integers)`.
     ///
     /// Example: A function having the reals as its domain and the real
     /// interval [0, +inf) as its codomain is considered a member of both
     /// `Functions.RealsToReals` and `Functions.Get([0, +inf), Reals.Values)`.
     ///
+    /// Example: A function having the real interval [0, +inf) as its domain
+    /// and the reals as its codomain is considered a member of
+    /// `Functions.Get(Reals.Values, [0, +inf))` but NOT a member of
+    /// `Functions.RealsToReals`.
+    ///
+    /// Example: A function having the reals as its domain and X as its
+    /// codomain would be a member of both `Functions.Get(X, Reals.Value)` and
+    /// `Functions.Get(X, Integers.Value)`, because the integers are a subset
+    /// of the reals.
+    ///
+    /// Example: A function having the the integers as its domain and X as its
+    /// codomain would be considered a member of
+    /// `Functions.Get(X, Integers.Value)`, but not a member of
+    /// `Functions.Get(X, Reals.Value)`.
+    ///
+    /// Example: A function having X as its domain and the reals as its
+    /// codomain would be considered a member of
+    /// `Functions.Get(Reals.Value, X)`, but not a member of
+    /// `Functions.Get(Integers.Value, X)`.
+    ///
+    /// Example: A function having X as its domain and the integers as its
+    /// codomain would be considered a member of both
+    /// `Functions.Get(Reals.Value, X)` and
+    /// `Functions.Get(Integers.Value, X)`.
+    ///
     /// Counter-example: A function having the reals as both its domain and
     /// codomain would not be considered a member of
     /// `Functions.Get(Integers.Value, Integers.Value)`.
-    ///
-    /// Counter-example: A function having the reals as its domain and the
-    /// real interval [0, +inf) as its codomain would not be considered a
-    /// member of `Functions.Get([0, +inf), [0, +inf))`.
     /// </summary>
     public class Functions : IFunctionType
     {

--- a/Sets/Functions.cs
+++ b/Sets/Functions.cs
@@ -251,6 +251,72 @@ namespace MetaphysicsIndustries.Solus.Sets
     }
 
     /// <summary>
+    /// All functions taking a (positive) fixed or varying number of
+    /// arguments, each argument being a vector, all arguments having the
+    /// same dimension, and returning a vector of that dimension.
+    ///
+    /// i.e. union( VF(V(n), V(n)) for all n in NaturalNumbers )
+    /// </summary>
+    public class AllVectorFunctions : ISet
+    {
+        public static readonly AllVectorFunctions Value =
+            new AllVectorFunctions();
+
+        public bool Contains(IMathObject mo)
+        {
+            if (!mo.IsIsFunction(null))
+                return false;
+            var f = mo.ToFunction();
+            if (f.Parameters.Count < 1)
+                // nullary functions not included
+                return false;
+            if (!f.Parameters[0].Type.IsSubsetOf(AllVectors.Value))
+                return false;
+            var t = f.Parameters[0].Type;
+            if (!(t is Vectors))
+                return false;
+            if (f.GetResultType(null, null) != t)
+                return false;
+            int i;
+            // this will also work for variadic functions
+            for (i = 0; i < f.Parameters.Count; i++)
+                if (f.Parameters[i].Type != t)
+                    return false;
+            return true;
+        }
+
+        public bool IsSupersetOf(ISet other) => this == other;
+        public bool IsSubsetOf(ISet other) =>
+            // TODO: VariadicFunctions ?
+            other == this ||
+            other is AllFunctions ||
+            other is MathObjects;
+
+        public bool? IsScalar(SolusEnvironment env) => false;
+        public bool? IsBoolean(SolusEnvironment env) => false;
+        public bool? IsVector(SolusEnvironment env) => false;
+        public bool? IsMatrix(SolusEnvironment env) => false;
+        public int? GetTensorRank(SolusEnvironment env) => null;
+        public bool? IsString(SolusEnvironment env) => false;
+        public int? GetDimension(SolusEnvironment env, int index) => null;
+        public int[] GetDimensions(SolusEnvironment env) => null;
+        public int? GetVectorLength(SolusEnvironment env) => null;
+        public bool? IsInterval(SolusEnvironment env) => false;
+        public bool? IsFunction(SolusEnvironment env) => false;
+        public bool? IsExpression(SolusEnvironment env) => false;
+        public bool? IsSet(SolusEnvironment env) => true;
+        public bool IsConcrete => true;
+
+        private string _docString = null;
+
+        public string DocString =>
+            "The set of all functions taking any number of parameters of a " +
+            "vector type and returning that same vector type";
+
+        public string DisplayName => "VectorFunction";
+    }
+
+    /// <summary>
     /// All functions of any arity
     /// </summary>
     public class AllFunctions : ISet

--- a/Sets/Functions.cs
+++ b/Sets/Functions.cs
@@ -32,7 +32,19 @@ namespace MetaphysicsIndustries.Solus.Sets
     }
 
     /// <summary>
-    /// Functions of fixed arity and defined types
+    /// The set of functions of fixed arity, and whose parameters' types are
+    /// subsets of the types given in `this.ParameterTypes`, and whose return
+    /// types are subsets of `this.ReturnType`.
+    ///
+    /// Example: A function having the reals as both its domain and
+    /// codomain is a member of `Functions.RealsToReals`.
+    ///
+    /// Example: A function having the integers as both its domain and
+    /// codomain is considered a member of `Functions.RealsToReals`.
+    ///
+    /// Counter-example: A function having the reals as both its domain and
+    /// codomain would not be considered a member of
+    /// `Functions.Get(Integers.Value, Integers.Value)`.
     /// </summary>
     public class Functions : IFunctionType
     {

--- a/Sets/Functions.cs
+++ b/Sets/Functions.cs
@@ -27,6 +27,9 @@ using MetaphysicsIndustries.Solus.Functions;
 
 namespace MetaphysicsIndustries.Solus.Sets
 {
+    /// <summary>
+    /// Functions of fixed arity and defined types
+    /// </summary>
     public class Functions : ISet
     {
         protected static Dictionary<ISet, Dictionary<ISet[], Functions>> sets =
@@ -169,6 +172,87 @@ namespace MetaphysicsIndustries.Solus.Sets
         public string DisplayName => "Function";
     }
 
+    /// <summary>
+    /// Functions of varying arity, having all arguments of the same type
+    /// </summary>
+    public class VariadicFunctions : ISet
+    {
+        protected static Dictionary<STuple<ISet, ISet>, VariadicFunctions>
+            sets = new Dictionary<STuple<ISet, ISet>, VariadicFunctions>();
+        public static VariadicFunctions Get(ISet returnType,
+            ISet parameterType)
+        {
+            var stuple = new STuple<ISet, ISet>(returnType, parameterType);
+            if (!sets.ContainsKey(stuple))
+                sets[stuple] = new VariadicFunctions(returnType,
+                    parameterType);
+            return sets[stuple];
+        }
+
+        public static VariadicFunctions RealsToReals = Get(Reals.Value,
+            Reals.Value);
+
+        protected VariadicFunctions(ISet returnType, ISet parameterType)
+        {
+            ReturnType = returnType;
+            ParameterType = parameterType;
+        }
+
+        public readonly ISet ReturnType;
+        public readonly ISet ParameterType;
+
+        public bool Contains(IMathObject mo)
+        {
+            if (!mo.IsIsFunction(null))
+                return false;
+            var f = mo.ToFunction();
+            if (!f.IsVariadic)
+                return false;
+            if (f.GetResultType(null, null) != ReturnType)
+                return false;
+            if (f.Parameters.Count != 1)
+                // this should not even be possible, since the function is
+                // marked variadic
+                return false;
+            if (f.Parameters[0].Type != ParameterType)
+                return false;
+            return true;
+        }
+
+        public bool IsSupersetOf(ISet other) => this == other;
+        public bool IsSubsetOf(ISet other) =>
+            other == this ||
+            other is AllFunctions ||
+            other is MathObjects;
+
+        public bool? IsScalar(SolusEnvironment env) => false;
+        public bool? IsBoolean(SolusEnvironment env) => false;
+        public bool? IsVector(SolusEnvironment env) => false;
+        public bool? IsMatrix(SolusEnvironment env) => false;
+        public int? GetTensorRank(SolusEnvironment env) => null;
+        public bool? IsString(SolusEnvironment env) => false;
+        public int? GetDimension(SolusEnvironment env, int index) => null;
+        public int[] GetDimensions(SolusEnvironment env) => null;
+        public int? GetVectorLength(SolusEnvironment env) => null;
+        public bool? IsInterval(SolusEnvironment env) => false;
+        public bool? IsFunction(SolusEnvironment env) => false;
+        public bool? IsExpression(SolusEnvironment env) => false;
+        public bool? IsSet(SolusEnvironment env) => true;
+        public bool IsConcrete => true;
+
+        private string _docString = null;
+
+        public string DocString =>
+            "The set of all variadic functions taking parameters of " +
+            $"{ParameterType.DisplayName} and returning " +
+            $"{ReturnType.DisplayName}";
+
+        public string DisplayName => "Function";
+    }
+
+    /// <summary>
+    /// All functions of any arity
+    /// </summary>
     public class AllFunctions : ISet
     {
         public static readonly AllFunctions Value = new AllFunctions();

--- a/Sets/Functions.cs
+++ b/Sets/Functions.cs
@@ -139,7 +139,7 @@ namespace MetaphysicsIndustries.Solus.Sets
 
         public static bool FunctionHasFixedTypes(Function f)
         {
-            if (f is AssociativeCommutativeOperation)
+            if (f is IAssociativeCommutativeOperation)
                 // + * |
                 return false;
             if (f is SizeFunction)

--- a/Sets/Functions.cs
+++ b/Sets/Functions.cs
@@ -262,7 +262,9 @@ namespace MetaphysicsIndustries.Solus.Sets
             return true;
         }
 
-        public bool IsSupersetOf(ISet other) => this == other;
+        public bool IsSupersetOf(ISet other) =>
+            other == this ||
+            other.IsSubsetOf(this);
         public bool IsSubsetOf(ISet other) =>
             other == this ||
             other is AllFunctions ||
@@ -373,9 +375,8 @@ namespace MetaphysicsIndustries.Solus.Sets
         public bool Contains(IMathObject mo) => mo.IsIsFunction(null);
 
         public bool IsSupersetOf(ISet other) =>
-            other is Functions ||
-            other is AllFunctions;
-
+            other == this ||
+            other.IsSubsetOf(this);
         public bool IsSubsetOf(ISet other) =>
             other == this ||
             other is MathObjects;

--- a/Sets/Functions.cs
+++ b/Sets/Functions.cs
@@ -42,9 +42,17 @@ namespace MetaphysicsIndustries.Solus.Sets
     /// Example: A function having the integers as both its domain and
     /// codomain is considered a member of `Functions.RealsToReals`.
     ///
+    /// Example: A function having the reals as its domain and the real
+    /// interval [0, +inf) as its codomain is considered a member of both
+    /// `Functions.RealsToReals` and `Functions.Get([0, +inf), Reals.Values)`.
+    ///
     /// Counter-example: A function having the reals as both its domain and
     /// codomain would not be considered a member of
     /// `Functions.Get(Integers.Value, Integers.Value)`.
+    ///
+    /// Counter-example: A function having the reals as its domain and the
+    /// real interval [0, +inf) as its codomain would not be considered a
+    /// member of `Functions.Get([0, +inf), [0, +inf))`.
     /// </summary>
     public class Functions : IFunctionType
     {

--- a/Sets/Functions.cs
+++ b/Sets/Functions.cs
@@ -128,6 +128,9 @@ namespace MetaphysicsIndustries.Solus.Sets
         {
             ID = __id++;
             ReturnType = returnType;
+            // TODO: replace AsReadOnly with something that makes a copy. A
+            //       simple wrapper doesn't guarantee that the underlying
+            //       array can't change.
             ParameterTypes = Array.AsReadOnly(parameterTypes);
         }
 

--- a/Sets/Functions.cs
+++ b/Sets/Functions.cs
@@ -280,7 +280,8 @@ namespace MetaphysicsIndustries.Solus.Sets
     public class VariadicFunctions : IFunctionType
     {
         protected static Dictionary<STuple<ISet, ISet, int>, VariadicFunctions>
-            sets = new();
+            sets = new Dictionary<STuple<ISet, ISet, int>,
+                VariadicFunctions>();
 
         public static VariadicFunctions Get(ISet returnType,
             ISet parameterType, int? minimumNumberOfArguments=null)

--- a/Sets/Functions.cs
+++ b/Sets/Functions.cs
@@ -58,6 +58,8 @@ namespace MetaphysicsIndustries.Solus.Sets
                 sets2[returnType] =
                     new PrefixTree<ISet, Functions>(new Functions(returnType,
                         Array.Empty<ISet>()));
+            if (parameterTypes.Length == 0)
+                return sets2[returnType].Value;
             var x = sets2[returnType].Get(parameterTypes, 0,
                 (ptypes, index) => Allocate(returnType, ptypes, index));
             return x;

--- a/Sets/Functions.cs
+++ b/Sets/Functions.cs
@@ -27,10 +27,14 @@ using MetaphysicsIndustries.Solus.Functions;
 
 namespace MetaphysicsIndustries.Solus.Sets
 {
+    public interface IFunctionType : ISet
+    {
+    }
+
     /// <summary>
     /// Functions of fixed arity and defined types
     /// </summary>
-    public class Functions : ISet
+    public class Functions : IFunctionType
     {
         protected static Dictionary<ISet, PrefixTree<ISet, Functions>> sets2 =
             new Dictionary<ISet, PrefixTree<ISet, Functions>>();
@@ -192,7 +196,7 @@ namespace MetaphysicsIndustries.Solus.Sets
     /// <summary>
     /// Functions of varying arity, having all arguments of the same type
     /// </summary>
-    public class VariadicFunctions : ISet
+    public class VariadicFunctions : IFunctionType
     {
         protected static Dictionary<STuple<ISet, ISet>, VariadicFunctions>
             sets = new Dictionary<STuple<ISet, ISet>, VariadicFunctions>();
@@ -274,7 +278,7 @@ namespace MetaphysicsIndustries.Solus.Sets
     ///
     /// i.e. union( VF(V(n), V(n)) for all n in NaturalNumbers )
     /// </summary>
-    public class AllVectorFunctions : ISet
+    public class AllVectorFunctions : IFunctionType
     {
         public static readonly AllVectorFunctions Value =
             new AllVectorFunctions();
@@ -334,9 +338,9 @@ namespace MetaphysicsIndustries.Solus.Sets
     }
 
     /// <summary>
-    /// All functions of any arity
+    /// All functions of any arity and type
     /// </summary>
-    public class AllFunctions : ISet
+    public class AllFunctions : IFunctionType
     {
         public static readonly AllFunctions Value = new AllFunctions();
 

--- a/Sets/Intervals.cs
+++ b/Sets/Intervals.cs
@@ -35,7 +35,9 @@ namespace MetaphysicsIndustries.Solus.Sets
             return mo.IsIsInterval(null);
         }
 
-        public bool IsSupersetOf(ISet other) => other is Intervals;
+        public bool IsSupersetOf(ISet other) =>
+            other == this ||
+            other.IsSubsetOf(this);
         public bool IsSubsetOf(ISet other) =>
             other is Intervals ||
             other is MathObjects;

--- a/Sets/MathObjects.cs
+++ b/Sets/MathObjects.cs
@@ -32,34 +32,10 @@ namespace MetaphysicsIndustries.Solus.Sets
 
         public bool Contains(IMathObject mo) => mo != null;
 
-        public bool IsSupersetOf(ISet other)
-        {
-            // TODO: Russel's paradox
-            return
-                other is MathObjects ||
-                other is Booleans ||
-                other is Functions ||
-                other is AllFunctions ||
-                other is Intervals ||
-                other is Matrices ||
-                other is AllMatrices ||
-                other is Reals ||
-                other is Sets ||
-                other is Strings ||
-                other is Tensors ||
-                other is Vectors ||
-                other is AllVectors ||
-                other is Expressions ||
-                other is TensorExpressions ||
-                other is MatrixExpressions ||
-                other is VectorExpressions ||
-                other is Literals ||
-                other is ComponentAccesses ||
-                other is FunctionCalls ||
-                other is IntervalExpressions ||
-                other is VariableAccesses;
-        }
-
+        // TODO: Russel's paradox?
+        public bool IsSupersetOf(ISet other) =>
+            other == this ||
+            other.IsSubsetOf(this);
         public bool IsSubsetOf(ISet other) => other is MathObjects;
 
         public bool? IsScalar(SolusEnvironment env) => false;

--- a/Sets/Matrices.cs
+++ b/Sets/Matrices.cs
@@ -72,7 +72,9 @@ namespace MetaphysicsIndustries.Solus.Sets
                    m.ColumnCount == ColumnCount;
         }
 
-        public bool IsSupersetOf(ISet other) => other == this;
+        public bool IsSupersetOf(ISet other) =>
+            other == this ||
+            other.IsSubsetOf(this);
         public bool IsSubsetOf(ISet other) =>
             other == this ||
             other is AllMatrices ||
@@ -113,8 +115,8 @@ namespace MetaphysicsIndustries.Solus.Sets
         }
 
         public bool IsSupersetOf(ISet other) =>
-            other is Matrices ||
-            other is AllMatrices;
+            other == this ||
+            other.IsSubsetOf(this);
         public bool IsSubsetOf(ISet other) =>
             other is AllMatrices ||
             other is Tensors ||

--- a/Sets/Matrices.cs
+++ b/Sets/Matrices.cs
@@ -98,7 +98,7 @@ namespace MetaphysicsIndustries.Solus.Sets
         public string DocString =>
             $"The set of {RowCount}x{ColumnCount} matrices";
 
-        public string DisplayName => "Matrix";
+        public string DisplayName => $"Matrix({RowCount}, {ColumnCount})";
     }
 
     public class AllMatrices : ISet

--- a/Sets/Reals.cs
+++ b/Sets/Reals.cs
@@ -36,8 +36,9 @@ namespace MetaphysicsIndustries.Solus.Sets
             return mo.IsIsScalar(null);
         }
 
-        public bool IsSupersetOf(ISet other) => other == this;
-
+        public bool IsSupersetOf(ISet other) =>
+            other == this ||
+            other.IsSubsetOf(this);
         public bool IsSubsetOf(ISet other)
         {
             // TODO: are reals tensors of rank 0?

--- a/Sets/Sets.cs
+++ b/Sets/Sets.cs
@@ -35,12 +35,10 @@ namespace MetaphysicsIndustries.Solus.Sets
             //       ordered pairs/tuples
             mo.IsIsSet(null);
 
-        public bool IsSupersetOf(ISet other)
-        {
-            // TODO: Russel's paradox
-            return other is Sets;
-        }
-
+        // TODO: Russel's paradox?
+        public bool IsSupersetOf(ISet other) =>
+            other == this ||
+            other.IsSubsetOf(this);
         public bool IsSubsetOf(ISet other) =>
             other is Sets ||
             other is MathObjects;

--- a/Sets/Strings.cs
+++ b/Sets/Strings.cs
@@ -35,7 +35,9 @@ namespace MetaphysicsIndustries.Solus.Sets
             return mo.IsIsString(null);
         }
 
-        public bool IsSupersetOf(ISet other) => other == this;
+        public bool IsSupersetOf(ISet other) =>
+            other == this ||
+            other.IsSubsetOf(this);
         public bool IsSubsetOf(ISet other) =>
             other == this ||
             other is MathObjects;

--- a/Sets/Tensors.cs
+++ b/Sets/Tensors.cs
@@ -37,12 +37,8 @@ namespace MetaphysicsIndustries.Solus.Sets
         }
 
         public bool IsSupersetOf(ISet other) =>
-            other is Tensors ||
-            other is Vectors ||
-            other is AllVectors ||
-            other is Matrices ||
-            other is AllMatrices;
-
+            other == this ||
+            other.IsSubsetOf(this);
         public bool IsSubsetOf(ISet other) =>
             other is Tensors ||
             other is MathObjects;

--- a/Sets/Vectors.cs
+++ b/Sets/Vectors.cs
@@ -90,7 +90,7 @@ namespace MetaphysicsIndustries.Solus.Sets
         public string DocString =>
             $"The real coordinate space of dimension {Dimension}, " +
             $"ℝ^{Dimension}";
-        public string DisplayName => "Vector";
+        public string DisplayName => $"Vector({Dimension})";
     }
 
     public class AllVectors : ISet

--- a/Sets/Vectors.cs
+++ b/Sets/Vectors.cs
@@ -63,7 +63,9 @@ namespace MetaphysicsIndustries.Solus.Sets
             return v.Length == Dimension;
         }
 
-        public bool IsSupersetOf(ISet other) => other == this;
+        public bool IsSupersetOf(ISet other) =>
+            other == this ||
+            other.IsSubsetOf(this);
         public bool IsSubsetOf(ISet other) =>
             other == this ||
             other is AllVectors ||
@@ -105,8 +107,8 @@ namespace MetaphysicsIndustries.Solus.Sets
         }
 
         public bool IsSupersetOf(ISet other) =>
-            other is AllVectors||
-            other is Vectors;
+            other == this ||
+            other.IsSubsetOf(this);
         public bool IsSubsetOf(ISet other) =>
             other is AllVectors ||
             other is Tensors ||

--- a/SolusEnvironment.cs
+++ b/SolusEnvironment.cs
@@ -43,7 +43,7 @@ namespace MetaphysicsIndustries.Solus
         ///
         /// An environment can be a child of another environment. If a
         /// variable is not defined in the child environment, then the parent
-        /// will be search. This process can be repeated recursively.
+        /// will be searched. This process can be repeated recursively.
         /// </summary>
         /// <param name="useDefaults">
         /// Whether to include the default name mappings.</param>

--- a/Transformers/CleanUpTransformer.cs
+++ b/Transformers/CleanUpTransformer.cs
@@ -144,9 +144,9 @@ namespace MetaphysicsIndustries.Solus.Transformers
             {
                 return InternalCleanUpAssociativeCommutativeOperation((IAssociativeCommutativeOperation)function, args);
             }
-            if (function is BinaryOperation)
+            if (function is IBinaryOperation)
             {
-                return InternalCleanUpBinaryOperation((BinaryOperation)function, args);
+                return InternalCleanUpBinaryOperation((IBinaryOperation)function, args);
             }
 
             // throw new NotImplementedException();
@@ -202,17 +202,17 @@ namespace MetaphysicsIndustries.Solus.Transformers
             {
                 return InternalCleanUpPartAssociativeOperationAssociativeCommutativeOperation((IAssociativeCommutativeOperation)function, args, combinedLiteral, nonLiterals);
             }
-            if (function is BinaryOperation)
+            if (function is IBinaryOperation)
             {
-                return InternalCleanUpPartAssociativeOperationBinaryOperation((BinaryOperation)function, args, combinedLiteral, nonLiterals);
+                return InternalCleanUpPartAssociativeOperationBinaryOperation((IBinaryOperation)function, args, combinedLiteral, nonLiterals);
             }
 
             throw new NotImplementedException();
         }
 
-        public Expression[] InternalCleanUpPartAssociativeOperationBinaryOperation(BinaryOperation function, Expression[] args, Literal combinedLiteral, List<Expression> nonLiterals)
+        public Expression[] InternalCleanUpPartAssociativeOperationBinaryOperation(IBinaryOperation function, Expression[] args, Literal combinedLiteral, List<Expression> nonLiterals)
         {
-            FunctionCall ret = new FunctionCall(function, combinedLiteral);
+            FunctionCall ret = new FunctionCall((Function)function, combinedLiteral);
             FunctionCall temp = ret;
             FunctionCall last = null;
 
@@ -220,7 +220,7 @@ namespace MetaphysicsIndustries.Solus.Transformers
             {
                 //Expression cleanExpr = CleanUp(expr);
                 last = temp;
-                temp = new FunctionCall(function, expr);//cleanExpr);
+                temp = new FunctionCall((Function)function, expr);//cleanExpr);
                 last.Arguments.Add(temp);
             }
 
@@ -307,12 +307,12 @@ namespace MetaphysicsIndustries.Solus.Transformers
             return newArgs.ToArray();
         }
 
-        public Expression InternalCleanUpBinaryOperation(BinaryOperation function, Expression[] args)
+        public Expression InternalCleanUpBinaryOperation(IBinaryOperation function, Expression[] args)
         {
             if (args[0] is Literal &&
                 args[1] is Literal)
             {
-                var newExpr = new FunctionCall(function, args);
+                var newExpr = new FunctionCall((Function)function, args);
                 var result = _evaluator.Eval(newExpr, null);
                 return new Literal(result.ToNumber().Value);
             }
@@ -338,7 +338,7 @@ namespace MetaphysicsIndustries.Solus.Transformers
                 }
             }
 
-            return new FunctionCall(function, args);
+            return new FunctionCall((Function)function, args);
         }
     }
 }

--- a/Transformers/DerivativeTransformer.cs
+++ b/Transformers/DerivativeTransformer.cs
@@ -438,7 +438,8 @@ namespace MetaphysicsIndustries.Solus.Transformers
             }
             else
             {
-                return new Literal(AdditionOperation.Value.IdentityValue);
+                // return new Literal(AdditionOperation.Value.IdentityValue);
+                return new Literal(0);
             }
 
 

--- a/Transformers/DerivativeTransformer.cs
+++ b/Transformers/DerivativeTransformer.cs
@@ -97,7 +97,7 @@ namespace MetaphysicsIndustries.Solus.Transformers
                     "Call target is not a function");
             var function = (Function)literal.Value;
 
-            if (function is Operation)
+            if (function is IOperation)
             {
                 return GetDerivativeOfOperation(functionCall, var);
             }
@@ -150,11 +150,11 @@ namespace MetaphysicsIndustries.Solus.Transformers
             if (functionCall.Function is Literal literal)
                 f = literal.Value as Function;
 
-            if (f is BinaryOperation)
+            if (f is IBinaryOperation)
             {
                 return GetDerivativeOfBinaryOperation(functionCall, var);
             }
-            else if (f is AssociativeCommutativeOperation)
+            else if (f is IAssociativeCommutativeOperation)
             {
                 return GetDerivativeOfAssociativeCommutativOperation(functionCall, var);
             }
@@ -193,7 +193,7 @@ namespace MetaphysicsIndustries.Solus.Transformers
                 throw new OperandException(
                     "Call target is not a function");
             var f = (Function)literal.Value;
-            var binaryOperation = f as BinaryOperation;
+            var binaryOperation = f as IBinaryOperation;
 
             if (binaryOperation == DivisionOperation.Value)
                 return GetDerivativeOfDivisionOperation(functionCall, var);

--- a/Values/Matrix.cs
+++ b/Values/Matrix.cs
@@ -72,6 +72,123 @@ namespace MetaphysicsIndustries.Solus.Values
         public static Matrix Zero(int rowCount, int columnCount) =>
             new Matrix(new float[rowCount, columnCount]);
 
+        public static Matrix M22(
+            float m11, float m12,
+            float m21, float m22)
+        {
+            return new Matrix(new[,]
+            {
+                { m11, m12 },
+                { m21, m22 }
+            });
+        }
+
+        public static Matrix M23(
+            float m11, float m12, float m13,
+            float m21, float m22, float m23)
+        {
+            return new Matrix(new[,]
+            {
+                { m11, m12, m13 },
+                { m21, m22, m23 }
+            });
+        }
+
+        public static Matrix M24(
+            float m11, float m12, float m13, float m14,
+            float m21, float m22, float m23, float m24)
+        {
+            return new Matrix(new[,]
+            {
+                { m11, m12, m13, m14 },
+                { m21, m22, m23, m24 }
+            });
+        }
+
+        public static Matrix M32(
+            float m11, float m12,
+            float m21, float m22,
+            float m31, float m32)
+        {
+            return new Matrix(new[,]
+            {
+                { m11, m12 },
+                { m21, m22 },
+                { m31, m32 }
+            });
+        }
+
+        public static Matrix M33(
+            float m11, float m12, float m13,
+            float m21, float m22, float m23,
+            float m31, float m32, float m33)
+        {
+            return new Matrix(new[,]
+            {
+                { m11, m12, m13 },
+                { m21, m22, m23 },
+                { m31, m32, m33 }
+            });
+        }
+
+        public static Matrix M34(
+            float m11, float m12, float m13, float m14,
+            float m21, float m22, float m23, float m24,
+            float m31, float m32, float m33, float m34)
+        {
+            return new Matrix(new[,]
+            {
+                { m11, m12, m13, m14 },
+                { m21, m22, m23, m24 },
+                { m31, m32, m33, m34 }
+            });
+        }
+
+        public static Matrix M42(
+            float m11, float m12,
+            float m21, float m22,
+            float m31, float m32,
+            float m41, float m42)
+        {
+            return new Matrix(new[,]
+            {
+                { m11, m12 },
+                { m21, m22 },
+                { m31, m32 },
+                { m41, m42 }
+            });
+        }
+
+        public static Matrix M43(
+            float m11, float m12, float m13,
+            float m21, float m22, float m23,
+            float m31, float m32, float m33,
+            float m41, float m42, float m43)
+        {
+            return new Matrix(new[,]
+            {
+                { m11, m12, m13 },
+                { m21, m22, m23 },
+                { m31, m32, m33 },
+                { m41, m42, m43 }
+            });
+        }
+
+        public static Matrix M44(
+            float m11, float m12, float m13, float m14,
+            float m21, float m22, float m23, float m24,
+            float m31, float m32, float m33, float m34,
+            float m41, float m42, float m43, float m44)
+        {
+            return new Matrix(new[,]
+            {
+                { m11, m12, m13, m14 },
+                { m21, m22, m23, m24 },
+                { m31, m32, m33, m34 },
+                { m41, m42, m43, m44 }
+            });
+        }
+
         private readonly IMathObject[,] _components;
 
         public IMathObject this[int row, int column] =>

--- a/Values/Matrix.cs
+++ b/Values/Matrix.cs
@@ -69,6 +69,9 @@ namespace MetaphysicsIndustries.Solus.Values
                 { 0, 0, 0, 1 }
             });
 
+        public static Matrix Zero(int rowCount, int columnCount) =>
+            new Matrix(new float[rowCount, columnCount]);
+
         private readonly IMathObject[,] _components;
 
         public IMathObject this[int row, int column] =>

--- a/Values/Matrix.cs
+++ b/Values/Matrix.cs
@@ -128,5 +128,51 @@ namespace MetaphysicsIndustries.Solus.Values
             sb.Append("]");
             return sb.ToString();
         }
+
+        public override bool Equals(object obj)
+        {
+            if (!(obj is IMatrix m))
+                return false;
+            if (m.RowCount != RowCount ||
+                m.ColumnCount != ColumnCount)
+                return false;
+            int r, c;
+            for (r = 0; r < RowCount; r++)
+            for (c = 0; c < ColumnCount; c++)
+                if (!m[r, c].Equals(this[r, c]))
+                    return false;
+            return true;
+        }
+
+        public override int GetHashCode()
+        {
+            const uint s_seed = 399891796U;
+            const uint Prime1 = 2654435761U;
+            const uint Prime2 = 2246822519U;
+            const uint Prime3 = 3266489917U;
+            const uint Prime4 = 668265263U;
+            const uint Prime5 = 374761393U;
+            var primes = new[] { Prime1, Prime2, Prime3, Prime4, Prime5 };
+            uint hash = s_seed + Prime5;
+            hash += 8;
+
+            int r, c, k;
+            k = 0;
+            for (r = 0; r < RowCount; r++)
+            {
+                for (c = 0; c < ColumnCount; c++, k++)
+                {
+                    var h = this[r, c].GetHashCode();
+                    var x = (uint)(hash + h * primes[k % 5]);
+                    var y = (x << 17) | (x >> (32 - 17));
+                    var z = y * primes[(k + 1) % 5];
+                    hash = z;
+                }
+
+                k++;
+            }
+
+            return (int)hash;
+        }
     }
 }

--- a/Values/Vector.cs
+++ b/Values/Vector.cs
@@ -42,6 +42,9 @@ namespace MetaphysicsIndustries.Solus.Values
         {
         }
 
+        public static Vector Zero(int length) =>
+            new Vector(new float[length]);
+
         private readonly IMathObject[] _components;
         public IMathObject this[int index] => _components[index];
         public int Length => _components.Length;

--- a/Values/Vector.cs
+++ b/Values/Vector.cs
@@ -82,5 +82,31 @@ namespace MetaphysicsIndustries.Solus.Values
                 _components.Select(c => c.ToString()));
             return $"[{inner}]";
         }
+
+        public override int GetHashCode()
+        {
+            int hash = 1009;
+            foreach (var v in _components)
+                hash = hash * 2003 + v.GetHashCode();
+            return hash;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (!(obj is IVector v))
+                return false;
+            return Equals(this, v);
+        }
+
+        public static bool Equals(IVector a, IVector b)
+        {
+
+            if (a.Length != b.Length)
+                return false;
+            for (var i = 0; i < a.Length; i++)
+                if (a[i].ToFloat() != b[i].ToFloat())
+                    return false;
+            return true;
+        }
     }
 }

--- a/Values/Vector2.cs
+++ b/Values/Vector2.cs
@@ -80,19 +80,22 @@ namespace MetaphysicsIndustries.Solus.Values
         }
         public override bool Equals(object other)
         {
-            if (other is Vector2)
+            switch (other)
             {
-                return Equals((Vector2)other);
-            }
-            else
-            {
-                return false;
+                case Vector2 v:
+                    return Equals(v);
+                case IVector vv:
+                    return Vector.Equals(this, vv);
+                default:
+                    return false;
             }
         }
         public override int GetHashCode()
         {
-            var x = 101 * X.GetHashCode();
-            return x ^ Y.GetHashCode();
+            int hash = 1009;
+            hash = hash * 2003 + X.GetHashCode();
+            hash = hash * 2003 + Y.GetHashCode();
+            return hash;
         }
 
         public float Length()

--- a/Values/Vector3.cs
+++ b/Values/Vector3.cs
@@ -92,21 +92,24 @@ namespace MetaphysicsIndustries.Solus.Values
 
         public override bool Equals(object other)
         {
-            if (other is Vector3)
+            switch (other)
             {
-                return Equals((Vector3)other);
-            }
-            else
-            {
-                return false;
+                case Vector3 v:
+                    return Equals(v);
+                case IVector vv:
+                    return Vector.Equals(this, vv);
+                default:
+                    return false;
             }
         }
 
         public override int GetHashCode()
         {
-            var x = 113 * X.GetHashCode();
-            x ^= 127 * Y.GetHashCode();
-            return x ^ Z.GetHashCode();
+            int hash = 1009;
+            hash = hash * 2003 + X.GetHashCode();
+            hash = hash * 2003 + Y.GetHashCode();
+            hash = hash * 2003 + Z.GetHashCode();
+            return hash;
         }
 
         public float Length()


### PR DESCRIPTION
This PR adds the ability to add and multiply vectors and matrices. This includes extended support for function types, including variadic functions.

This PR only includes full support for the `BasicEvaluator`. The `CompilingEvaluator` can add but not yet multiply vectors and matrices. That will be the subject of a future PR.

There are still a number of edge cases that produce false positives (for example, multiplying two vectors is not clearly defined, but no error is produced in the repl). Those will have to be worked out.